### PR TITLE
Move AnnotationManager inside Style, make Style shared

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -34,7 +34,7 @@ public:
     explicit Map(RendererFrontend&,
                  MapObserver&,
                  const MapOptions&,
-                 const ResourceOptions&);
+                 const ResourceOptions &resourceOptions = ResourceOptions());
     ~Map();
 
     // Register a callback that will get called (on the render thread) when all resources have
@@ -48,8 +48,9 @@ public:
 
           style::Style& getStyle();
     const style::Style& getStyle() const;
+    std::shared_ptr<style::Style> getStylePointer();
 
-    void setStyle(std::unique_ptr<style::Style>);
+    void setStyle(const std::shared_ptr<mbgl::style::Style>&);
 
     // Transition
     void cancelTransitions();

--- a/include/mbgl/style/style.hpp
+++ b/include/mbgl/style/style.hpp
@@ -11,6 +11,7 @@
 namespace mbgl {
 
 class FileSource;
+class ResourceOptions;
 
 namespace style {
 
@@ -18,10 +19,12 @@ class Light;
 class Image;
 class Source;
 class Layer;
+class StyleImpl;
 
 class Style {
 public:
     Style(std::shared_ptr<FileSource>, float pixelRatio);
+    Style(const ResourceOptions& resourceOptions, float pixelRatio);
     ~Style();
 
     void loadJSON(const std::string&);
@@ -70,8 +73,7 @@ public:
     std::unique_ptr<Layer> removeLayer(const std::string& layerID);
 
     // Private implementation
-    class Impl;
-    const std::unique_ptr<Impl> impl;
+    const std::unique_ptr<StyleImpl> impl;
 };
 
 } // namespace style

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -21,11 +21,12 @@ class ShapeAnnotationImpl;
 
 namespace style {
 class Style;
+class StyleImpl;
 } // namespace style
 
 class AnnotationManager : private util::noncopyable {
 public:
-    AnnotationManager(style::Style&);
+    AnnotationManager(style::StyleImpl&);
     ~AnnotationManager();
 
     AnnotationID addAnnotation(const Annotation&);
@@ -36,7 +37,6 @@ public:
     void removeImage(const std::string&);
     double getTopOffsetPixelsForImage(const std::string&);
 
-    void setStyle(style::Style&);
     void onStyleLoaded();
 
     void updateData();
@@ -63,7 +63,7 @@ private:
 
     std::unique_ptr<AnnotationTileData> getTileData(const CanonicalTileID&);
 
-    std::reference_wrapper<style::Style> style;
+    style::StyleImpl& style;
 
     std::mutex mutex;
 

--- a/src/mbgl/annotation/fill_annotation_impl.cpp
+++ b/src/mbgl/annotation/fill_annotation_impl.cpp
@@ -12,7 +12,7 @@ FillAnnotationImpl::FillAnnotationImpl(AnnotationID id_, FillAnnotation annotati
       annotation(ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.color, annotation_.outlineColor) {
 }
 
-void FillAnnotationImpl::updateStyle(Style::Impl& style) const {
+void FillAnnotationImpl::updateStyle(StyleImpl& style) const {
     Layer* layer = style.getLayer(layerID);
 
     if (!layer) {

--- a/src/mbgl/annotation/fill_annotation_impl.hpp
+++ b/src/mbgl/annotation/fill_annotation_impl.hpp
@@ -9,7 +9,7 @@ class FillAnnotationImpl : public ShapeAnnotationImpl {
 public:
     FillAnnotationImpl(AnnotationID, FillAnnotation);
 
-    void updateStyle(style::Style::Impl&) const final;
+    void updateStyle(style::StyleImpl&) const final;
     const ShapeAnnotationGeometry& geometry() const final;
 
 private:

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -12,7 +12,7 @@ LineAnnotationImpl::LineAnnotationImpl(AnnotationID id_, LineAnnotation annotati
       annotation(ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.width, annotation_.color) {
 }
 
-void LineAnnotationImpl::updateStyle(Style::Impl& style) const {
+void LineAnnotationImpl::updateStyle(StyleImpl& style) const {
     Layer* layer = style.getLayer(layerID);
 
     if (!layer) {

--- a/src/mbgl/annotation/line_annotation_impl.hpp
+++ b/src/mbgl/annotation/line_annotation_impl.hpp
@@ -9,7 +9,7 @@ class LineAnnotationImpl : public ShapeAnnotationImpl {
 public:
     LineAnnotationImpl(AnnotationID, LineAnnotation);
 
-    void updateStyle(style::Style::Impl&) const final;
+    void updateStyle(style::StyleImpl&) const final;
     const ShapeAnnotationGeometry& geometry() const final;
 
 private:

--- a/src/mbgl/annotation/shape_annotation_impl.hpp
+++ b/src/mbgl/annotation/shape_annotation_impl.hpp
@@ -20,7 +20,7 @@ public:
     ShapeAnnotationImpl(const AnnotationID);
     virtual ~ShapeAnnotationImpl() = default;
 
-    virtual void updateStyle(style::Style::Impl&) const = 0;
+    virtual void updateStyle(style::StyleImpl&) const = 0;
     virtual const ShapeAnnotationGeometry& geometry() const = 0;
 
     void updateTileData(const CanonicalTileID&, AnnotationTileData&);

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/map_options.hpp>
@@ -28,7 +27,14 @@ struct StillImageRequest {
 
 class Map::Impl : public style::Observer, public RendererObserver {
 public:
-    Impl(RendererFrontend&, MapObserver&, std::shared_ptr<FileSource>, const MapOptions&);
+    Impl(RendererFrontend&,
+         MapObserver&,
+         const ResourceOptions&,
+         const MapOptions&);
+    Impl(RendererFrontend&,
+         MapObserver&,
+         std::shared_ptr<FileSource>,
+         const MapOptions&); // Used in tests
     ~Impl() final;
 
     // StyleObserver
@@ -50,6 +56,7 @@ public:
 
     // Map
     void jumpTo(const CameraOptions&);
+    void setStyle(const std::shared_ptr<style::Style>& style);
 
     MapObserver& observer;
     RendererFrontend& rendererFrontend;
@@ -62,10 +69,7 @@ public:
 
     MapDebugOptions debugOptions { MapDebugOptions::NoDebug };
 
-    std::shared_ptr<FileSource> fileSource;
-
-    std::unique_ptr<style::Style> style;
-    AnnotationManager annotationManager;
+    std::shared_ptr<style::Style> style;
 
     bool cameraMutated = false;
 
@@ -74,6 +78,9 @@ public:
     bool loading = false;
     bool rendererFullyLoaded;
     std::unique_ptr<StillImageRequest> stillImageRequest;
+
+private:
+    void init(const MapOptions&);
 };
 
 } // namespace mbgl

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -4,12 +4,18 @@
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/layer.hpp>
+#include <mbgl/storage/file_source_manager.hpp>
+#include <mbgl/storage/resource_options.hpp>
 
 namespace mbgl {
 namespace style {
 
 Style::Style(std::shared_ptr<FileSource> fileSource, float pixelRatio)
-    : impl(std::make_unique<Impl>(std::move(fileSource), pixelRatio)) {}
+    : impl(std::make_unique<StyleImpl>(std::move(fileSource), pixelRatio)) {}
+
+Style::Style(const ResourceOptions &resourceOptions, float pixelRatio)
+    : impl(std::make_unique<StyleImpl>(FileSourceManager::get() ? FileSourceManager::get()->getFileSource(ResourceLoader, resourceOptions) : nullptr,
+                                       pixelRatio)) {}
 
 Style::~Style() = default;
 
@@ -79,7 +85,7 @@ std::vector<Source*> Style::getSources() {
 }
 
 std::vector<const Source*> Style::getSources() const {
-    return const_cast<const Impl&>(*impl).getSources();
+    return const_cast<const StyleImpl&>(*impl).getSources();
 }
 
 Source* Style::getSource(const std::string& id) {
@@ -107,7 +113,7 @@ std::vector<Layer*> Style::getLayers() {
 }
 
 std::vector<const Layer*> Style::getLayers() const {
-    return const_cast<const Impl&>(*impl).getLayers();
+    return const_cast<const StyleImpl&>(*impl).getLayers();
 }
 
 Layer* Style::getLayer(const std::string& layerID) {

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -59,7 +59,7 @@ public:
     Transform transform;
     TransformState transformState;
     Style style{fileSource, 1};
-    AnnotationManager annotationManager { style };
+    AnnotationManager annotationManager { *style.impl };
     ImageManager imageManager;
     GlyphManager glyphManager;
 

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -19,7 +19,7 @@ TEST(Style, Properties) {
     util::RunLoop loop;
 
     auto fileSource = std::make_shared<StubFileSource>();
-    Style::Impl style { fileSource, 1.0 };
+    StyleImpl style { fileSource, 1.0 };
 
     style.loadJSON(R"STYLE({"name": "Test"})STYLE");
     ASSERT_EQ("Test", style.getName());
@@ -61,7 +61,7 @@ TEST(Style, DuplicateSource) {
     util::RunLoop loop;
 
     auto fileSource = std::make_shared<StubFileSource>();
-    Style::Impl style { fileSource, 1.0 };
+    StyleImpl style { fileSource, 1.0 };
 
     style.loadJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"));
 
@@ -82,7 +82,7 @@ TEST(Style, RemoveSourceInUse) {
     Log::setObserver(std::unique_ptr<Log::Observer>(log));
 
     auto fileSource = std::make_shared<StubFileSource>();
-    Style::Impl style { fileSource, 1.0 };
+    StyleImpl style { fileSource, 1.0 };
 
     style.loadJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"));
 
@@ -107,7 +107,7 @@ TEST(Style, RemoveSourceInUse) {
 TEST(Style, SourceImplsOrder) {
     util::RunLoop loop;
     auto fileSource = std::make_shared<StubFileSource>();
-    Style::Impl style{fileSource, 1.0};
+    StyleImpl style{fileSource, 1.0};
 
     style.addSource(std::make_unique<VectorSource>("c", "mapbox://mapbox.mapbox-terrain-v2"));
     style.addSource(std::make_unique<VectorSource>("b", "mapbox://mapbox.mapbox-terrain-v2"));

--- a/test/style/style_layer.test.cpp
+++ b/test/style/style_layer.test.cpp
@@ -284,7 +284,7 @@ TEST(Layer, DuplicateLayer) {
 
     // Setup style
     auto fileSource = std::make_shared<StubFileSource>();
-    Style::Impl style { fileSource, 1.0 };
+    StyleImpl style { fileSource, 1.0 };
     style.loadJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"));
 
     // Add initial layer
@@ -305,7 +305,7 @@ TEST(Layer, IncompatibleLayer) {
 
     // Setup style
     auto fileSource = std::make_shared<StubFileSource>();
-    Style::Impl style{fileSource, 1.0};
+    StyleImpl style{fileSource, 1.0};
     style.loadJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"));
 
     // Try to add duplicate

--- a/test/tile/custom_geometry_tile.test.cpp
+++ b/test/tile/custom_geometry_tile.test.cpp
@@ -26,7 +26,7 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     style::Style style{fileSource, 1};
-    AnnotationManager annotationManager { style };
+    AnnotationManager annotationManager { *style.impl };
     ImageManager imageManager;
     GlyphManager glyphManager;
 

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -26,7 +26,7 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     style::Style style{fileSource, 1};
-    AnnotationManager annotationManager { style };
+    AnnotationManager annotationManager { *style.impl };
     ImageManager imageManager;
     GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };

--- a/test/tile/raster_dem_tile.test.cpp
+++ b/test/tile/raster_dem_tile.test.cpp
@@ -20,7 +20,7 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     style::Style style{fileSource, 1};
-    AnnotationManager annotationManager { style };
+    AnnotationManager annotationManager { *style.impl };
     ImageManager imageManager;
     GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -20,7 +20,7 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     style::Style style{fileSource, 1};
-    AnnotationManager annotationManager { style };
+    AnnotationManager annotationManager { *style.impl };
     ImageManager imageManager;
     GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };

--- a/test/tile/tile_cache.test.cpp
+++ b/test/tile/tile_cache.test.cpp
@@ -29,7 +29,7 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     style::Style style{fileSource, 1};
-    AnnotationManager annotationManager{style};
+    AnnotationManager annotationManager { *style.impl };
     ImageManager imageManager;
     GlyphManager glyphManager;
     Tileset tileset{{"https://example.com"}, {0, 22}, "none"};

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -26,7 +26,7 @@ public:
     TransformState transformState;
     util::RunLoop loop;
     style::Style style{fileSource, 1};
-    AnnotationManager annotationManager { style };
+    AnnotationManager annotationManager { *style.impl };
     ImageManager imageManager;
     GlyphManager glyphManager;
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };


### PR DESCRIPTION
This change enables to share a style across Maps.
The goal is to avoid loading the same style multiple times if
multiple maps with the same style are used.
Use cases range from minimap to snapshotters.

This change moves the AnnotationManager inside the Style itself.
In this way, the old behavior is retained under the old use-cases:
single map-single style.

When using the style on multiple maps, changing annotations on the
style, or on one map will result in changing them on all
maps where that style is used.

To add more flexibility, moving forward, a possible solution
can be to support multiple stacked styles in the Map, that will
then be flattened in the map.
In this way a style will be a group of layers that can be added
or removed without much troubles.
Practical use case would be a style with the annotations on
top of a style for the base map, that could be changed by the
user.

This would allow avoiding the current required procedure of
modifying the new style when it gets set, in order to add the
annotations.

## Launch Checklist

WIP:

 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] tagged `@mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk` if this PR adds or updates a public API
 - [ ] tagged `@mapbox/gl-js` if this PR includes shader changes or needs a js port
 - [ ] apply `needs changelog` label if a changelog is needed (remove label when added)
