### PR TITLE
Made number format work for newer versions of ICU

### DIFF
--- a/platform/default/src/mbgl/i18n/number_format.cpp
+++ b/platform/default/src/mbgl/i18n/number_format.cpp
@@ -22,7 +22,11 @@ std::string formatNumber(double number,
                    .unit(icu::CurrencyUnit(ucurrency.getBuffer(), status))
                    .locale(locale)
                    .formatDouble(number, status)
+#if U_ICU_VERSION_MAJOR_NUM >= 62
+                   .toString(status);
+#else
                    .toString();
+#endif
     } else {
         ustr = icu::number::NumberFormatter::with()
 #if U_ICU_VERSION_MAJOR_NUM >= 62
@@ -32,7 +36,11 @@ std::string formatNumber(double number,
 #endif
                    .locale(locale)
                    .formatDouble(number, status)
+#if U_ICU_VERSION_MAJOR_NUM >= 62
+                   .toString(status);
+#else
                    .toString();
+#endif
     }
     return ustr.toUTF8String(formatted);
 }


### PR DESCRIPTION
numberformatter.h is not included with next/vendor/icu, so we can't use mbgl-vendor-icu, and must look for a system ICU. This is fine, however the file platform/default/src/mbgl/i18n/number_format.cpp does not handle newer version of ICU (since toString() was deprecated and removed, requiring toString(status) ).

This fixed support for newer version of ICU, no longer using the deprecated (and later removed) API call. Though in future, the vendor ICU should have numberformatter added to it.