### PR TITLE
[core] Add runtime API for setting tile prefetch delta for a Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
   This property allows to re-open the offline database in read-only mode and thus improves the performance for the set-ups that do not require the offline database modifications.
 
+- [core] Add runtime API for setting tile prefetch delta for a Source ([#16179](https://github.com/mapbox/mapbox-gl-native/pull/16179))
+
+  The new `Source::setPrefetchZoomDelta(optional<uint8_t>)` method allows overriding default tile prefetch setting that is defined by the Map instance.
+
 ## maps-v1.0.1 (2020.01-release-unicorn)
 
 ### 🐞 Bug fixes

--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -73,6 +73,8 @@ public:
     SourceObserver* observer = nullptr;
 
     virtual void loadDescription(FileSource&) = 0;
+    void setPrefetchZoomDelta(optional<uint8_t> delta) noexcept;
+    optional<uint8_t> getPrefetchZoomDelta() const noexcept;
     void dumpDebugLogs() const;
 
     virtual bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const = 0;
@@ -85,6 +87,9 @@ public:
     mapbox::base::TypeWrapper peer;
 
     virtual mapbox::base::WeakPtr<Source> makeWeakPtr() = 0;
+
+protected:
+    virtual Mutable<Impl> createMutable() const noexcept = 0;
 };
 
 } // namespace style

--- a/include/mbgl/style/sources/custom_geometry_source.hpp
+++ b/include/mbgl/style/sources/custom_geometry_source.hpp
@@ -50,6 +50,10 @@ public:
     mapbox::base::WeakPtr<Source> makeWeakPtr() override {
         return weakFactory.makeWeakPtr();
     }
+
+protected:
+    Mutable<Source::Impl> createMutable() const noexcept final;
+
 private:
     std::shared_ptr<ThreadPool> threadPool;
     std::unique_ptr<Actor<CustomTileLoader>> loader;

--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -81,6 +81,9 @@ public:
         return weakFactory.makeWeakPtr();
     }
 
+protected:
+    Mutable<Source::Impl> createMutable() const noexcept final;
+
 private:
     optional<std::string> url;
     std::unique_ptr<AsyncRequest> req;

--- a/include/mbgl/style/sources/image_source.hpp
+++ b/include/mbgl/style/sources/image_source.hpp
@@ -33,6 +33,10 @@ public:
     mapbox::base::WeakPtr<Source> makeWeakPtr() override {
         return weakFactory.makeWeakPtr();
     }
+
+protected:
+    Mutable<Source::Impl> createMutable() const noexcept final;
+
 private:
     optional<std::string> url;
     std::unique_ptr<AsyncRequest> req;

--- a/include/mbgl/style/sources/raster_source.hpp
+++ b/include/mbgl/style/sources/raster_source.hpp
@@ -31,6 +31,9 @@ public:
         return weakFactory.makeWeakPtr();
     }
 
+protected:
+    Mutable<Source::Impl> createMutable() const noexcept final;
+
 private:
     const variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;

--- a/include/mbgl/style/sources/vector_source.hpp
+++ b/include/mbgl/style/sources/vector_source.hpp
@@ -30,6 +30,9 @@ public:
         return weakFactory.makeWeakPtr();
     }
 
+protected:
+    Mutable<Source::Impl> createMutable() const noexcept final;
+
 private:
     const variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;

--- a/metrics/binary-size/macos-xcode11/metrics.json
+++ b/metrics/binary-size/macos-xcode11/metrics.json
@@ -3,17 +3,17 @@
         [
             "mbgl-glfw",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-glfw",
-            5562556
+            5616056
         ],
         [
             "mbgl-offline",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-offline",
-            5427032
+            5484604
         ],
         [
             "mbgl-render",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-render",
-            5477244
+            5530720
         ]
     ]
 }

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -14,6 +14,10 @@ AnnotationSource::Impl::Impl()
     : Source::Impl(SourceType::Annotations, AnnotationManager::SourceID) {
 }
 
+const AnnotationSource::Impl& AnnotationSource::impl() const {
+    return static_cast<const Impl&>(*baseImpl);
+}
+
 void AnnotationSource::loadDescription(FileSource&) {
     loaded = true;
 }
@@ -24,6 +28,10 @@ optional<std::string> AnnotationSource::Impl::getAttribution() const {
 
 bool AnnotationSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) const {
     return !std::strcmp(info->type, "line") || !std::strcmp(info->type, "symbol") || !std::strcmp(info->type, "fill");
+}
+
+Mutable<Source::Impl> AnnotationSource::createMutable() const noexcept {
+    return staticMutableCast<Source::Impl>(makeMutable<Impl>(impl()));
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -12,13 +12,15 @@ public:
     class Impl;
     const Impl& impl() const;
 
+protected:
+    Mutable<Source::Impl> createMutable() const noexcept final;
+
 private:
     void loadDescription(FileSource&) final;
     bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const override;
     mapbox::base::WeakPtr<Source> makeWeakPtr() override {
         return weakFactory.makeWeakPtr();
     }
-    Mutable<Impl> mutableImpl() const;
     mapbox::base::WeakPtrFactory<Source> weakFactory {this};
 };
 

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -28,19 +28,19 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     enabled = needsRendering;
 
-    tilePyramid.update(layers,
-                       needsRendering,
-                       needsRelayout,
-                       parameters,
-                       SourceType::Annotations,
-                       util::tileSize,
-                       // Zoom level 16 is typically sufficient for annotations.
-                       // See https://github.com/mapbox/mapbox-gl-native/issues/10197
-                       { 0, 16 },
-                       optional<LatLngBounds> {},
-                       [&] (const OverscaledTileID& tileID) {
-                           return std::make_unique<AnnotationTile>(tileID, parameters);
-                       });
+    tilePyramid.update(
+        layers,
+        needsRendering,
+        needsRelayout,
+        parameters,
+        SourceType::Annotations,
+        util::tileSize,
+        // Zoom level 16 is typically sufficient for annotations.
+        // See https://github.com/mapbox/mapbox-gl-native/issues/10197
+        {0, 16},
+        optional<LatLngBounds>{},
+        [&](const OverscaledTileID& tileID) { return std::make_unique<AnnotationTile>(tileID, parameters); },
+        baseImpl->getPrefetchZoomDelta());
 }
 
 std::unordered_map<std::string, std::vector<Feature>>

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -23,7 +23,14 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
                                  const TileParameters& parameters) {
     if (baseImpl != baseImpl_) {
         std::swap(baseImpl, baseImpl_);
-        tilePyramid.clearAll();
+
+        // Clear tile pyramid only if updated source has different tile options,
+        // zoom range or initialization state for a custom tile loader.
+        auto newImpl = staticImmutableCast<style::CustomGeometrySource::Impl>(baseImpl);
+        auto currentImpl = staticImmutableCast<style::CustomGeometrySource::Impl>(baseImpl_);
+        if (*newImpl != *currentImpl) {
+            tilePyramid.clearAll();
+        }
     }
 
     enabled = needsRendering;

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -33,17 +33,20 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
         return;
     }
 
-    tilePyramid.update(layers,
-                       needsRendering,
-                       needsRelayout,
-                       parameters,
-                       SourceType::CustomVector,
-                       util::tileSize,
-                       impl().getZoomRange(),
-                       {},
-                       [&] (const OverscaledTileID& tileID) {
-                           return std::make_unique<CustomGeometryTile>(tileID, impl().id, parameters, impl().getTileOptions(), *tileLoader);
-                       });
+    tilePyramid.update(
+        layers,
+        needsRendering,
+        needsRelayout,
+        parameters,
+        SourceType::CustomVector,
+        util::tileSize,
+        impl().getZoomRange(),
+        {},
+        [&](const OverscaledTileID& tileID) {
+            return std::make_unique<CustomGeometryTile>(
+                tileID, impl().id, parameters, impl().getTileOptions(), *tileLoader);
+        },
+        baseImpl->getPrefetchZoomDelta());
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -103,17 +103,19 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     if (!data_) return;
 
-    tilePyramid.update(layers,
-                       needsRendering,
-                       needsRelayout,
-                       parameters,
-                       SourceType::GeoJSON,
-                       util::tileSize,
-                       impl().getZoomRange(),
-                       optional<LatLngBounds>{},
-                       [&, data_](const OverscaledTileID& tileID) {
-                           return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data_);
-                       });
+    tilePyramid.update(
+        layers,
+        needsRendering,
+        needsRelayout,
+        parameters,
+        SourceType::GeoJSON,
+        util::tileSize,
+        impl().getZoomRange(),
+        optional<LatLngBounds>{},
+        [&, data_](const OverscaledTileID& tileID) {
+            return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data_);
+        },
+        baseImpl->getPrefetchZoomDelta());
 }
 
 mapbox::util::variant<Value, FeatureCollection>

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -27,17 +27,17 @@ void RenderRasterDEMSource::updateInternal(const Tileset& tileset,
                                            const bool needsRendering,
                                            const bool needsRelayout,
                                            const TileParameters& parameters) {
-    tilePyramid.update(layers,
-                       needsRendering,
-                       needsRelayout,
-                       parameters,
-                       SourceType::RasterDEM,
-                       impl().getTileSize(),
-                       tileset.zoomRange,
-                       tileset.bounds,
-                       [&] (const OverscaledTileID& tileID) {
-                           return std::make_unique<RasterDEMTile>(tileID, parameters, tileset);
-                       });
+    tilePyramid.update(
+        layers,
+        needsRendering,
+        needsRelayout,
+        parameters,
+        SourceType::RasterDEM,
+        impl().getTileSize(),
+        tileset.zoomRange,
+        tileset.bounds,
+        [&](const OverscaledTileID& tileID) { return std::make_unique<RasterDEMTile>(tileID, parameters, tileset); },
+        baseImpl->getPrefetchZoomDelta());
     algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -25,17 +25,17 @@ void RenderRasterSource::updateInternal(const Tileset& tileset,
                                         const bool needsRendering,
                                         const bool needsRelayout,
                                         const TileParameters& parameters) {
-    tilePyramid.update(layers,
-                       needsRendering,
-                       needsRelayout,
-                       parameters,
-                       SourceType::Raster,
-                       impl().getTileSize(),
-                       tileset.zoomRange,
-                       tileset.bounds,
-                       [&] (const OverscaledTileID& tileID) {
-                           return std::make_unique<RasterTile>(tileID, parameters, tileset);
-                       });
+    tilePyramid.update(
+        layers,
+        needsRendering,
+        needsRelayout,
+        parameters,
+        SourceType::Raster,
+        impl().getTileSize(),
+        tileset.zoomRange,
+        tileset.bounds,
+        [&](const OverscaledTileID& tileID) { return std::make_unique<RasterTile>(tileID, parameters, tileset); },
+        baseImpl->getPrefetchZoomDelta());
     algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -21,17 +21,19 @@ void RenderVectorSource::updateInternal(const Tileset& tileset,
                                         const bool needsRendering,
                                         const bool needsRelayout,
                                         const TileParameters& parameters) {
-    tilePyramid.update(layers,
-                       needsRendering,
-                       needsRelayout,
-                       parameters,
-                       SourceType::Vector,
-                       util::tileSize,
-                       tileset.zoomRange,
-                       tileset.bounds,
-                       [&] (const OverscaledTileID& tileID) {
-                           return std::make_unique<VectorTile>(tileID, baseImpl->id, parameters, tileset);
-                       });
+    tilePyramid.update(
+        layers,
+        needsRendering,
+        needsRelayout,
+        parameters,
+        SourceType::Vector,
+        util::tileSize,
+        tileset.zoomRange,
+        tileset.bounds,
+        [&](const OverscaledTileID& tileID) {
+            return std::make_unique<VectorTile>(tileID, baseImpl->id, parameters, tileset);
+        },
+        baseImpl->getPrefetchZoomDelta());
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -57,7 +57,8 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
                          const uint16_t tileSize,
                          const Range<uint8_t> zoomRange,
                          optional<LatLngBounds> bounds,
-                         std::function<std::unique_ptr<Tile> (const OverscaledTileID&)> createTile) {
+                         std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile,
+                         optional<uint8_t> sourcePrefetchZoomDelta) {
     // If we need a relayout, abandon any cached tiles; they're now stale.
     if (needsRelayout) {
         cache.clear();
@@ -105,8 +106,10 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
         if (parameters.mode == MapMode::Continuous && type != style::SourceType::GeoJSON && type != style::SourceType::Annotations) {
             // Request lower zoom level tiles (if configured to do so) in an attempt
             // to show something on the screen faster at the cost of a little of bandwidth.
-            if (parameters.prefetchZoomDelta) {
-                panZoom = std::max<int32_t>(tileZoom - parameters.prefetchZoomDelta, zoomRange.min);
+            const uint8_t prefetchZoomDelta =
+                sourcePrefetchZoomDelta ? *sourcePrefetchZoomDelta : parameters.prefetchZoomDelta;
+            if (prefetchZoomDelta) {
+                panZoom = std::max<int32_t>(tileZoom - prefetchZoomDelta, zoomRange.min);
             }
 
             if (panZoom < idealZoom) {

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -41,7 +41,8 @@ public:
                 uint16_t tileSize,
                 Range<uint8_t> zoomRange,
                 optional<LatLngBounds> bounds,
-                std::function<std::unique_ptr<Tile> (const OverscaledTileID&)> createTile);
+                std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile,
+                optional<uint8_t> sourcePrefetchZoomDelta);
 
     const std::map<UnwrappedTileID, std::reference_wrapper<Tile>>& getRenderedTiles() const { return renderedTiles; }
     Tile* getTile(const OverscaledTileID&);

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -31,6 +31,18 @@ void Source::setObserver(SourceObserver* observer_) {
     observer = observer_ ? observer_ : &nullObserver;
 }
 
+void Source::setPrefetchZoomDelta(optional<uint8_t> delta) noexcept {
+    if (getPrefetchZoomDelta() == delta) return;
+    auto newImpl = createMutable();
+    newImpl->setPrefetchZoomDelta(std::move(delta));
+    baseImpl = std::move(newImpl);
+    observer->onSourceChanged(*this);
+}
+
+optional<uint8_t> Source::getPrefetchZoomDelta() const noexcept {
+    return baseImpl->getPrefetchZoomDelta();
+}
+
 void Source::dumpDebugLogs() const {
     Log::Info(Event::General, "Source::id: %s", getID().c_str());
     Log::Info(Event::General, "Source::loaded: %d", loaded);

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -8,5 +8,13 @@ Source::Impl::Impl(SourceType type_, std::string id_)
       id(std::move(id_)) {
 }
 
+void Source::Impl::setPrefetchZoomDelta(optional<uint8_t> delta) noexcept {
+    prefetchZoomDelta = std::move(delta);
+}
+
+optional<uint8_t> Source::Impl::getPrefetchZoomDelta() const noexcept {
+    return prefetchZoomDelta;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -20,9 +20,12 @@ public:
     Impl& operator=(const Impl&) = delete;
 
     virtual optional<std::string> getAttribution() const = 0;
+    void setPrefetchZoomDelta(optional<uint8_t> delta) noexcept;
+    optional<uint8_t> getPrefetchZoomDelta() const noexcept;
 
     const SourceType type;
     const std::string id;
+    optional<uint8_t> prefetchZoomDelta;
 
 protected:
     Impl(SourceType, std::string);

--- a/src/mbgl/style/sources/custom_geometry_source.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source.cpp
@@ -27,7 +27,7 @@ const CustomGeometrySource::Impl& CustomGeometrySource::impl() const {
 }
 
 void CustomGeometrySource::loadDescription(FileSource&) {
-    baseImpl = makeMutable<CustomGeometrySource::Impl>(impl(), loader->self());
+    baseImpl = makeMutable<Impl>(impl(), loader->self());
     loaded = true;
     observer->onSourceLoaded(*this);
 }
@@ -47,6 +47,10 @@ void CustomGeometrySource::invalidateTile(const CanonicalTileID& tileID) {
 
 void CustomGeometrySource::invalidateRegion(const LatLngBounds& bounds) {
     loader->self().invoke(&CustomTileLoader::invalidateRegion, bounds, impl().getZoomRange());
+}
+
+Mutable<Source::Impl> CustomGeometrySource::createMutable() const noexcept {
+    return staticMutableCast<Source::Impl>(makeMutable<Impl>(impl()));
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/custom_geometry_source.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source.cpp
@@ -14,11 +14,10 @@
 namespace mbgl {
 namespace style {
 
-CustomGeometrySource::CustomGeometrySource(std::string id,
-                                       const CustomGeometrySource::Options options)
+CustomGeometrySource::CustomGeometrySource(std::string id, CustomGeometrySource::Options options)
     : Source(makeMutable<CustomGeometrySource::Impl>(std::move(id), options)),
-    loader(std::make_unique<Actor<CustomTileLoader>>(Scheduler::GetBackground(), options.fetchTileFunction, options.cancelTileFunction)) {
-}
+      loader(std::make_unique<Actor<CustomTileLoader>>(
+          Scheduler::GetBackground(), options.fetchTileFunction, options.cancelTileFunction)) {}
 
 CustomGeometrySource::~CustomGeometrySource() = default;
 

--- a/src/mbgl/style/sources/custom_geometry_source_impl.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source_impl.cpp
@@ -4,27 +4,20 @@
 namespace mbgl {
 namespace style {
 
-CustomGeometrySource::Impl::Impl(std::string id_,
-                               const CustomGeometrySource::Options options)
+CustomGeometrySource::Impl::Impl(std::string id_, CustomGeometrySource::Options options)
     : Source::Impl(SourceType::CustomVector, std::move(id_)),
-      tileOptions(options.tileOptions),
+      tileOptions(makeMutable<CustomGeometrySource::TileOptions>(options.tileOptions)),
       zoomRange(options.zoomRange),
-      loaderRef({}) {
-}
+      loaderRef({}) {}
 
 CustomGeometrySource::Impl::Impl(const Impl& impl, ActorRef<CustomTileLoader> loaderRef_)
-    : Source::Impl(impl),
-    tileOptions(impl.tileOptions),
-    zoomRange(impl.zoomRange),
-    loaderRef(loaderRef_){
-    
-}
+    : Source::Impl(impl), tileOptions(impl.tileOptions), zoomRange(impl.zoomRange), loaderRef(loaderRef_) {}
 
 optional<std::string> CustomGeometrySource::Impl::getAttribution() const {
     return {};
 }
 
-CustomGeometrySource::TileOptions CustomGeometrySource::Impl::getTileOptions() const {
+Immutable<CustomGeometrySource::TileOptions> CustomGeometrySource::Impl::getTileOptions() const {
     return tileOptions;
 }
 

--- a/src/mbgl/style/sources/custom_geometry_source_impl.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source_impl.cpp
@@ -13,6 +13,10 @@ CustomGeometrySource::Impl::Impl(std::string id_, CustomGeometrySource::Options 
 CustomGeometrySource::Impl::Impl(const Impl& impl, ActorRef<CustomTileLoader> loaderRef_)
     : Source::Impl(impl), tileOptions(impl.tileOptions), zoomRange(impl.zoomRange), loaderRef(loaderRef_) {}
 
+bool CustomGeometrySource::Impl::operator!=(const Impl& other) const noexcept {
+    return tileOptions != other.tileOptions || zoomRange != other.zoomRange || bool(loaderRef) != bool(other.loaderRef);
+}
+
 optional<std::string> CustomGeometrySource::Impl::getAttribution() const {
     return {};
 }

--- a/src/mbgl/style/sources/custom_geometry_source_impl.hpp
+++ b/src/mbgl/style/sources/custom_geometry_source_impl.hpp
@@ -15,12 +15,12 @@ public:
 
     optional<std::string> getAttribution() const final;
 
-    CustomGeometrySource::TileOptions getTileOptions() const;
+    Immutable<CustomGeometrySource::TileOptions> getTileOptions() const;
     Range<uint8_t> getZoomRange() const;
     optional<ActorRef<CustomTileLoader>> getTileLoader() const;
 
 private:
-    CustomGeometrySource::TileOptions tileOptions;
+    Immutable<CustomGeometrySource::TileOptions> tileOptions;
     Range<uint8_t> zoomRange;
     optional<ActorRef<CustomTileLoader>> loaderRef;
 };

--- a/src/mbgl/style/sources/custom_geometry_source_impl.hpp
+++ b/src/mbgl/style/sources/custom_geometry_source_impl.hpp
@@ -18,6 +18,7 @@ public:
     Immutable<CustomGeometrySource::TileOptions> getTileOptions() const;
     Range<uint8_t> getZoomRange() const;
     optional<ActorRef<CustomTileLoader>> getTileLoader() const;
+    bool operator!=(const Impl&) const noexcept;
 
 private:
     Immutable<CustomGeometrySource::TileOptions> tileOptions;

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -120,5 +120,9 @@ bool GeoJSONSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) co
     return mbgl::underlying_type(Tile::Kind::Geometry) == mbgl::underlying_type(info->tileKind);
 }
 
+Mutable<Source::Impl> GeoJSONSource::createMutable() const noexcept {
+    return staticMutableCast<Source::Impl>(makeMutable<Impl>(impl()));
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/sources/image_source.cpp
+++ b/src/mbgl/style/sources/image_source.cpp
@@ -87,5 +87,9 @@ bool ImageSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) cons
     return mbgl::underlying_type(Tile::Kind::Raster) == mbgl::underlying_type(info->tileKind);
 }
 
+Mutable<Source::Impl> ImageSource::createMutable() const noexcept {
+    return staticMutableCast<Source::Impl>(makeMutable<Impl>(impl()));
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -87,5 +87,9 @@ bool RasterSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) con
     return mbgl::underlying_type(Tile::Kind::Raster) == mbgl::underlying_type(info->tileKind);
 }
 
+Mutable<Source::Impl> RasterSource::createMutable() const noexcept {
+    return staticMutableCast<Source::Impl>(makeMutable<Impl>(impl()));
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -91,5 +91,9 @@ bool VectorSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) con
     return mbgl::underlying_type(Tile::Kind::Geometry) == mbgl::underlying_type(info->tileKind);
 }
 
+Mutable<Source::Impl> VectorSource::createMutable() const noexcept {
+    return staticMutableCast<Source::Impl>(makeMutable<Impl>(impl()));
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -13,17 +13,16 @@
 namespace mbgl {
 
 CustomGeometryTile::CustomGeometryTile(const OverscaledTileID& overscaledTileID,
-                         std::string sourceID_,
-                         const TileParameters& parameters,
-                         const style::CustomGeometrySource::TileOptions options_,
-                         ActorRef<style::CustomTileLoader> loader_)
+                                       std::string sourceID_,
+                                       const TileParameters& parameters,
+                                       Immutable<style::CustomGeometrySource::TileOptions> options_,
+                                       ActorRef<style::CustomTileLoader> loader_)
     : GeometryTile(overscaledTileID, sourceID_, parameters),
-    necessity(TileNecessity::Optional),
-    options(options_),
-    loader(std::move(loader_)),
-    mailbox(std::make_shared<Mailbox>(*Scheduler::GetCurrent())),
-    actorRef(*this, mailbox) {
-}
+      necessity(TileNecessity::Optional),
+      options(std::move(options_)),
+      loader(std::move(loader_)),
+      mailbox(std::make_shared<Mailbox>(*Scheduler::GetCurrent())),
+      actorRef(*this, mailbox) {}
 
 CustomGeometryTile::~CustomGeometryTile() {
     loader.invoke(&style::CustomTileLoader::removeTile, id);
@@ -33,15 +32,16 @@ void CustomGeometryTile::setTileData(const GeoJSON& geoJSON) {
 
     auto featureData = mapbox::feature::feature_collection<int16_t>();
     if (geoJSON.is<FeatureCollection>() && !geoJSON.get<FeatureCollection>().empty()) {
-        const double scale = util::EXTENT / options.tileSize;
+        const double scale = util::EXTENT / options->tileSize;
 
         mapbox::geojsonvt::TileOptions vtOptions;
         vtOptions.extent = util::EXTENT;
-        vtOptions.buffer = ::round(scale * options.buffer);
-        vtOptions.tolerance = scale * options.tolerance;
-        featureData = mapbox::geojsonvt::geoJSONToTile(geoJSON,
-            id.canonical.z, id.canonical.x, id.canonical.y,
-            vtOptions, options.wrap, options.clip).features;
+        vtOptions.buffer = ::round(scale * options->buffer);
+        vtOptions.tolerance = scale * options->tolerance;
+        featureData =
+            mapbox::geojsonvt::geoJSONToTile(
+                geoJSON, id.canonical.z, id.canonical.x, id.canonical.y, vtOptions, options->wrap, options->clip)
+                .features;
     }
     setData(std::make_unique<GeoJSONTileData>(std::move(featureData)));
 }

--- a/src/mbgl/tile/custom_geometry_tile.hpp
+++ b/src/mbgl/tile/custom_geometry_tile.hpp
@@ -17,10 +17,10 @@ class CustomTileLoader;
 class CustomGeometryTile: public GeometryTile {
 public:
     CustomGeometryTile(const OverscaledTileID&,
-               std::string sourceID,
-               const TileParameters&,
-               const style::CustomGeometrySource::TileOptions,
-               ActorRef<style::CustomTileLoader> loader);
+                       std::string sourceID,
+                       const TileParameters&,
+                       Immutable<style::CustomGeometrySource::TileOptions>,
+                       ActorRef<style::CustomTileLoader> loader);
     ~CustomGeometryTile() override;
 
     void setTileData(const GeoJSON& data);
@@ -35,7 +35,7 @@ public:
 private:
     bool stale = true;
     TileNecessity necessity;
-    const style::CustomGeometrySource::TileOptions options;
+    Immutable<style::CustomGeometrySource::TileOptions> options;
     ActorRef<style::CustomTileLoader> loader;
     std::shared_ptr<Mailbox> mailbox;
     ActorRef<CustomGeometryTile> actorRef;

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -765,15 +765,17 @@ public:
                         const bool needsRendering,
                         const bool needsRelayout,
                         const TileParameters& parameters) override {
-        tilePyramid.update(layers,
-                           needsRendering,
-                           needsRelayout,
-                           parameters,
-                           SourceType::Vector,
-                           util::tileSize,
-                           tileset.zoomRange,
-                           tileset.bounds,
-                           [&](const OverscaledTileID& tileID) { return std::make_unique<FakeTile>(*this, tileID); });
+        tilePyramid.update(
+            layers,
+            needsRendering,
+            needsRelayout,
+            parameters,
+            SourceType::Vector,
+            util::tileSize,
+            tileset.zoomRange,
+            tileset.bounds,
+            [&](const OverscaledTileID& tileID) { return std::make_unique<FakeTile>(*this, tileID); },
+            baseImpl->getPrefetchZoomDelta());
     }
 
     const optional<Tileset>& getTileset() const override {

--- a/test/tile/custom_geometry_tile.test.cpp
+++ b/test/tile/custom_geometry_tile.test.cpp
@@ -61,8 +61,11 @@ TEST(CustomGeometryTile, InvokeFetchTile) {
     auto mb =std::make_shared<Mailbox>(*Scheduler::GetCurrent());
     ActorRef<CustomTileLoader> loaderActor(loader, mb);
 
-    CustomGeometryTile tile(OverscaledTileID(0, 0, 0), "source", test.tileParameters, CustomGeometrySource::TileOptions(),
-    loaderActor);
+    CustomGeometryTile tile(OverscaledTileID(0, 0, 0),
+                            "source",
+                            test.tileParameters,
+                            makeMutable<CustomGeometrySource::TileOptions>(),
+                            loaderActor);
 
     tile.setNecessity(TileNecessity::Required);
 
@@ -86,8 +89,11 @@ TEST(CustomGeometryTile, InvokeCancelTile) {
     auto mb =std::make_shared<Mailbox>(*Scheduler::GetCurrent());
     ActorRef<CustomTileLoader> loaderActor(loader, mb);
 
-    CustomGeometryTile tile(OverscaledTileID(0, 0, 0), "source", test.tileParameters, CustomGeometrySource::TileOptions(),
-    loaderActor);
+    CustomGeometryTile tile(OverscaledTileID(0, 0, 0),
+                            "source",
+                            test.tileParameters,
+                            makeMutable<CustomGeometrySource::TileOptions>(),
+                            loaderActor);
 
     tile.setNecessity(TileNecessity::Required);
     tile.setNecessity(TileNecessity::Optional);
@@ -108,8 +114,11 @@ TEST(CustomGeometryTile, InvokeTileChanged) {
     auto mb =std::make_shared<Mailbox>(*Scheduler::GetCurrent());
     ActorRef<CustomTileLoader> loaderActor(loader, mb);
 
-    CustomGeometryTile tile(OverscaledTileID(0, 0, 0), "source", test.tileParameters, CustomGeometrySource::TileOptions(),
-    loaderActor);
+    CustomGeometryTile tile(OverscaledTileID(0, 0, 0),
+                            "source",
+                            test.tileParameters,
+                            makeMutable<CustomGeometrySource::TileOptions>(),
+                            loaderActor);
 
     Immutable<LayerProperties> layerProperties = makeMutable<CircleLayerProperties>(staticImmutableCast<CircleLayer::Impl>(layer.baseImpl));
     StubTileObserver observer;


### PR DESCRIPTION
The new `Source::setPrefetchZoomDelta(optional<uint8_t> delta)` method allows overriding default tile prefetch setting that is defined by the Map instance. The method can be moved to a generic style specification if found to be useful for gl-js engine.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] tagged `@mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk` if this PR adds or updates a public API
 - [x] tagged `@mapbox/gl-js` if this PR includes shader changes or needs a js port
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)

/cc @mapbox/gl-js @mapbox/core-sdk