### PR TITLE
Expose READ_ONLY_MODE_KEY property for DatabaseFileSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - [core] Global settings API ([#16174](https://github.com/mapbox/mapbox-gl-native/pull/16174))
 
   Global settings API provides means of managing non-persistent in-process settings. Initial implementation contains support for experimental option for setting thread priorities.
+
+- Expose READ_ONLY_MODE_KEY property for DatabaseFileSource ([#16183](https://github.com/mapbox/mapbox-gl-native/pull/16183))
+
+  The `READ_ONLY_MODE_KEY` property is exposed for `DatabaseFileSource`.
+
+  This property allows to re-open the offline database in read-only mode and thus improves the performance for the set-ups that do not require the offline database modifications.
+
 ## maps-v1.0.1 (2020.01-release-unicorn)
 
 ### 🐞 Bug fixes

--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -7,6 +7,12 @@
 
 namespace mbgl {
 
+// Properties that may be supported by database file sources.
+
+// Property to set database mode. When set, database opens in read-only mode; database opens in read-write-create mode
+// otherwise. type: bool
+constexpr const char* READ_ONLY_MODE_KEY = "read-only-mode";
+
 class ResourceOptions;
 
 // TODO: Split DatabaseFileSource into Ambient cache and Database interfaces.

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -94,8 +94,7 @@ public:
     std::exception_ptr pack();
     void runPackDatabaseAutomatically(bool autopack_) { autopack = autopack_; }
 
-    // For testing only
-    void reopenDatabaseReadOnlyForTesting();
+    void reopenDatabaseReadOnly(bool readOnly);
 
 private:
     void initialize();
@@ -113,6 +112,7 @@ private:
     void cleanup();
     bool disabled();
     void vacuum();
+    void checkFlags();
 
     mapbox::sqlite::Statement& getStatement(const char *);
 

--- a/platform/default/src/mbgl/storage/database_file_source.cpp
+++ b/platform/default/src/mbgl/storage/database_file_source.cpp
@@ -14,10 +14,6 @@
 #include <map>
 
 namespace mbgl {
-
-// For testing use only
-constexpr const char* READ_ONLY_MODE_KEY = "read-only-mode";
-
 class DatabaseFileSourceThread {
 public:
     DatabaseFileSourceThread(std::shared_ptr<FileSource> onlineFileSource_, std::string cachePath)
@@ -122,7 +118,7 @@ public:
 
     void setOfflineMapboxTileCountLimit(uint64_t limit) { db->setOfflineMapboxTileCountLimit(limit); }
 
-    void reopenDatabaseReadOnlyForTesting() { db->reopenDatabaseReadOnlyForTesting(); }
+    void reopenDatabaseReadOnly(bool readOnly) { db->reopenDatabaseReadOnly(readOnly); }
 
 private:
     expected<OfflineDownload*, std::exception_ptr> getDownload(int64_t regionID) {
@@ -278,9 +274,7 @@ void DatabaseFileSource::setOfflineMapboxTileCountLimit(uint64_t limit) const {
 
 void DatabaseFileSource::setProperty(const std::string& key, const mapbox::base::Value& value) {
     if (key == READ_ONLY_MODE_KEY && value.getBool()) {
-        if (*value.getBool()) {
-            impl->actor().invoke(&DatabaseFileSourceThread::reopenDatabaseReadOnlyForTesting);
-        }
+        impl->actor().invoke(&DatabaseFileSourceThread::reopenDatabaseReadOnly, *value.getBool());
     } else {
         std::string message = "Resource provider does not support property " + key;
         Log::Error(Event::General, message.c_str());

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -1902,3 +1902,19 @@ TEST(OfflineDatabase, PutResourceReadOnlyMode) {
 
     EXPECT_EQ(0u, log.uncheckedCount());
 }
+
+TEST(OfflineDatabase, TEST_REQUIRES_WRITE(UpdateDatabaseReadOnlyMode)) {
+    FixtureLog log;
+    deleteDatabaseFiles();
+
+    OfflineDatabase db(filename);
+    db.reopenDatabaseReadOnly(true /*readOnly*/);
+    db.clearAmbientCache();
+    EXPECT_EQ(1u,
+              log.count({EventSeverity::Error,
+                         Event::Database,
+                         -1,
+                         "Can't clear ambient cache: Cannot modify database in read-only mode"}));
+
+    EXPECT_EQ(0u, log.uncheckedCount());
+}


### PR DESCRIPTION
This PR exposes `DatabaseFileSource` property, which allows to re-open the offline database in read-only mode and thus improves the performance for the set ups that do not require the offline database modifications. Example of usage:
```
auto fileSource = mbgl::FileSourceManager::get()->getFileSource(
    mbgl::FileSourceType::Database, resourceOptions);
fileSource->setProperty(READ_ONLY_MODE_KEY, true);
```

Tag https://github.com/mapbox/mapbox-gl-native-team/issues/169