### PR TITLE
[core] Loading images to style optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@
 
   The new `Source::setPrefetchZoomDelta(optional<uint8_t>)` method allows overriding default tile prefetch setting that is defined by the Map instance.
 
+### 🏁 Performance improvements
+
+ - [core] Loading images to style optimization ([#16187](https://github.com/mapbox/mapbox-gl-native/pull/16187))
+
+   This change enables attaching images to the style with batches and avoids massive re-allocations. Thus, it improves UI performance especially at start-up time.
+
+### 🧩  Architectural changes
+
+##### ⚠️  Breaking changes
+
+ - [core] Loading images to style optimization ([#16187](https://github.com/mapbox/mapbox-gl-native/pull/16187))
+
+   The `style::Style::getImage()` semantics changed - it now returns `optional<style::Image>`.
+
 ## maps-v1.0.1 (2020.01-release-unicorn)
 
 ### 🐞 Bug fixes

--- a/include/mbgl/style/image.hpp
+++ b/include/mbgl/style/image.hpp
@@ -69,6 +69,7 @@ public:
 
     class Impl;
     Immutable<Impl> baseImpl;
+    explicit Image(Immutable<Impl> baseImpl_) : baseImpl(std::move(baseImpl_)) {}
 };
 
 } // namespace style

--- a/include/mbgl/style/style.hpp
+++ b/include/mbgl/style/style.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <mbgl/style/transition_options.hpp>
 #include <mbgl/map/camera.hpp>
+#include <mbgl/style/transition_options.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/image.hpp>
+#include <mbgl/util/immutable.hpp>
 
 #include <string>
 #include <vector>
@@ -45,7 +47,7 @@ public:
     void setLight(std::unique_ptr<Light>);
 
     // Images
-    const Image* getImage(const std::string&) const;
+    const PremultipliedImage* getImage(const std::string&) const;
     void addImage(std::unique_ptr<Image>);
     void removeImage(const std::string&);
 

--- a/include/mbgl/style/style.hpp
+++ b/include/mbgl/style/style.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <mbgl/map/camera.hpp>
+#include <mbgl/style/image.hpp>
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/util/geo.hpp>
-#include <mbgl/util/image.hpp>
 #include <mbgl/util/immutable.hpp>
 
 #include <string>
@@ -17,7 +17,6 @@ class FileSource;
 namespace style {
 
 class Light;
-class Image;
 class Source;
 class Layer;
 
@@ -47,7 +46,7 @@ public:
     void setLight(std::unique_ptr<Light>);
 
     // Images
-    const PremultipliedImage* getImage(const std::string&) const;
+    optional<Image> getImage(const std::string&) const;
     void addImage(std::unique_ptr<Image>);
     void removeImage(const std::string&);
 

--- a/metrics/binary-size/android-armeabi-v7a/metrics.json
+++ b/metrics/binary-size/android-armeabi-v7a/metrics.json
@@ -3,7 +3,7 @@
         [
             "android-armeabi-v7a",
             "/tmp/attach/install/android-armeabi-v7a-release/lib/libmapbox-gl.so",
-            1624848
+            1643552
         ]
     ]
 }

--- a/metrics/binary-size/linux-gcc8/metrics.json
+++ b/metrics/binary-size/linux-gcc8/metrics.json
@@ -3,17 +3,17 @@
         [
             "mbgl-glfw",
             "/tmp/attach/install/linux-gcc8-release/bin/mbgl-glfw",
-            7475528
+            7549288
         ],
         [
             "mbgl-offline",
             "/tmp/attach/install/linux-gcc8-release/bin/mbgl-offline",
-            6570216
+            6631656
         ],
         [
             "mbgl-render",
             "/tmp/attach/install/linux-gcc8-release/bin/mbgl-render",
-            7360840
+            7434600
         ]
     ]
 }

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -1099,8 +1099,8 @@ void NativeMapView::removeImage(JNIEnv& env, const jni::String& name) {
 }
 
 jni::Local<jni::Object<Bitmap>> NativeMapView::getImage(JNIEnv& env, const jni::String& name) {
-    if (auto* image = map->getStyle().getImage(jni::Make<std::string>(env, name))) {
-        return Bitmap::CreateBitmap(env, *image);
+    if (auto image = map->getStyle().getImage(jni::Make<std::string>(env, name))) {
+        return Bitmap::CreateBitmap(env, image->getImage());
     }
     return jni::Local<jni::Object<Bitmap>>();
 }

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -1099,12 +1099,10 @@ void NativeMapView::removeImage(JNIEnv& env, const jni::String& name) {
 }
 
 jni::Local<jni::Object<Bitmap>> NativeMapView::getImage(JNIEnv& env, const jni::String& name) {
-    const mbgl::style::Image *image = map->getStyle().getImage(jni::Make<std::string>(env, name));
-    if (image) {
-        return Bitmap::CreateBitmap(env, image->getImage());
-    } else {
-        return jni::Local<jni::Object<Bitmap>>();
+    if (auto* image = map->getStyle().getImage(jni::Make<std::string>(env, name))) {
+        return Bitmap::CreateBitmap(env, *image);
     }
+    return jni::Local<jni::Object<Bitmap>>();
 }
 
 void NativeMapView::setPrefetchTiles(JNIEnv&, jni::jboolean enable) {

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -528,7 +528,7 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     }
 
     auto styleImage = self.rawStyle->getImage([name UTF8String]);
-    return styleImage ? [[MGLImage alloc] initWithMGLStyleImage:styleImage] : nil;
+    return styleImage ? [[MGLImage alloc] initWithMGLStyleImage:&(*styleImage)] : nil;
 }
 
 #pragma mark Style transitions

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -170,9 +170,7 @@ void Map::Impl::jumpTo(const CameraOptions& camera) {
 }
 
 void Map::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
-    if (style->getImage(id) == nullptr) {
-        observer.onStyleImageMissing(id);
-    }
+    if (!style->getImage(id)) observer.onStyleImageMissing(id);
 
     done();
     onUpdate();

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -170,7 +170,6 @@ void Map::Impl::jumpTo(const CameraOptions& camera) {
 }
 
 void Map::Impl::onStyleImageMissing(const std::string& id, std::function<void()> done) {
-
     if (style->getImage(id) == nullptr) {
         observer.onStyleImageMissing(id);
     }

--- a/src/mbgl/sprite/sprite_loader.cpp
+++ b/src/mbgl/sprite/sprite_loader.cpp
@@ -90,7 +90,7 @@ void SpriteLoader::emitSpriteLoadedIfComplete() {
     loader->worker.self().invoke(&SpriteLoaderWorker::parse, loader->image, loader->json);
 }
 
-void SpriteLoader::onParsed(std::vector<std::unique_ptr<style::Image>>&& result) {
+void SpriteLoader::onParsed(std::vector<Immutable<style::Image::Impl>> result) {
     observer->onSpriteLoaded(std::move(result));
 }
 

--- a/src/mbgl/sprite/sprite_loader.hpp
+++ b/src/mbgl/sprite/sprite_loader.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mbgl/util/noncopyable.hpp>
 #include <mbgl/style/image.hpp>
 
 #include <string>
@@ -15,7 +14,7 @@ namespace mbgl {
 class FileSource;
 class SpriteLoaderObserver;
 
-class SpriteLoader : public util::noncopyable {
+class SpriteLoader {
 public:
     SpriteLoader(float pixelRatio);
     ~SpriteLoader();
@@ -29,7 +28,7 @@ private:
 
     // Invoked by SpriteAtlasWorker
     friend class SpriteLoaderWorker;
-    void onParsed(std::vector<std::unique_ptr<style::Image>>&&);
+    void onParsed(std::vector<Immutable<style::Image::Impl>>);
     void onError(std::exception_ptr);
 
     const float pixelRatio;

--- a/src/mbgl/sprite/sprite_loader_observer.hpp
+++ b/src/mbgl/sprite/sprite_loader_observer.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <mbgl/style/image.hpp>
+#include <mbgl/util/immutable.hpp>
+
 #include <exception>
-#include <memory>
 #include <vector>
 
 namespace mbgl {
@@ -13,8 +15,7 @@ class Image;
 class SpriteLoaderObserver {
 public:
     virtual ~SpriteLoaderObserver() = default;
-
-    virtual void onSpriteLoaded(std::vector<std::unique_ptr<style::Image>>&&) {}
+    virtual void onSpriteLoaded(std::vector<Immutable<style::Image::Impl>>) {}
     virtual void onSpriteError(std::exception_ptr) {}
 };
 

--- a/src/mbgl/sprite/sprite_parser.hpp
+++ b/src/mbgl/sprite/sprite_parser.hpp
@@ -20,6 +20,6 @@ std::unique_ptr<style::Image> createStyleImage(const std::string& id,
                                                optional<style::ImageContent> content = nullopt);
 
 // Parses an image and an associated JSON file and returns the sprite objects.
-std::vector<std::unique_ptr<style::Image>> parseSprite(const std::string& image, const std::string& json);
+std::vector<Immutable<style::Image::Impl>> parseSprite(const std::string& image, const std::string& json);
 
 } // namespace mbgl

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -60,11 +60,10 @@ const Light* Style::getLight() const {
     return impl->getLight();
 }
 
-const PremultipliedImage* Style::getImage(const std::string& name) const {
-    if (auto* image = impl->getImage(name)) {
-        return &(image->image);
-    }
-    return nullptr;
+optional<Image> Style::getImage(const std::string& name) const {
+    auto image = impl->getImage(name);
+    if (!image) return nullopt;
+    return style::Image(std::move(*image));
 }
 
 void Style::addImage(std::unique_ptr<Image> image) {

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -1,9 +1,10 @@
+#include <mbgl/style/image.hpp>
+#include <mbgl/style/image_impl.hpp>
+#include <mbgl/style/layer.hpp>
+#include <mbgl/style/light.hpp>
+#include <mbgl/style/source.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_impl.hpp>
-#include <mbgl/style/light.hpp>
-#include <mbgl/style/image.hpp>
-#include <mbgl/style/source.hpp>
-#include <mbgl/style/layer.hpp>
 
 namespace mbgl {
 namespace style {
@@ -59,8 +60,11 @@ const Light* Style::getLight() const {
     return impl->getLight();
 }
 
-const Image* Style::getImage(const std::string& name) const {
-    return impl->getImage(name);
+const PremultipliedImage* Style::getImage(const std::string& name) const {
+    if (auto* image = impl->getImage(name)) {
+        return &(image->image);
+    }
+    return nullptr;
 }
 
 void Style::addImage(std::unique_ptr<Image> image) {

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -301,10 +301,10 @@ void Style::Impl::removeImage(const std::string& id) {
     images = std::move(newImages);
 }
 
-const style::Image::Impl* Style::Impl::getImage(const std::string& id) const {
+optional<Immutable<style::Image::Impl>> Style::Impl::getImage(const std::string& id) const {
     auto found = std::find_if(images->begin(), images->end(), [&id](const auto& image) { return image->id == id; });
-    if (found == images->end()) return nullptr;
-    return found->get();
+    if (found == images->end()) return nullopt;
+    return *found;
 }
 
 void Style::Impl::setObserver(style::Observer* observer_) {

--- a/src/mbgl/style/style_impl.hpp
+++ b/src/mbgl/style/style_impl.hpp
@@ -78,13 +78,14 @@ public:
     void setLight(std::unique_ptr<Light>);
     Light* getLight() const;
 
-    const style::Image* getImage(const std::string&) const;
+    const style::Image::Impl* getImage(const std::string&) const;
     void addImage(std::unique_ptr<style::Image>);
     void removeImage(const std::string&);
 
     const std::string& getGlyphURL() const;
 
-    Immutable<std::vector<Immutable<Image::Impl>>> getImageImpls() const;
+    using ImageImpls = std::vector<Immutable<Image::Impl>>;
+    Immutable<ImageImpls> getImageImpls() const;
     Immutable<std::vector<Immutable<Source::Impl>>> getSourceImpls() const;
     Immutable<std::vector<Immutable<Layer::Impl>>> getLayerImpls() const;
 
@@ -106,7 +107,7 @@ private:
     std::unique_ptr<SpriteLoader> spriteLoader;
 
     std::string glyphURL;
-    CollectionWithPersistentOrder<style::Image> images;
+    Immutable<ImageImpls> images = makeMutable<ImageImpls>();
     CollectionWithPersistentOrder<Source> sources;
     Collection<Layer> layers;
     TransitionOptions transitionOptions;
@@ -117,7 +118,7 @@ private:
     CameraOptions defaultCamera;
 
     // SpriteLoaderObserver implementation.
-    void onSpriteLoaded(std::vector<std::unique_ptr<Image>>&&) override;
+    void onSpriteLoaded(std::vector<Immutable<style::Image::Impl>>) override;
     void onSpriteError(std::exception_ptr) override;
 
     // SourceObserver implementation.

--- a/src/mbgl/style/style_impl.hpp
+++ b/src/mbgl/style/style_impl.hpp
@@ -78,7 +78,7 @@ public:
     void setLight(std::unique_ptr<Light>);
     Light* getLight() const;
 
-    const style::Image::Impl* getImage(const std::string&) const;
+    optional<Immutable<style::Image::Impl>> getImage(const std::string&) const;
     void addImage(std::unique_ptr<style::Image>);
     void removeImage(const std::string&);
 

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -27,10 +27,10 @@ TEST(ImageManager, Basic) {
     auto images = parseSprite(util::read_file("test/fixtures/annotations/emerald.png"),
                               util::read_file("test/fixtures/annotations/emerald.json"));
     for (auto& image : images) {
-        imageManager.addImage(image->baseImpl);
-        auto* stored = imageManager.getImage(image->getID());
+        imageManager.addImage(image);
+        auto* stored = imageManager.getImage(image->id);
         ASSERT_TRUE(stored);
-        EXPECT_EQ(image->getImage().size, stored->image.size);
+        EXPECT_EQ(image->image.size, stored->image.size);
     }
 }
 

--- a/test/renderer/pattern_atlas.test.cpp
+++ b/test/renderer/pattern_atlas.test.cpp
@@ -21,8 +21,8 @@ TEST(PatternAtlas, Basic) {
     auto images = parseSprite(util::read_file("test/fixtures/annotations/emerald.png"),
                               util::read_file("test/fixtures/annotations/emerald.json"));
     for (auto& image : images) {
-        if (image->getID() == "metro") {
-            ASSERT_TRUE(patternAtlas.addPattern(*image->baseImpl));
+        if (image->id == "metro") {
+            ASSERT_TRUE(patternAtlas.addPattern(*image));
         }
     }
     auto found = patternAtlas.getPattern("metro");

--- a/test/sprite/sprite_loader.test.cpp
+++ b/test/sprite/sprite_loader.test.cpp
@@ -17,7 +17,7 @@ using namespace mbgl::style;
 
 class StubSpriteLoaderObserver : public SpriteLoaderObserver {
 public:
-    void onSpriteLoaded(std::vector<std::unique_ptr<style::Image>>&& images) override {
+    void onSpriteLoaded(std::vector<Immutable<style::Image::Impl>> images) override {
         if (spriteLoaded) spriteLoaded(std::move(images));
     }
 
@@ -25,7 +25,7 @@ public:
         if (spriteError) spriteError(error);
     }
 
-    std::function<void (std::vector<std::unique_ptr<style::Image>>&&)> spriteLoaded;
+    std::function<void(std::vector<Immutable<style::Image::Impl>>)> spriteLoaded;
     std::function<void (std::exception_ptr)> spriteError;
 };
 
@@ -92,7 +92,7 @@ TEST(SpriteLoader, LoadingSuccess) {
         test.end();
     };
 
-    test.observer.spriteLoaded = [&] (std::vector<std::unique_ptr<style::Image>>&& images) {
+    test.observer.spriteLoaded = [&](std::vector<Immutable<style::Image::Impl>> images) {
         EXPECT_EQ(images.size(), 367u);
         test.end();
     };
@@ -169,7 +169,7 @@ TEST(SpriteLoader, LoadingCancel) {
         return optional<Response>();
     };
 
-    test.observer.spriteLoaded = [&] (const std::vector<std::unique_ptr<style::Image>>&) {
+    test.observer.spriteLoaded = [&](std::vector<Immutable<style::Image::Impl>>) {
         FAIL() << "Should never be called";
     };
 

--- a/test/sprite/sprite_parser.test.cpp
+++ b/test/sprite/sprite_parser.test.cpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/sprite/sprite_parser.hpp>
 #include <mbgl/style/image.hpp>
+#include <mbgl/style/image_impl.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/string.hpp>
@@ -242,8 +243,8 @@ TEST(Sprite, SpriteParsing) {
     const auto images = parseSprite(image_1x, json_1x);
 
     std::set<std::string> names;
-    std::transform(images.begin(), images.end(), std::inserter(names, names.begin()),
-                   [](const auto& image) { return image->getID(); });
+    std::transform(
+        images.begin(), images.end(), std::inserter(names, names.begin()), [](const auto& image) { return image->id; });
 
     EXPECT_EQ(std::set<std::string>({ "airfield_icon",
                                       "airport_icon",
@@ -321,11 +322,12 @@ TEST(Sprite, SpriteParsing) {
               names);
 
     {
-        auto& sprite = *std::find_if(images.begin(), images.end(), [] (const auto& image) { return image->getID() == "generic-metro"; });
-        EXPECT_EQ(18u, sprite->getImage().size.width);
-        EXPECT_EQ(18u, sprite->getImage().size.height);
-        EXPECT_EQ(1, sprite->getPixelRatio());
-        EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteparsing.png"), sprite->getImage());
+        auto& sprite =
+            *std::find_if(images.begin(), images.end(), [](const auto& image) { return image->id == "generic-metro"; });
+        EXPECT_EQ(18u, sprite->image.size.width);
+        EXPECT_EQ(18u, sprite->image.size.height);
+        EXPECT_EQ(1, sprite->pixelRatio);
+        EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteparsing.png"), sprite->image);
     }
 }
 
@@ -460,10 +462,10 @@ TEST(Sprite, SpriteParsingStretchAndContent) {
         }
     })JSON");
     EXPECT_EQ(1u, images.size());
-    EXPECT_EQ("image", images[0]->getID());
-    EXPECT_EQ((style::ImageStretches{{2, 14}}), images[0]->getStretchX());
-    EXPECT_EQ((style::ImageStretches{{0, 4}, {12, 16}}), images[0]->getStretchY());
-    EXPECT_EQ((style::ImageContent{2, 2, 14, 14}), images[0]->getContent());
+    EXPECT_EQ("image", images[0]->id);
+    EXPECT_EQ((style::ImageStretches{{2, 14}}), images[0]->stretchX);
+    EXPECT_EQ((style::ImageStretches{{0, 4}, {12, 16}}), images[0]->stretchY);
+    EXPECT_EQ((style::ImageContent{2, 2, 14, 14}), images[0]->content);
 }
 
 TEST(Sprite, SpriteParsingEmptyImage) {

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -125,3 +125,19 @@ TEST(Style, SourceImplsOrder) {
     EXPECT_EQ("b", sourceImpls[1]->id);
     EXPECT_EQ("c", sourceImpls[2]->id);
 }
+
+TEST(Style, AddRemoveImage) {
+    util::RunLoop loop;
+    auto fileSource = std::make_shared<StubFileSource>();
+    Style::Impl style{fileSource, 1.0};
+    style.addImage(std::make_unique<style::Image>("one", PremultipliedImage({16, 16}), 2));
+    style.addImage(std::make_unique<style::Image>("two", PremultipliedImage({16, 16}), 2));
+    style.addImage(std::make_unique<style::Image>("three", PremultipliedImage({16, 16}), 2));
+
+    style.removeImage("one");
+    style.removeImage("two");
+
+    EXPECT_TRUE(!!style.getImage("three"));
+    EXPECT_FALSE(!!style.getImage("two"));
+    EXPECT_FALSE(!!style.getImage("four"));
+}


### PR DESCRIPTION
This change enables attaching images to the style with batches and avoids massive re-allocations. Thus, it improves UI performance especially at start-up time.

Tag https://github.com/mapbox/mapbox-gl-native-team/issues/169