### PR TITLE
Enable `within` Expression with layout property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
  
   Support for using `within expression` with layout propery will be implemented separately.
 
+- [core] Add support for using `within expression` with layout propery. ([#16194](https://github.com/mapbox/mapbox-gl-native/pull/16194))
+
 ### 🏁 Performance improvements
 
  - [core] Loading images to style optimization ([#16187](https://github.com/mapbox/mapbox-gl-native/pull/16187))

--- a/include/mbgl/style/property_expression.hpp
+++ b/include/mbgl/style/property_expression.hpp
@@ -73,6 +73,20 @@ public:
                         finalDefaultValue);
     }
 
+    T evaluate(const GeometryTileFeature& feature, const CanonicalTileID& canonical, T finalDefaultValue) const {
+        return evaluate(expression::EvaluationContext(&feature).withCanonicalTileID(&canonical), finalDefaultValue);
+    }
+
+    T evaluate(const GeometryTileFeature& feature,
+               const std::set<std::string>& availableImages,
+               const CanonicalTileID& canonical,
+               T finalDefaultValue) const {
+        return evaluate(expression::EvaluationContext(&feature)
+                            .withAvailableImages(&availableImages)
+                            .withCanonicalTileID(&canonical),
+                        finalDefaultValue);
+    }
+
     T evaluate(float zoom, const GeometryTileFeature& feature, T finalDefaultValue) const {
         return evaluate(expression::EvaluationContext(zoom, &feature), finalDefaultValue);
     }
@@ -82,6 +96,25 @@ public:
                const std::set<std::string>& availableImages,
                T finalDefaultValue) const {
         return evaluate(expression::EvaluationContext(zoom, &feature).withAvailableImages(&availableImages),
+                        finalDefaultValue);
+    }
+
+    T evaluate(float zoom,
+               const GeometryTileFeature& feature,
+               const std::set<std::string>& availableImages,
+               const CanonicalTileID& canonical,
+               T finalDefaultValue) const {
+        return evaluate(expression::EvaluationContext(zoom, &feature)
+                            .withAvailableImages(&availableImages)
+                            .withCanonicalTileID(&canonical),
+                        finalDefaultValue);
+    }
+
+    T evaluate(float zoom,
+               const GeometryTileFeature& feature,
+               const CanonicalTileID& canonical,
+               T finalDefaultValue) const {
+        return evaluate(expression::EvaluationContext(zoom, &feature).withCanonicalTileID(&canonical),
                         finalDefaultValue);
     }
 

--- a/metrics/android-render-test-runner/render-tests/within/layout-text/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/within/layout-text/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            13,
+            17,
+            21,
+            1,
+            [
+                207208,
+                207208
+            ],
+            [
+                210,
+                210
+            ],
+            [
+                944,
+                944
+            ]
+        ]
+    ]
+}

--- a/metrics/ignores/platform-all.json
+++ b/metrics/ignores/platform-all.json
@@ -132,6 +132,5 @@
     "render-tests/text-variable-anchor/left-top-right-buttom-offset-tile-map-mode":"https://github.com/mapbox/mapbox-gl-js/pull/9202",
     "render-tests/line-pattern/with-dasharray":"https://github.com/mapbox/mapbox-gl-js/pull/9189",
     "render-tests/symbol-sort-key/placement-tile-boundary-right-then-left": "https://github.com/mapbox/mapbox-gl-js/pull/9054",
-    "render-tests/line-dasharray/zero-length-gap":"https://github.com/mapbox/mapbox-gl-js/pull/9246",
-    "render-tests/within/layout-text": "TODO: Fix by enabling `within` expreesion with layout property"
+    "render-tests/line-dasharray/zero-length-gap":"https://github.com/mapbox/mapbox-gl-js/pull/9246"
 }

--- a/metrics/ios-render-test-runner/render-tests/within/layout-text/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/within/layout-text/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            13,
+            17,
+            21,
+            1,
+            [
+                207208,
+                207208
+            ],
+            [
+                210,
+                210
+            ],
+            [
+                944,
+                944
+            ]
+        ]
+    ]
+}

--- a/metrics/linux-clang8-release/render-tests/within/layout-text/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/within/layout-text/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            13,
+            17,
+            21,
+            1,
+            [
+                207208,
+                207208
+            ],
+            [
+                210,
+                210
+            ],
+            [
+                944,
+                944
+            ]
+        ]
+    ]
+}

--- a/metrics/linux-gcc8-release/render-tests/within/layout-text/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/within/layout-text/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            1,
+            84942
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            13,
+            17,
+            21,
+            1,
+            [
+                207208,
+                207208
+            ],
+            [
+                210,
+                210
+            ],
+            [
+                944,
+                944
+            ]
+        ]
+    ]
+}

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -115,6 +115,7 @@ private:
     const std::unique_ptr<GeometryTileLayer> sourceLayer;
     const float overscaling;
     const float zoom;
+    const CanonicalTileID canonicalID;
     const MapMode mode;
     const float pixelRatio;
 

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -115,7 +115,7 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
 
     for (auto& pair : paintPropertyBinders) {
         const auto it = patternDependencies.find(pair.first);
-        if (it != patternDependencies.end()){
+        if (it != patternDependencies.end()) {
             pair.second.populateVertexVectors(
                 feature, vertices.elements(), index, patternPositions, it->second, canonical);
         } else {

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -34,7 +34,7 @@ void LineBucket::addFeature(const GeometryTileFeature& feature,
                             std::size_t index,
                             const CanonicalTileID& canonical) {
     for (auto& line : geometryCollection) {
-        addGeometry(line, feature);
+        addGeometry(line, feature, canonical);
     }
 
     for (auto& pair : paintPropertyBinders) {
@@ -97,7 +97,9 @@ private:
     double total;
 };
 
-void LineBucket::addGeometry(const GeometryCoordinates& coordinates, const GeometryTileFeature& feature) {
+void LineBucket::addGeometry(const GeometryCoordinates& coordinates,
+                             const GeometryTileFeature& feature,
+                             const CanonicalTileID& canonical) {
     const FeatureType type = feature.getType();
     const std::size_t len = [&coordinates] {
         std::size_t l = coordinates.size();
@@ -137,7 +139,7 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates, const Geome
             *numericValue<double>(clip_start_it->second), *numericValue<double>(clip_end_it->second), total_length};
     }
 
-    const LineJoinType joinType = layout.evaluate<LineJoin>(zoom, feature);
+    const LineJoinType joinType = layout.evaluate<LineJoin>(zoom, feature, canonical);
 
     const float miterLimit = joinType == LineJoinType::Bevel ? 1.05f : float(layout.get<LineMiterLimit>());
 

--- a/src/mbgl/renderer/buckets/line_bucket.hpp
+++ b/src/mbgl/renderer/buckets/line_bucket.hpp
@@ -52,7 +52,7 @@ public:
     std::map<std::string, LineProgram::Binders> paintPropertyBinders;
 
 private:
-    void addGeometry(const GeometryCoordinates&, const GeometryTileFeature&);
+    void addGeometry(const GeometryCoordinates&, const GeometryTileFeature&, const CanonicalTileID&);
 
     struct TriangleElement {
         TriangleElement(uint16_t a_, uint16_t b_, uint16_t c_) : a(a_), b(b_), c(c_) {}

--- a/src/mbgl/renderer/possibly_evaluated_property_value.hpp
+++ b/src/mbgl/renderer/possibly_evaluated_property_value.hpp
@@ -51,6 +51,14 @@ public:
     }
 
     template <class Feature>
+    T evaluate(const Feature& feature, float zoom, const CanonicalTileID& canonical, T defaultValue) const {
+        return this->match([&](const T& constant_) { return constant_; },
+                           [&](const style::PropertyExpression<T>& expression) {
+                               return expression.evaluate(zoom, feature, canonical, defaultValue);
+                           });
+    }
+
+    template <class Feature>
     T evaluate(const Feature& feature, float zoom, const FeatureState& featureState, T defaultValue) const {
         return this->match([&](const T& constant_) { return constant_; },
                            [&](const style::PropertyExpression<T>& expression) {
@@ -96,13 +104,15 @@ public:
     Faded<T> evaluate(const Feature& feature,
                       float zoom,
                       const std::set<std::string>& availableImages,
+                      const CanonicalTileID& canonical,
                       T defaultValue) const {
         return this->match(
             [&] (const Faded<T>& constant_) { return constant_; },
             [&] (const style::PropertyExpression<T>& expression) {
                 if (!expression.isZoomConstant()) {
-                    const T min = expression.evaluate(floor(zoom), feature, availableImages, defaultValue);
-                    const T max = expression.evaluate(floor(zoom) + 1, feature, availableImages, defaultValue);
+                    const T min = expression.evaluate(floor(zoom), feature, availableImages, canonical, defaultValue);
+                    const T max =
+                        expression.evaluate(floor(zoom) + 1, feature, availableImages, canonical, defaultValue);
                     return Faded<T> {min, max};
                 } else {
                     const T evaluated = expression.evaluate(feature, availableImages, defaultValue);

--- a/src/mbgl/style/properties.hpp
+++ b/src/mbgl/style/properties.hpp
@@ -169,6 +169,11 @@ public:
         }
 
         template <class T>
+        static T evaluate(float, const GeometryTileFeature&, const CanonicalTileID&, const T& t, const T&) {
+            return t;
+        }
+
+        template <class T>
         static T evaluate(float z,
                           const GeometryTileFeature& feature,
                           const PossiblyEvaluatedPropertyValue<T>& v,
@@ -191,6 +196,30 @@ public:
             return v.match(
                 [&](const T& t) { return t; },
                 [&](const PropertyExpression<T>& t) { return t.evaluate(z, feature, availableImages, defaultValue); });
+        }
+
+        template <class T>
+        static T evaluate(float z,
+                          const GeometryTileFeature& feature,
+                          const PossiblyEvaluatedPropertyValue<T>& v,
+                          const T& defaultValue,
+                          const std::set<std::string>& availableImages,
+                          const CanonicalTileID& canonical) {
+            return v.match([&](const T& t) { return t; },
+                           [&](const PropertyExpression<T>& t) {
+                               return t.evaluate(z, feature, availableImages, canonical, defaultValue);
+                           });
+        }
+
+        template <class T>
+        static T evaluate(float z,
+                          const GeometryTileFeature& feature,
+                          const CanonicalTileID& canonical,
+                          const PossiblyEvaluatedPropertyValue<T>& v,
+                          const T& defaultValue) {
+            return v.match(
+                [&](const T& t) { return t; },
+                [&](const PropertyExpression<T>& t) { return t.evaluate(z, feature, canonical, defaultValue); });
         }
 
         template <class T>
@@ -218,6 +247,14 @@ public:
         template <class P>
         auto evaluate(float z, const GeometryTileFeature& feature, const std::set<std::string>& availableImages) const {
             return evaluate(z, feature, this->template get<P>(), P::defaultValue(), availableImages);
+        }
+
+        template <class P>
+        auto evaluate(float z,
+                      const GeometryTileFeature& feature,
+                      const std::set<std::string>& availableImages,
+                      const CanonicalTileID& canonical) const {
+            return evaluate(z, feature, this->template get<P>(), P::defaultValue(), availableImages, canonical);
         }
 
         Evaluated evaluate(float z, const GeometryTileFeature& feature) const {


### PR DESCRIPTION
This pr implement usage of `within` expression with layout property. Currently the usage is: [`within`, `geoJSONObj`]. It returns true if the feature is inside the geometry boundary that defined by `geoJSONObj`.  `geoJSONObj` should be inlined.

Following example shows how to set different text contents based on the feature's geometry location. 
```
{
        "id": "text",
        "type": "symbol",
        "source": "points",
        "layout": {
            "text-field": ["case", ["within", {
                "type": "Polygon",
                "coordinates": [
                    [
                      [0, 0],
                      [0, 5],
                      [5, 5],
                      [5, 0],
                      [0, 0]
                    ]
                  ]
                }], "In", "Out"],
            "text-font": [
                "Open Sans Semibold",
                "Arial Unicode MS Bold"
            ],
            "text-size": 10
          },
          "paint" : {
            "text-color": "red"
          }
 }
```
