### PR TITLE
[core] Fix excessive onSpriteLoaded() notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
    This change enables attaching images to the style with batches and avoids massive re-allocations. Thus, it improves UI performance especially at start-up time.
 
+ - [core] Fix excessive onSpriteLoaded() notifications ([#16196](https://github.com/mapbox/mapbox-gl-native/pull/16196))
+
+   The excessive `onSpriteLoaded()` notifications affected the render orchestration logic and could have significant negative performance impact.
+
 ### 🧩  Architectural changes
 
 ##### ⚠️  Breaking changes

--- a/src/mbgl/sprite/sprite_loader.cpp
+++ b/src/mbgl/sprite/sprite_loader.cpp
@@ -58,9 +58,9 @@ void SpriteLoader::load(const std::string& url, FileSource& fileSource) {
         } else if (res.noContent) {
             loader->json = std::make_shared<std::string>();
             emitSpriteLoadedIfComplete();
-        } else {
+        } else if (loader->json != res.data) { // They can be equal, see OnlineFileRequest::completed().
             // Only trigger a sprite loaded event we got new data.
-            loader->json = res.data;
+            loader->json = std::move(res.data);
             emitSpriteLoadedIfComplete();
         }
     });
@@ -73,8 +73,8 @@ void SpriteLoader::load(const std::string& url, FileSource& fileSource) {
         } else if (res.noContent) {
             loader->image = std::make_shared<std::string>();
             emitSpriteLoadedIfComplete();
-        } else {
-            loader->image = res.data;
+        } else if (loader->image != res.data) { // They can be equal - see OnlineFileRequest::completed().
+            loader->image = std::move(res.data);
             emitSpriteLoadedIfComplete();
         }
     });


### PR DESCRIPTION
**What happened:**

The excessive `onSpriteLoaded()` notifications were caused by the trick inside `OnlineFileRequest::completed()` implementation, which causes receiving of two file source updates pointing to the *same* data in case _the network response is `notModified` and the local storage has the sprite sheet already stored inside_.

In the `SpriteLoader` implementation, it resulted in 2 extra `parseSprite()` calls and 2 extra `onSpriteLoaded()` notifications.

Then, the excessive `onSpriteLoaded()` notifications affected style images and all the unnecessarily added image dupes (btw, the amount of these dupes `= 2 * number of style images`) were treated by the `RenderOrchestrator` as *updated* images.

Further, `RenderOrchestrator` called `ImageManager::updateImage()` for the updated images and the `ImageManager` populated the `updatedImageVersions` map.

Finally, _at every frame_ all the geometry tiles iterated through the `updatedImageVersions` map to check whether their uploaded textures needed patching.

All the mentioned above had a negative performance impact.

**The fix:**

Now, `SpriteLoader` sends `onSpriteLoaded()` notifications only if the data in the file source response is different comparing to the existing one.

Tag mapbox/mapbox-gl-native-team#169