### PR TITLE
Add tracing probes to the rendering pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,8 @@ add_library(
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/work_request.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/work_task.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/work_task_impl.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/perf/runtime_metrics.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/perf/trace_data.in
     ${PROJECT_SOURCE_DIR}/src/csscolorparser/csscolorparser.cpp
     ${PROJECT_SOURCE_DIR}/src/csscolorparser/csscolorparser.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/actor/mailbox.cpp

--- a/include/mbgl/perf/runtime_metrics.hpp
+++ b/include/mbgl/perf/runtime_metrics.hpp
@@ -1,0 +1,201 @@
+#pragma once
+
+#define MBGL_COLLECT_RUNTIME_METRICS
+
+#ifndef MBGL_COLLECT_RUNTIME_METRICS
+#define MBGL_TRACE_RENDERER_BEGIN(range, ...)
+#define MBGL_TRACE_RENDERER_END(range, ...)
+#define MBGL_TRACE_RENDERER_BEGINRECORD(range, ...)
+#define MBGL_TRACE_RENDERER_ENDRECORD(range, ...)
+#define MBGL_IF_TRACING(x)
+#else
+#include <mutex>
+#include <mbgl/util/chrono.hpp>
+#include <mbgl/util/logging.hpp>
+#include <vector>
+
+#define MBGL_IF_TRACING(x) x
+
+//#define MBGL_TRACER_USE_MUTEX
+#ifndef MBGL_TRACER_USE_MUTEX
+#define LOCK_RENDERER(t)
+#define UNLOCK_RENDERER(t)
+#define RENDERER_LOCKER()
+#else
+#define LOCK_RENDERER(t) t.frame_mutex.lock();
+#define UNLOCK_RENDERER(t) t.frame_mutex.unlock();
+#define RENDERER_LOCKER() std::unique_lock<std::mutex> locker(frame_mutex);
+#endif
+
+// First argument intended to be rangeName
+#define RANGE_NAME(X, ...) X
+#define MBGL_TRACE_RENDERER_BEGIN(...) { \
+    mbgl::util::Tracer &t = mbgl::util::Tracer::get(); \
+    LOCK_RENDERER(t); \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).scope = t.currentScope; \
+    t.currentScope += 1; \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).begin = mbgl::util::Tracer::nanoseconds(); \
+    UNLOCK_RENDERER(t); \
+                                              }
+#define MBGL_TRACE_RENDERER_END(...) { \
+    mbgl::util::Tracer &t = mbgl::util::Tracer::get(); \
+    LOCK_RENDERER(t); \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).end = mbgl::util::Tracer::nanoseconds(); \
+    t.currentScope -= 1; \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).totalCalls += 1; \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).totalMs += t.frameTrace.RANGE_NAME(__VA_ARGS__).end - t.frameTrace.RANGE_NAME(__VA_ARGS__).begin; \
+    UNLOCK_RENDERER(t); \
+                                            }
+#define MBGL_TRACE_RENDERER_BEGINRECORD(...) { \
+    mbgl::util::Tracer &t = mbgl::util::Tracer::get(); \
+    LOCK_RENDERER(t); \
+    t.frameTraceReset(t.frameTrace); \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).scope = t.currentScope; \
+    t.currentScope += 1; \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).begin = mbgl::util::Tracer::nanoseconds(); \
+    UNLOCK_RENDERER(t); \
+                                                }
+#define MBGL_TRACE_RENDERER_ENDRECORD(...) { \
+    mbgl::util::Tracer &t = mbgl::util::Tracer::get(); \
+    LOCK_RENDERER(t); \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).end = mbgl::util::Tracer::nanoseconds(); \
+    t.currentScope -= 1; \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).totalCalls += 1; \
+    t.frameTrace.RANGE_NAME(__VA_ARGS__).totalMs += t.frameTrace.RANGE_NAME(__VA_ARGS__).end - t.frameTrace.RANGE_NAME(__VA_ARGS__).begin; \
+    if (t.collectData) t.frameList.push_back(t.frameTrace); \
+    UNLOCK_RENDERER(t); }
+
+#define MBGL_TRACE_APPSTART(...) { mbgl::util::Tracer::get().appStart = mbgl::util::Tracer::nanoseconds(); }
+
+#define NS2MS(x) ((x) * 0.000001)
+
+namespace mbgl {
+namespace util {
+
+struct TraceInterval {
+    unsigned char scope = 0;    // overwritten by each range
+    uint64_t begin = 0u;        // overwritten by each range
+    uint64_t end = 0u;          // overwritten by each range
+    uint64_t totalMs = 0u;
+    uint64_t totalCalls = 0u;
+};
+
+#define STRUCT_BEGIN(name) struct name {
+#define STRUCT_END() };
+#define STRUCT_MEMBER_UINT64_RANGE(name, store_range, store_counter)   TraceInterval name;
+#include <mbgl/perf/trace_data.in>
+#undef STRUCT_BEGIN
+#undef STRUCT_END
+#undef STRUCT_MEMBER_UINT64_RANGE
+
+// Instrumentation-less tracing implementation, possibly requiring mutexing
+class Tracer
+{
+public:
+    static uint64_t nanoseconds() {
+        return Clock::now().time_since_epoch().count();
+    }
+    static Tracer& get() {
+        static Tracer i; // Guaranteed to be destroyed.
+        // Instantiated on first use.
+        return i;
+    }
+private:
+    Tracer() {}
+
+public:
+    Tracer(Tracer const&)               = delete;
+    void operator=(Tracer const&)       = delete;
+    bool collectData = false;
+
+
+    std::mutex frame_mutex;
+    std::vector<mbgl::util::FrameTrace> frameList;
+    mbgl::util::FrameTrace frameTrace;
+    unsigned int currentScope = 0u;
+    unsigned int appStart = 0u;
+
+/* frameTraceReset */
+#define STRUCT_BEGIN(name) static void frameTraceReset(name &data) { data = name();  // clear it by assigning to a new struct
+#define STRUCT_END() };
+#define STRUCT_MEMBER_UINT64_RANGE(name, store_range, store_counter)
+#include <mbgl/perf/trace_data.in>
+#undef STRUCT_BEGIN
+#undef STRUCT_END
+#undef STRUCT_MEMBER_UINT64_RANGE
+
+/* framesToJson */
+#define STRUCT_BEGIN(name) \
+static std::string frameToJson(const name &data) { \
+    std::string res; \
+    res += "{\n";
+// The following assumes that one of { store_range, store_counter } is true.
+#define STRUCT_MEMBER_UINT64_RANGE(name, store_range, store_counter) \
+res += std::string("\"") + std::string(#name) + std::string("\" : { "); \
+if (store_range) { \
+    res += std::string("\"scope\" : ") + std::to_string(data.name.scope) + std::string(" , ") \
+    + std::string("\"begin\" : ") + std::to_string(data.name.begin) + std::string(" , ") \
+    + std::string("\"end\" : ") + std::to_string(data.name.end); } \
+if (store_counter) { if (store_range) res += std::string(","); \
+    res += std::string("\"totalMs\" : ") + std::to_string(data.name.totalMs) + std::string(" , ") \
+    + std::string("\"totalCalls\" : ") + std::to_string(data.name.totalCalls); \
+} \
+res += std::string(" },");
+#define STRUCT_END() \
+    res.pop_back(); res += "}"; \
+    return res; \
+};
+#include <mbgl/perf/trace_data.in>
+#undef STRUCT_BEGIN
+#undef STRUCT_END
+#undef STRUCT_MEMBER_UINT64_RANGE
+
+    inline bool isCollectingData() const {
+        return collectData;
+    }
+    inline void setCollectData(bool enabled) {
+        collectData = enabled;
+    }
+
+    inline std::string framesJson(bool steal = false) const {
+        LOCK_RENDERER(*this);
+        std::vector<mbgl::util::FrameTrace> frameList_;
+        if (steal)
+            frameList_ = std::move(frameList);
+        else
+            frameList_ = frameList;
+        UNLOCK_RENDERER(*this);
+
+        std::string res;
+        res += "[\n";
+        for (const auto &f: frameList)
+            res += frameToJson(f) + std::string(",");
+        res.pop_back();
+        res += "]\n";
+        return res;
+    }
+
+    inline std::string dumpAll(bool steal = false) const {
+        std::string res;
+        res += "{\n";
+        // meta
+        res += "\"global\": {\n";
+
+        res += "}\n";
+
+        //  frames
+        res += ", \"frames\": ";
+        res += framesJson(steal);
+
+        res += "}\n";
+        return res;
+    }
+
+    inline void clearFrames() {
+        RENDERER_LOCKER();
+        frameList.clear();
+    }
+};
+} // namespace util
+} // namespace mbgl
+#endif

--- a/include/mbgl/perf/trace_data.in
+++ b/include/mbgl/perf/trace_data.in
@@ -1,0 +1,34 @@
+STRUCT_BEGIN(FrameTrace)
+
+STRUCT_MEMBER_UINT64_RANGE(update, true, false)  // Before attaching render target
+STRUCT_MEMBER_UINT64_RANGE(attach, true, false)
+STRUCT_MEMBER_UINT64_RANGE(render, true, false)
+STRUCT_MEMBER_UINT64_RANGE(orchestrate, true, false)   // Before orchestration
+STRUCT_MEMBER_UINT64_RANGE(prepare, true, false)       // Before prepare -- This and below are not present IF (!isMapModeContinuous && !renderTreeParameters->loaded)
+STRUCT_MEMBER_UINT64_RANGE(renderimpl, true, false)    // Before Impl::render
+STRUCT_MEMBER_UINT64_RANGE(waitrenderable, true, false) // Before wait on renderable
+STRUCT_MEMBER_UINT64_RANGE(upload, true, false)     // Before UPLOAD PASS
+STRUCT_MEMBER_UINT64_RANGE(draw, true, false)
+STRUCT_MEMBER_UINT64_RANGE(extrusions, true, false)                 // Before 3D pass (extrusions)
+STRUCT_MEMBER_UINT64_RANGE(clear, true, false)                      // 1st draw stage
+STRUCT_MEMBER_UINT64_RANGE(opaque, true, false)                     // 2 opaque should only have layer render items
+STRUCT_MEMBER_UINT64_RANGE(translucent, true, false)                // 3 same here
+STRUCT_MEMBER_UINT64_RANGE(debug, true, false)                      // 4 debug only renders sourceRenderItems
+STRUCT_MEMBER_UINT64_RANGE(flushencoder, true, false)               // 5 ---
+
+STRUCT_MEMBER_UINT64_RANGE(imagesourcerenderdata, false, true)
+STRUCT_MEMBER_UINT64_RANGE(layerrenderitem, false, true)
+STRUCT_MEMBER_UINT64_RANGE(tilesourcerenderitem, false, true)
+
+STRUCT_MEMBER_UINT64_RANGE(fill_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(extrusion_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(line_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(circle_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(heatmap_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(background_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(raster_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(symbol_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(hillshade_layer, false, true)
+STRUCT_MEMBER_UINT64_RANGE(custom_layer, false, true)
+
+STRUCT_END()

--- a/include/mbgl/util/chrono.hpp
+++ b/include/mbgl/util/chrono.hpp
@@ -9,6 +9,7 @@ using Clock = std::chrono::steady_clock;
 
 using Seconds = std::chrono::seconds;
 using Milliseconds = std::chrono::milliseconds;
+using Nanoseconds = std::chrono::nanoseconds;
 
 using TimePoint = Clock::time_point;
 using Duration  = Clock::duration;
@@ -20,6 +21,10 @@ namespace util {
 
 inline Timestamp now() {
     return std::chrono::time_point_cast<Seconds>(std::chrono::system_clock::now());
+}
+
+inline uint64_t now_ns() {
+    return Clock::now().time_since_epoch().count();
 }
 
 // Returns the RFC1123 formatted date. E.g. "Tue, 04 Nov 2014 02:13:24 GMT"

--- a/platform/glfw/glfw_renderer_frontend.cpp
+++ b/platform/glfw/glfw_renderer_frontend.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/gfx/backend_scope.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 GLFWRendererFrontend::GLFWRendererFrontend(std::unique_ptr<mbgl::Renderer> renderer_, GLFWView& glfwView_)
     : glfwView(glfwView_)
@@ -30,7 +31,8 @@ void GLFWRendererFrontend::render() {
     assert(renderer);
     
     if (!updateParameters) return;
-    
+    MBGL_TRACE_RENDERER_BEGINRECORD(update);
+    MBGL_TRACE_RENDERER_BEGIN(attach);
     mbgl::gfx::BackendScope guard { glfwView.getRendererBackend(), mbgl::gfx::BackendScope::ScopeType::Implicit };
 
     // onStyleImageMissing might be called during a render. The user implemented method
@@ -38,10 +40,17 @@ void GLFWRendererFrontend::render() {
     // Copy the shared pointer here so that the parameters aren't destroyed while `render(...)` is
     // still using them.
     auto updateParameters_ = updateParameters;
+    MBGL_TRACE_RENDERER_END(attach);
     renderer->render(updateParameters_);
+    MBGL_TRACE_RENDERER_ENDRECORD(update);
 }
 
 mbgl::Renderer* GLFWRendererFrontend::getRenderer() {
     assert(renderer);
     return renderer.get();
+}
+
+void GLFWRendererFrontend::setRecordFrame(bool enabled)
+{
+    recordFrames = enabled;
 }

--- a/platform/glfw/glfw_renderer_frontend.hpp
+++ b/platform/glfw/glfw_renderer_frontend.hpp
@@ -21,9 +21,11 @@ public:
     void render();
     
     mbgl::Renderer* getRenderer();
+    void setRecordFrame(bool enabled);
 
 private:
     GLFWView& glfwView;
     std::unique_ptr<mbgl::Renderer> renderer;
     std::shared_ptr<mbgl::UpdateParameters> updateParameters;
+    bool recordFrames = false;
 };

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -23,10 +23,15 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 #include <mapbox/cheap_ruler.hpp>
 #include <mapbox/geometry.hpp>
 #include <mapbox/geojson.hpp>
+
+#include <fstream>
+#include <string>
+#include <iostream>
 
 #if MBGL_USE_GLES2
 #define GLFW_INCLUDE_ES2
@@ -233,6 +238,18 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             break;
         case GLFW_KEY_K:
             view->addRandomCustomPointAnnotations(1);
+            break;
+        case GLFW_KEY_H:
+            MBGL_IF_TRACING(if (mbgl::util::Tracer::get().isCollectingData()) { \
+                mbgl::util::Tracer::get().setCollectData(false); \
+                std::string json = mbgl::util::Tracer::get().dumpAll(true); \
+                printf("%s\n", json.c_str()); \
+                                std::ofstream out("/tmp/mbgl_glfw_trace.json"); \
+                                out << json; \
+                                out.close(); \
+            } else { \
+                mbgl::util::Tracer::get().setCollectData(true); \
+            })
             break;
         case GLFW_KEY_L:
             view->addRandomLineAnnotations(1);

--- a/src/mbgl/gl/render_custom_layer.cpp
+++ b/src/mbgl/gl/render_custom_layer.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/util/mat4.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -59,6 +60,7 @@ void RenderCustomLayer::prepare(const LayerPrepareParameters&) {
 }
 
 void RenderCustomLayer::render(PaintParameters& paintParameters) {
+    MBGL_TRACE_RENDERER_BEGIN(custom_layer);
     if (host != impl(baseImpl).host) {
         //If the context changed, deinitialize the previous one before initializing the new one.
         if (host && !contextDestroyed) {
@@ -99,6 +101,7 @@ void RenderCustomLayer::render(PaintParameters& paintParameters) {
     // the viewport or Framebuffer.
     paintParameters.backend.getDefaultRenderable().getResource<gl::RenderableResource>().bind();
     glContext.setDirtyState();
+    MBGL_TRACE_RENDERER_END(custom_layer);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -11,6 +11,7 @@
 #include <mbgl/util/tile_cover.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -65,7 +66,7 @@ bool RenderBackgroundLayer::hasCrossfade() const {
 void RenderBackgroundLayer::render(PaintParameters& parameters) {
     // Note that for bottommost layers without a pattern, the background color is drawn with
     // glClear rather than this method.
-
+    MBGL_TRACE_RENDERER_BEGIN(background_layer);
     const Properties<>::PossiblyEvaluated properties;
     const BackgroundProgram::Binders paintAttributeData(properties, 0);
 
@@ -152,6 +153,7 @@ void RenderBackgroundLayer::render(PaintParameters& parameters) {
             );
         }
     }
+    MBGL_TRACE_RENDERER_END(background_layer);
 }
 
 optional<Color> RenderBackgroundLayer::getSolidBackground() const {

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -10,6 +10,7 @@
 #include <mbgl/gfx/cull_face_mode.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/intersection_tests.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -63,7 +64,7 @@ void RenderCircleLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }
-
+    MBGL_TRACE_RENDERER_BEGIN(circle_layer);
     for (const RenderTile& tile : *renderTiles) {
         const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
         if (!renderData) {
@@ -122,6 +123,7 @@ void RenderCircleLayer::render(PaintParameters& parameters) {
             getID()
         );
     }
+    MBGL_TRACE_RENDERER_END(circle_layer);
 }
 
 GeometryCoordinate projectPoint(const GeometryCoordinate& p, const mat4& posMatrix, const Size& size) {

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -16,6 +16,7 @@
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/util/intersection_tests.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -71,7 +72,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
     if (parameters.pass != RenderPass::Translucent) {
         return;
     }
-
+    MBGL_TRACE_RENDERER_BEGIN(extrusion_layer);
     const auto& evaluated = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).evaluated;
     const auto& crossfade = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).crossfade;
     if (evaluatedProperties->renderPasses == mbgl::underlying_type(RenderPass::None)) {
@@ -224,6 +225,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
         // to prevent the second draw in cases where we have coincident polygons.
         drawTiles(parameters.stencilModeFor3D(), parameters.colorModeForRenderPass(), "color");
     }
+    MBGL_TRACE_RENDERER_END(extrusion_layer);
 }
 
 bool RenderFillExtrusionLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeometry,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -17,6 +17,7 @@
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/util/intersection_tests.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -75,6 +76,7 @@ bool RenderFillLayer::hasCrossfade() const {
 
 void RenderFillLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
+    MBGL_TRACE_RENDERER_BEGIN(fill_layer);
     if (unevaluated.get<FillPattern>().isUndefined()) {
         parameters.renderTileClippingMasks(renderTiles);
         for (const RenderTile& tile : *renderTiles) {
@@ -248,6 +250,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
             }
         }
     }
+    MBGL_TRACE_RENDERER_END(fill_layer);
 }
 
 bool RenderFillLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeometry,

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -14,6 +14,7 @@
 #include <mbgl/gfx/context.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/intersection_tests.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -72,7 +73,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }
-
+    MBGL_TRACE_RENDERER_BEGIN(heatmap_layer);
     if (parameters.pass == RenderPass::Pass3D) {
         const auto& viewportSize = parameters.staticData.backendSize;
         const auto size = Size{viewportSize.width / 4, viewportSize.height / 4};
@@ -196,6 +197,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
             getID()
         );
     }
+    MBGL_TRACE_RENDERER_END(heatmap_layer);
 }
 
 void RenderHeatmapLayer::updateColorRamp() {

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -13,6 +13,7 @@
 #include <mbgl/gfx/offscreen_texture.hpp>
 #include <mbgl/gfx/render_pass.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -79,6 +80,7 @@ void RenderHillshadeLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
     if (parameters.pass != RenderPass::Translucent && parameters.pass != RenderPass::Pass3D)
         return;
+    MBGL_TRACE_RENDERER_BEGIN(hillshade_layer);
     const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;  
     auto draw = [&] (const mat4& matrix,
                      const auto& vertexBuffer,
@@ -221,9 +223,8 @@ void RenderHillshadeLayer::render(PaintParameters& parameters) {
                      });
             }
         }
-        
-
     }
+    MBGL_TRACE_RENDERER_END(hillshade_layer);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -16,6 +16,7 @@
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/util/intersection_tests.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -95,7 +96,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }
-
+    MBGL_TRACE_RENDERER_BEGIN(line_layer);
     parameters.renderTileClippingMasks(renderTiles);
 
     for (const RenderTile& tile : *renderTiles) {
@@ -217,6 +218,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
                  LineProgram::TextureBindings{});
         }
     }
+    MBGL_TRACE_RENDERER_END(line_layer);
 }
 
 namespace {

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
 #include <mbgl/style/layers/raster_layer_impl.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -90,6 +91,7 @@ void RenderRasterLayer::render(PaintParameters& parameters) {
     if (parameters.pass != RenderPass::Translucent || (!renderTiles && !imageData)) {
         return;
     }
+    MBGL_TRACE_RENDERER_BEGIN(raster_layer);
     const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
     RasterProgram::Binders paintAttributeData{ evaluated, 0 };
 
@@ -199,6 +201,7 @@ void RenderRasterLayer::render(PaintParameters& parameters) {
             }
         }
     }
+    MBGL_TRACE_RENDERER_END(raster_layer);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -19,6 +19,7 @@
 #include <mbgl/layout/symbol_layout.hpp>
 #include <mbgl/layout/symbol_layout.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 #include <cmath>
 #include <set>
@@ -345,7 +346,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }
-
+    MBGL_TRACE_RENDERER_BEGIN(symbol_layer);
     const bool sortFeaturesByKey = !impl(baseImpl).layout.get<SymbolSortKey>().isUndefined();
     std::multiset<RenderableSegment> renderableSegments;
 
@@ -540,6 +541,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
             }
         }
     }
+    MBGL_TRACE_RENDERER_END(symbol_layer);
 }
 
 // static

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -26,6 +26,7 @@
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -49,7 +50,11 @@ public:
 private:
     bool hasRenderPass(RenderPass pass) const override { return layer.get().hasRenderPass(pass); }
     void upload(gfx::UploadPass& pass) const override { layer.get().upload(pass); }
-    void render(PaintParameters& parameters) const override { layer.get().render(parameters); }
+    void render(PaintParameters& parameters) const override {
+        MBGL_TRACE_RENDERER_BEGIN(layerrenderitem);
+        layer.get().render(parameters);
+        MBGL_TRACE_RENDERER_END(layerrenderitem);
+    }
     const std::string& getName() const override { return layer.get().getID(); } 
 
     uint32_t index;

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -12,6 +12,7 @@
 #include <mbgl/util/tile_cover.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -29,7 +30,7 @@ void ImageSourceRenderData::render(PaintParameters& parameters) const {
     if (!bucket || !(parameters.debugOptions & MapDebugOptions::TileBorders)) {
         return;
     }
-
+    MBGL_TRACE_RENDERER_BEGIN(imagesourcerenderdata);
     static const style::Properties<>::PossiblyEvaluated properties {};
     static const DebugProgram::Binders paintAttributeData(properties, 0);
 
@@ -64,6 +65,7 @@ void ImageSourceRenderData::render(PaintParameters& parameters) const {
             "image"
         );
     }
+    MBGL_TRACE_RENDERER_END(imagesourcerenderdata);
 }
 
 RenderImageSource::RenderImageSource(Immutable<style::ImageSource::Impl> impl_)

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/tile/vector_tile.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/perf/runtime_metrics.hpp>
 
 namespace mbgl {
 
@@ -37,9 +38,11 @@ void TileSourceRenderItem::upload(gfx::UploadPass& parameters) const {
 }
 
 void TileSourceRenderItem::render(PaintParameters& parameters) const {
+    MBGL_TRACE_RENDERER_BEGIN(tilesourcerenderitem);
     for (auto& tile : *renderTiles) {
         tile.finishRender(parameters);
     }
+    MBGL_TRACE_RENDERER_END(tilesourcerenderitem);
 }
 
 RenderTileSource::RenderTileSource(Immutable<style::Source::Impl> impl_)


### PR DESCRIPTION
Ideally i think the current approach for generating json is quite lightweight, self contained, and simple, and i would like to avoid using additional tools unless necessary for adding additional wanted features.

The generated output is somehow hierarchical, embedding a basic amount of semantic.

Fixes mapbox/mapbox-gl-native-team#67
