### PR TITLE
[core] Don't provide multiple responses with the same data for 304 replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,6 @@
 
    This change enables attaching images to the style with batches and avoids massive re-allocations. Thus, it improves UI performance especially at start-up time.
 
- - [core] Fix excessive onSpriteLoaded() notifications ([#16196](https://github.com/mapbox/mapbox-gl-native/pull/16196))
-
-   The excessive `onSpriteLoaded()` notifications affected the render orchestration logic and could have significant negative performance impact.
-
 ### 🧩  Architectural changes
 
 ##### ⚠️  Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
 
 - [core] Add support for using `within expression` with layout propery. ([#16194](https://github.com/mapbox/mapbox-gl-native/pull/16194))
 
+### 🐞 Bug fixes
+
+- [core] Don't provide multiple responses with the same data for 304 replies ([#16200](https://github.com/mapbox/mapbox-gl-native/pull/16200))
+
+  In cases when cached resource is useable, yet don't have an expiration timestamp, we provided data to the requester from the cache and the same data was returned once 304 response was received from the network.
+
 ### 🏁 Performance improvements
 
  - [core] Loading images to style optimization ([#16187](https://github.com/mapbox/mapbox-gl-native/pull/16187))

--- a/platform/default/src/mbgl/storage/main_resource_loader.cpp
+++ b/platform/default/src/mbgl/storage/main_resource_loader.cpp
@@ -81,13 +81,17 @@ public:
                             callback(response);
                             // Set the priority of existing resource to low if it's expired but usable.
                             res.setPriority(Resource::Priority::Low);
+                        } else {
+                            // Set prior data only if it was not returned to the requester.
+                            // Once we get 304 response from the network, we will forward response
+                            // to the requester.
+                            res.priorData = response.data;
                         }
 
                         // Copy response fields for cache control request
                         res.priorModified = response.modified;
                         res.priorExpires = response.expires;
                         res.priorEtag = response.etag;
-                        res.priorData = response.data;
                     }
 
                     tasks[req] = requestFromNetwork(res, std::move(tasks[req]));

--- a/src/mbgl/sprite/sprite_loader.cpp
+++ b/src/mbgl/sprite/sprite_loader.cpp
@@ -60,7 +60,8 @@ void SpriteLoader::load(const std::string& url, FileSource& fileSource) {
             emitSpriteLoadedIfComplete();
         } else {
             // Only trigger a sprite loaded event we got new data.
-            loader->json = res.data;
+            assert(loader->json != res.data);
+            loader->json = std::move(res.data);
             emitSpriteLoadedIfComplete();
         }
     });
@@ -74,7 +75,8 @@ void SpriteLoader::load(const std::string& url, FileSource& fileSource) {
             loader->image = std::make_shared<std::string>();
             emitSpriteLoadedIfComplete();
         } else {
-            loader->image = res.data;
+            assert(loader->image != res.data);
+            loader->image = std::move(res.data);
             emitSpriteLoadedIfComplete();
         }
     });

--- a/src/mbgl/sprite/sprite_loader.cpp
+++ b/src/mbgl/sprite/sprite_loader.cpp
@@ -58,9 +58,9 @@ void SpriteLoader::load(const std::string& url, FileSource& fileSource) {
         } else if (res.noContent) {
             loader->json = std::make_shared<std::string>();
             emitSpriteLoadedIfComplete();
-        } else if (loader->json != res.data) { // They can be equal, see OnlineFileRequest::completed().
+        } else {
             // Only trigger a sprite loaded event we got new data.
-            loader->json = std::move(res.data);
+            loader->json = res.data;
             emitSpriteLoadedIfComplete();
         }
     });
@@ -73,8 +73,8 @@ void SpriteLoader::load(const std::string& url, FileSource& fileSource) {
         } else if (res.noContent) {
             loader->image = std::make_shared<std::string>();
             emitSpriteLoadedIfComplete();
-        } else if (loader->image != res.data) { // They can be equal - see OnlineFileRequest::completed().
-            loader->image = std::move(res.data);
+        } else {
+            loader->image = res.data;
             emitSpriteLoadedIfComplete();
         }
     });


### PR DESCRIPTION
In cases when cached resource is useable, yet don't have an expiration timestamp, we provided data to the requester from the cache and the same data was returned once 304 response was received from the network.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)
