### PR TITLE
[test] Include cpp-httplib as a system library

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,10 +156,6 @@ else()
         COMPILE_OPTIONS
         $<$<STREQUAL:${CMAKE_SYSTEM_NAME},iOS>:-Wno-shorten-64-to-32>
     )
-    target_include_directories(
-        mbgl-test
-        PRIVATE ${PROJECT_SOURCE_DIR}/vendor/cpp-httplib
-    )
 endif()
 
 if(NOT DEFINED ENV{CI})
@@ -187,6 +183,7 @@ target_include_directories(
     PUBLIC ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/test/include
 )
 
+include(${PROJECT_SOURCE_DIR}/vendor/cpp-httplib.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/googletest.cmake)
 
 if(CMAKE_SYSTEM_NAME STREQUAL iOS)
@@ -211,6 +208,7 @@ target_link_libraries(
         Mapbox::Base::Extras::args
         Mapbox::Base::pixelmatch-cpp
         mbgl-compiler-options
+        mbgl-vendor-cpp-httplib
     PUBLIC mbgl-core
 )
 

--- a/vendor/cpp-httplib.cmake
+++ b/vendor/cpp-httplib.cmake
@@ -1,0 +1,12 @@
+if(TARGET mbgl-vendor-cpp-httplib)
+    return()
+endif()
+
+add_library(
+    mbgl-vendor-cpp-httplib INTERFACE
+)
+
+target_include_directories(
+    mbgl-vendor-cpp-httplib SYSTEM
+    INTERFACE ${CMAKE_CURRENT_LIST_DIR}/cpp-httplib
+)


### PR DESCRIPTION
This way it will not get warnings by linters and -Werror.