### PR TITLE
[cp][core] sort symbols using symbol-sort-key before placement

### DIFF
--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -122,4 +122,11 @@ public:
     uint32_t crossTileID = 0;
 };
 
+class SortKeyRange {
+public:
+    float sortKey;
+    size_t symbolInstanceStart;
+    size_t symbolInstanceEnd;
+};
+
 } // namespace mbgl

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -44,6 +44,7 @@ public:
 
     const std::string bucketLeaderID;
     std::vector<SymbolInstance> symbolInstances;
+    std::vector<SortKeyRange> sortKeyRanges;
 
     static constexpr float INVALID_OFFSET_VALUE = std::numeric_limits<float>::max();
     /**
@@ -105,6 +106,7 @@ private:
 
     bool iconsNeedLinear = false;
     bool sortFeaturesByY = false;
+    bool sortFeaturesByKey = false;
     bool allowVerticalPlacement = false;
     std::vector<style::TextWritingModeType> placementModes;
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -22,6 +22,7 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
                            bool sortFeaturesByY_,
                            const std::string bucketName_,
                            const std::vector<SymbolInstance>&& symbolInstances_,
+                           const std::vector<SortKeyRange>&& sortKeyRanges_,
                            float tilePixelRatio_,
                            bool allowVerticalPlacement_,
                            std::vector<style::TextWritingModeType> placementModes_)
@@ -36,6 +37,7 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
       justReloaded(false),
       hasVariablePlacement(false),
       symbolInstances(symbolInstances_),
+      sortKeyRanges(sortKeyRanges_),
       textSizeBinder(SymbolSizeBinder::create(zoom, textSize, TextSize::defaultValue())),
       iconSizeBinder(SymbolSizeBinder::create(zoom, iconSize, IconSize::defaultValue())),
       tilePixelRatio(tilePixelRatio_),

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -59,6 +59,7 @@ public:
                  bool sortFeaturesByY,
                  const std::string bucketLeaderID,
                  const std::vector<SymbolInstance>&&,
+                 const std::vector<SortKeyRange>&&,
                  const float tilePixelRatio,
                  bool allowVerticalPlacement,
                  std::vector<style::TextWritingModeType> placementModes);
@@ -100,6 +101,7 @@ public:
     bool hasVariablePlacement : 1;
 
     std::vector<SymbolInstance> symbolInstances;
+    std::vector<SortKeyRange> sortKeyRanges;
 
     struct PaintProperties {
         SymbolIconProgram::Binders iconBinders;

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -1,3 +1,4 @@
+#include <list>
 #include <mbgl/text/placement.hpp>
 
 #include <mbgl/layout/symbol_layout.hpp>
@@ -110,12 +111,14 @@ void Placement::placeLayer(const RenderLayer& layer, const mat4& projMatrix, boo
     std::set<uint32_t> seenCrossTileIDs;
     for (const auto& item : layer.getPlacementData()) {
         Bucket& bucket = item.bucket;
-        BucketPlacementParameters params{
-                item.tile,
-                projMatrix,
-                layer.baseImpl->source,
-                item.featureIndex,
-                showCollisionBoxes};
+        BucketPlacementParameters params{item.tile,
+                                         projMatrix,
+                                         layer.baseImpl->source,
+                                         item.featureIndex,
+                                         item.sortKey,
+                                         item.symbolInstanceStart,
+                                         item.symbolInstanceEnd,
+                                         showCollisionBoxes};
         bucket.place(*this, params, seenCrossTileIDs);
     }
 }
@@ -518,12 +521,14 @@ void Placement::placeBucket(
             placeSymbol(*it);
         }
     } else {
-        for (const SymbolInstance& symbol : bucket.symbolInstances) {
-            placeSymbol(symbol);
+        auto beginIt = bucket.symbolInstances.begin() + params.symbolInstanceStart;
+        auto endIt = bucket.symbolInstances.begin() + params.symbolInstanceEnd;
+        assert(params.symbolInstanceStart < params.symbolInstanceEnd);
+        assert(params.symbolInstanceEnd <= bucket.symbolInstances.size());
+        for (auto it = beginIt; it != endIt; ++it) {
+            placeSymbol(*it);
         }
     }
-
-    bucket.justReloaded = false;
 
     // As long as this placement lives, we have to hold onto this bucket's
     // matching FeatureIndex/data for querying purposes
@@ -590,7 +595,9 @@ void Placement::commit(TimePoint now, const double zoom) {
 void Placement::updateLayerBuckets(const RenderLayer& layer, const TransformState& state, bool updateOpacities) const {
     std::set<uint32_t> seenCrossTileIDs;
     for (const auto& item : layer.getPlacementData()) {
-        item.bucket.get().updateVertices(*this, updateOpacities, state, item.tile, seenCrossTileIDs);
+        if (item.firstInBucket) {
+            item.bucket.get().updateVertices(*this, updateOpacities, state, item.tile, seenCrossTileIDs);
+        }
     }
 }
 

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -91,6 +91,9 @@ public:
     const mat4& projMatrix;
     std::string sourceId;
     std::shared_ptr<FeatureIndex> featureIndex;
+    float sortKey;
+    size_t symbolInstanceStart;
+    size_t symbolInstanceEnd;
     bool showCollisionBoxes;
 };
 

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -123,9 +123,22 @@ TEST(Buckets, SymbolBucket) {
     bool sortFeaturesByY = false;
     std::string bucketLeaderID = "test";
     std::vector<SymbolInstance> symbolInstances;
+    std::vector<SortKeyRange> symbolRanges;
 
     gl::Context context{ backend };
-    SymbolBucket bucket { std::move(layout), {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(symbolInstances), 1.0f, false, {}};
+    SymbolBucket bucket{std::move(layout),
+                        {},
+                        16.0f,
+                        1.0f,
+                        0,
+                        iconsNeedLinear,
+                        sortFeaturesByY,
+                        bucketLeaderID,
+                        std::move(symbolInstances),
+                        std::move(symbolRanges),
+                        1.0f,
+                        false,
+                        {}};
     ASSERT_FALSE(bucket.hasIconData());
     ASSERT_FALSE(bucket.hasSdfIconData());
     ASSERT_FALSE(bucket.hasTextData());

--- a/test/text/cross_tile_symbol_index.test.cpp
+++ b/test/text/cross_tile_symbol_index.test.cpp
@@ -37,9 +37,22 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
 
     OverscaledTileID mainID(6, 0, 6, 8, 8);
     std::vector<SymbolInstance> mainInstances;
+    std::vector<SortKeyRange> mainRanges;
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"Detroit"));
     mainInstances.push_back(makeSymbolInstance(2000, 2000, u"Toronto"));
-    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f, false, {} };
+    SymbolBucket mainBucket{layout,
+                            {},
+                            16.0f,
+                            1.0f,
+                            0,
+                            iconsNeedLinear,
+                            sortFeaturesByY,
+                            bucketLeaderID,
+                            std::move(mainInstances),
+                            std::move(mainRanges),
+                            1.0f,
+                            false,
+                            {}};
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(mainID, mainBucket, maxCrossTileID);
 
@@ -50,11 +63,24 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
 
     OverscaledTileID childID(7, 0, 7, 16, 16);
     std::vector<SymbolInstance> childInstances;
+    std::vector<SortKeyRange> childRanges;
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"Detroit"));
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"Windsor"));
     childInstances.push_back(makeSymbolInstance(3000, 3000, u"Toronto"));
     childInstances.push_back(makeSymbolInstance(4001, 4001, u"Toronto"));
-    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f, false, {} };
+    SymbolBucket childBucket{layout,
+                             {},
+                             16.0f,
+                             1.0f,
+                             0,
+                             iconsNeedLinear,
+                             sortFeaturesByY,
+                             bucketLeaderID,
+                             std::move(childInstances),
+                             std::move(childRanges),
+                             1.0f,
+                             false,
+                             {}};
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(childID, childBucket, maxCrossTileID);
 
@@ -69,8 +95,21 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
 
     OverscaledTileID parentID(5, 0, 5, 4, 4);
     std::vector<SymbolInstance> parentInstances;
+    std::vector<SortKeyRange> parentRanges;
     parentInstances.push_back(makeSymbolInstance(500, 500, u"Detroit"));
-    SymbolBucket parentBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(parentInstances), 1.0f, false, {} };
+    SymbolBucket parentBucket{layout,
+                              {},
+                              16.0f,
+                              1.0f,
+                              0,
+                              iconsNeedLinear,
+                              sortFeaturesByY,
+                              bucketLeaderID,
+                              std::move(parentInstances),
+                              std::move(parentRanges),
+                              1.0f,
+                              false,
+                              {}};
     parentBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(parentID, parentBucket, maxCrossTileID);
 
@@ -84,9 +123,22 @@ TEST(CrossTileSymbolLayerIndex, addBucket) {
     // grandchild
     OverscaledTileID grandchildID(8, 0, 8, 32, 32);
     std::vector<SymbolInstance> grandchildInstances;
+    std::vector<SortKeyRange> grandchildRanges;
     grandchildInstances.push_back(makeSymbolInstance(4000, 4000, u"Detroit"));
     grandchildInstances.push_back(makeSymbolInstance(4000, 4000, u"Windsor"));
-    SymbolBucket grandchildBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(grandchildInstances), 1.0f, false, {} };
+    SymbolBucket grandchildBucket{layout,
+                                  {},
+                                  16.0f,
+                                  1.0f,
+                                  0,
+                                  iconsNeedLinear,
+                                  sortFeaturesByY,
+                                  bucketLeaderID,
+                                  std::move(grandchildInstances),
+                                  std::move(grandchildRanges),
+                                  1.0f,
+                                  false,
+                                  {}};
     grandchildBucket.bucketInstanceId = ++maxBucketInstanceId;
     index.addBucket(grandchildID, grandchildBucket, maxCrossTileID);
 
@@ -111,14 +163,40 @@ TEST(CrossTileSymbolLayerIndex, resetIDs) {
 
     OverscaledTileID mainID(6, 0, 6, 8, 8);
     std::vector<SymbolInstance> mainInstances;
+    std::vector<SortKeyRange> mainRanges;
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"Detroit"));
-    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f, false, {} };
+    SymbolBucket mainBucket{layout,
+                            {},
+                            16.0f,
+                            1.0f,
+                            0,
+                            iconsNeedLinear,
+                            sortFeaturesByY,
+                            bucketLeaderID,
+                            std::move(mainInstances),
+                            std::move(mainRanges),
+                            1.0f,
+                            false,
+                            {}};
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     OverscaledTileID childID(7, 0, 7, 16, 16);
     std::vector<SymbolInstance> childInstances;
+    std::vector<SortKeyRange> childRanges;
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"Detroit"));
-    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f, false, {} };
+    SymbolBucket childBucket{layout,
+                             {},
+                             16.0f,
+                             1.0f,
+                             0,
+                             iconsNeedLinear,
+                             sortFeaturesByY,
+                             bucketLeaderID,
+                             std::move(childInstances),
+                             std::move(childRanges),
+                             1.0f,
+                             false,
+                             {}};
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns a new id
@@ -151,17 +229,43 @@ TEST(CrossTileSymbolLayerIndex, noDuplicatesWithinZoomLevel) {
 
     OverscaledTileID mainID(6, 0, 6, 8, 8);
     std::vector<SymbolInstance> mainInstances;
+    std::vector<SortKeyRange> mainRanges;
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // A
     mainInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // B
-    SymbolBucket mainBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(mainInstances), 1.0f, false, {} };
+    SymbolBucket mainBucket{layout,
+                            {},
+                            16.0f,
+                            1.0f,
+                            0,
+                            iconsNeedLinear,
+                            sortFeaturesByY,
+                            bucketLeaderID,
+                            std::move(mainInstances),
+                            std::move(mainRanges),
+                            1.0f,
+                            false,
+                            {}};
     mainBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     OverscaledTileID childID(7, 0, 7, 16, 16);
     std::vector<SymbolInstance> childInstances;
+    std::vector<SortKeyRange> childRanges;
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"")); // A'
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"")); // B'
     childInstances.push_back(makeSymbolInstance(2000, 2000, u"")); // C'
-    SymbolBucket childBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(childInstances), 1.0f, false, {} };
+    SymbolBucket childBucket{layout,
+                             {},
+                             16.0f,
+                             1.0f,
+                             0,
+                             iconsNeedLinear,
+                             sortFeaturesByY,
+                             bucketLeaderID,
+                             std::move(childInstances),
+                             std::move(childRanges),
+                             1.0f,
+                             false,
+                             {}};
     childBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids
@@ -191,14 +295,39 @@ TEST(CrossTileSymbolLayerIndex, bucketReplacement) {
     std::vector<SymbolInstance> firstInstances;
     firstInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // A
     firstInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // B
-    SymbolBucket firstBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(firstInstances), 1.0f, false, {} };
+    SymbolBucket firstBucket{layout,
+                             {},
+                             16.0f,
+                             1.0f,
+                             0,
+                             iconsNeedLinear,
+                             sortFeaturesByY,
+                             bucketLeaderID,
+                             std::move(firstInstances),
+                             {},
+                             1.0f,
+                             false,
+                             {}};
     firstBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     std::vector<SymbolInstance> secondInstances;
+    std::vector<SortKeyRange> secondRanges;
     secondInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // A'
     secondInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // B'
     secondInstances.push_back(makeSymbolInstance(1000, 1000, u"")); // C'
-    SymbolBucket secondBucket { layout, {}, 16.0f, 1.0f, 0, iconsNeedLinear, sortFeaturesByY, bucketLeaderID, std::move(secondInstances), 1.0f, false, {} };
+    SymbolBucket secondBucket{layout,
+                              {},
+                              16.0f,
+                              1.0f,
+                              0,
+                              iconsNeedLinear,
+                              sortFeaturesByY,
+                              bucketLeaderID,
+                              std::move(secondInstances),
+                              std::move(secondRanges),
+                              1.0f,
+                              false,
+                              {}};
     secondBucket.bucketInstanceId = ++maxBucketInstanceId;
 
     // assigns new ids


### PR DESCRIPTION
Cherry pick `[core] sort symbols using symbol-sort-key before placement` (#16023) to release sangria.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 - [x] briefly describe the changes in this PR
-  [x] unit-tests pass
-  [x] cherry picked render tests from https://github.com/mapbox/mapbox-gl-js/pull/9054 pass locally