### PR TITLE
[android] Don't construct weak sheduler in renderer's custructor

### DIFF
--- a/platform/android/src/map_renderer.hpp
+++ b/platform/android/src/map_renderer.hpp
@@ -82,6 +82,14 @@ protected:
     void scheduleSnapshot(std::unique_ptr<SnapshotCallback>);
 
 private:
+    struct MailboxData {
+        explicit MailboxData(Scheduler*);
+        std::shared_ptr<Mailbox> getMailbox() const noexcept;
+
+    private:
+        Scheduler* scheduler;
+        mutable std::shared_ptr<Mailbox> mailbox;
+    };
     // Called from the GL Thread //
 
     // Resets the renderer
@@ -107,7 +115,7 @@ private:
     optional<std::string> localIdeographFontFamily;
 
     std::shared_ptr<ThreadPool> threadPool;
-    std::shared_ptr<Mailbox> mailbox;
+    const MailboxData mailboxData;
 
     std::mutex initialisationMutex;
     std::shared_ptr<RendererObserver> rendererObserver;


### PR DESCRIPTION
Android renderer creates mailbox that is owned by the scheduler that is required by the mailbox itself. Construction should be split, so that scheduler is fully constructed and it's weakPtr can be created.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)

No changelog required, since the file is not used in core.