### PR TITLE
[core] Support `line within polygon` in `within` expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
    
   The `in expression` enables checking whether a Number/String/Boolean type item is in a String/Array and returns a boolean value.
 
+- [core] Add support for using `within expression` with features having `'LineString'` geometry type. ([#16220](https://github.com/mapbox/mapbox-gl-native/pull/16220))
+  
+  `within expression` now supports features with geometry types: `'Point'` or `'LineString'`.
+
 ### 🐞 Bug fixes
 
 - [core] Don't provide multiple responses with the same data for 304 replies ([#16200](https://github.com/mapbox/mapbox-gl-native/pull/16200))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,6 +765,8 @@ add_library(
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/font_stack.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/geo.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/geojson_impl.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/util/geometry_within.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/util/geometry_within.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/grid_index.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/grid_index.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/hash.hpp

--- a/include/mbgl/style/expression/within.hpp
+++ b/include/mbgl/style/expression/within.hpp
@@ -13,7 +13,7 @@ namespace expression {
 
 class Within final : public Expression {
 public:
-    explicit Within(GeoJSON geojson);
+    explicit Within(GeoJSON geojson, Feature::geometry_type geometries_);
 
     ~Within() override;
 
@@ -32,6 +32,7 @@ public:
 
 private:
     GeoJSON geoJSONSource;
+    Feature::geometry_type geometries;
 };
 
 } // namespace expression

--- a/include/mbgl/style/expression/within.hpp
+++ b/include/mbgl/style/expression/within.hpp
@@ -23,18 +23,12 @@ public:
 
     void eachChild(const std::function<void(const Expression&)>&) const override {}
 
-    bool operator==(const Expression& e) const override {
-        if (e.getKind() == Kind::Within) {
-            auto rhs = static_cast<const Within*>(&e);
-            return geoJSONSource == rhs->geoJSONSource;
-        }
-        return false;
-    }
+    bool operator==(const Expression& e) const override;
 
-    std::vector<optional<Value>> possibleOutputs() const override { return {{true}, {false}}; }
+    std::vector<optional<Value>> possibleOutputs() const override;
 
     mbgl::Value serialize() const override;
-    std::string getOperator() const override { return "within"; }
+    std::string getOperator() const override;
 
 private:
     GeoJSON geoJSONSource;

--- a/include/mbgl/style/expression/within.hpp
+++ b/include/mbgl/style/expression/within.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/style/expression/expression.hpp>
 #include <mbgl/util/geojson.hpp>
+#include <mbgl/util/geometry_within.hpp>
 #include <mbgl/util/optional.hpp>
 
 namespace mbgl {
@@ -10,7 +11,7 @@ namespace expression {
 
 class Within final : public Expression {
 public:
-    explicit Within(GeoJSON geojson, Feature::geometry_type geometries_);
+    explicit Within(GeoJSON geojson, Feature::geometry_type geometries_, WithinBBox polygonBBox_);
 
     ~Within() override;
 
@@ -30,6 +31,7 @@ public:
 private:
     GeoJSON geoJSONSource;
     Feature::geometry_type geometries;
+    WithinBBox polygonBBox;
 };
 
 } // namespace expression

--- a/include/mbgl/style/expression/within.hpp
+++ b/include/mbgl/style/expression/within.hpp
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <mbgl/style/conversion.hpp>
 #include <mbgl/style/expression/expression.hpp>
-#include <mbgl/style/expression/parsing_context.hpp>
 #include <mbgl/util/geojson.hpp>
-
-#include <memory>
+#include <mbgl/util/optional.hpp>
 
 namespace mbgl {
 namespace style {

--- a/metrics/android-render-test-runner/render-tests/within/paint-line/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/within/paint-line/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            5,
+            4,
+            13,
+            1,
+            [
+                49152,
+                49152
+            ],
+            [
+                286,
+                286
+            ],
+            [
+                528,
+                528
+            ]
+        ]
+    ]
+}

--- a/metrics/ios-render-test-runner/render-tests/within/paint-line/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/within/paint-line/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            5,
+            4,
+            13,
+            1,
+            [
+                49152,
+                49152
+            ],
+            [
+                286,
+                286
+            ],
+            [
+                528,
+                528
+            ]
+        ]
+    ]
+}

--- a/metrics/linux-clang8-release/render-tests/within/paint-line/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/within/paint-line/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            5,
+            4,
+            13,
+            1,
+            [
+                49152,
+                49152
+            ],
+            [
+                286,
+                286
+            ],
+            [
+                528,
+                528
+            ]
+        ]
+    ]
+}

--- a/metrics/linux-gcc8-release/render-tests/within/paint-line/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/within/paint-line/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            5,
+            4,
+            13,
+            1,
+            [
+                49152,
+                49152
+            ],
+            [
+                286,
+                286
+            ],
+            [
+                528,
+                528
+            ]
+        ]
+    ]
+}

--- a/src/mbgl/style/expression/within.cpp
+++ b/src/mbgl/style/expression/within.cpp
@@ -165,7 +165,7 @@ ParseResult Within::parse(const Convertible& value, ParsingContext& ctx) {
                 mbgl::Feature f(geometrySet);
                 PolygonFeature polyFeature(f, CanonicalTileID(0, 0, 0));
                 auto refinedGeoSet = convertGeometry(polyFeature, CanonicalTileID(0, 0, 0));
-                return ParseResult(std::make_unique<Within>(*parsedValue, refinedGeoSet));
+                return ParseResult(std::make_unique<Within>(*parsedValue, std::move(refinedGeoSet)));
             },
             [&ctx](const auto&) {
                 ctx.error("'within' expression requires geojson source that contains valid geometry data.");

--- a/src/mbgl/style/expression/within.cpp
+++ b/src/mbgl/style/expression/within.cpp
@@ -2,7 +2,7 @@
 
 #include <mapbox/geojson.hpp>
 #include <mapbox/geometry.hpp>
-#include <mbgl/style/conversion_impl.hpp>
+#include <mbgl/style/conversion/json.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 
 #include <mbgl/util/geometry_within.hpp>
@@ -10,7 +10,6 @@
 #include <mbgl/util/string.hpp>
 
 #include <rapidjson/document.h>
-#include <mbgl/style/conversion/json.hpp>
 
 namespace mbgl {
 namespace {

--- a/src/mbgl/style/expression/within.cpp
+++ b/src/mbgl/style/expression/within.cpp
@@ -4,6 +4,7 @@
 #include <mapbox/geometry.hpp>
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
+
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/string.hpp>
 
@@ -34,6 +35,25 @@ public:
     }
 };
 
+void printPolygon(const Polygon<double>& polygon) {
+    mbgl::Log::Debug(mbgl::Event::General, "-------Print Polygon------");
+    for (auto ring : polygon) {
+        auto length = ring.size();
+        mbgl::Log::Debug(mbgl::Event::General, "-------Print New ring with size: %d ------", length);
+        // loop through every edge of the ring
+        for (std::size_t i = 0; i < length - 1; ++i) {
+            mbgl::Log::Debug(mbgl::Event::General, "point [%.15f, %.15f],", ring[i].x, ring[i].y);
+        }
+    }
+}
+
+void printLine(const LineString<double>& lineString) {
+    mbgl::Log::Debug(mbgl::Event::General, "-------Print LineString------");
+    for (std::size_t i = 0; i < lineString.size(); ++i) {
+        mbgl::Log::Debug(mbgl::Event::General, "point [%.15f, %.15f],", lineString[i].x, lineString[i].y);
+    }
+}
+
 bool rayIntersect(const mbgl::Point<double>& p, const mbgl::Point<double>& p1, const mbgl::Point<double>& p2) {
     return ((p1.y > p.y) != (p2.y > p.y)) && (p.x < (p2.x - p1.x) * (p.y - p1.y) / (p2.y - p1.y) + p1.x);
 }
@@ -42,9 +62,9 @@ bool rayIntersect(const mbgl::Point<double>& p, const mbgl::Point<double>& p1, c
 bool pointWithinPolygon(const mbgl::Point<double>& point, const mapbox::geometry::polygon<double>& polygon) {
     bool within = false;
     for (auto ring : polygon) {
-        auto size = ring.size();
+        auto length = ring.size();
         // loop through every edge of the ring
-        for (std::size_t i = 0; i < size - 1; ++i) {
+        for (std::size_t i = 0; i < length - 1; ++i) {
             if (rayIntersect(point, ring[i], ring[i + 1])) {
                 within = !within;
             }
@@ -60,12 +80,97 @@ bool pointWithinPolygons(const mbgl::Point<double>& point, const mapbox::geometr
     return false;
 }
 
+bool lineIntersectLine(const mbgl::Point<double>& p1,
+                       const mbgl::Point<double>& p2,
+                       const mbgl::Point<double>& q1,
+                       const mbgl::Point<double>& q2) {
+    // precondition is p1, p2 is inside polygon, so p1, p2 is not on line q1->q2
+    const auto perp = [](const mbgl::Point<double>& v1, const mbgl::Point<double>& v2) {
+        return (v1.x * v2.y - v1.y * v2.x);
+    };
+
+    // check if p1 and p2 are in different sides of line segment q1->q2
+    const auto twoSided = [](const mbgl::Point<double>& p1,
+                             const mbgl::Point<double>& p2,
+                             const mbgl::Point<double>& q1,
+                             const mbgl::Point<double>& q2) {
+        double x1, y1, x2, y2, x3, y3;
+
+        // q1->p1 (x1, y1), q1->p2 (x2, y2), q1->q2 (x3, y3)
+        x1 = p1.x - q1.x;
+        y1 = p1.y - q1.y;
+        x2 = p2.x - q1.x;
+        y2 = p2.y - q1.y;
+        x3 = q2.x - q1.x;
+        y3 = q2.y - q1.y;
+        if ((x1 * y3 - x3 * y1) * (x2 * y3 - x3 * y2) < 0) return true;
+        return false;
+    };
+    auto vectorP = mbgl::Point<double>(p2.x - p1.x, p2.y - p1.y);
+    auto vectorQ = mbgl::Point<double>(q2.x - q1.x, q2.y - q1.y);
+
+    // check if two segments are parallel or not
+    if (perp(vectorQ, vectorP) == 0) return false;
+
+    // check if there are intersecting with each other
+    // p1 and p2 lie in separate side of segment q1->q2
+    // q1 and q2 lie in separate side of segment p1->p2
+    if (twoSided(p1, p2, q1, q2) && twoSided(q1, q2, p1, p2)) return true;
+    return false;
+}
+
+bool lineIntersectPolygon(const mbgl::Point<double>& p1,
+                          const mbgl::Point<double>& p2,
+                          const mapbox::geometry::polygon<double>& polygon) {
+    for (auto ring : polygon) {
+        auto length = ring.size();
+        // loop through every edge of the ring
+        for (std::size_t i = 0; i < length - 1; ++i) {
+            if (lineIntersectLine(p1, p2, ring[i], ring[i + 1])) {
+                //               mbgl::Log::Debug(mbgl::Event::General,
+                //                                       "intersecting with edge from %.15f to %.15f", i, i+ 1);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool lineStringWithinPolygon(const mbgl::LineString<double>& lineString,
+                             const mapbox::geometry::polygon<double>& polygon) {
+    // First, check if endpoints of line are all inside polygon
+    for (std::size_t i = 0; i < lineString.size() - 1; ++i) {
+        if (!pointWithinPolygon(lineString[i], polygon)) {
+            mbgl::Log::Debug(
+                mbgl::Event::General, "point %.15f, %.15f is not inside polygon", lineString[i].x, lineString[i].y);
+            return false;
+        }
+    }
+
+    // Second, check if there was line segment intersecting polygon edge
+    for (std::size_t i = 0; i < lineString.size() - 1; ++i) {
+        if (lineIntersectPolygon(lineString[i], lineString[i + 1], polygon)) {
+            mbgl::Log::Debug(mbgl::Event::General,
+                             "---------line [%.15f, %.15f] to [%.15f, %.15f] is not inside polygon",
+                             lineString[i].x,
+                             lineString[i].y,
+                             lineString[i + 1].x,
+                             lineString[i + 1].y);
+            return false;
+        }
+    }
+
+    mbgl::Log::Debug(mbgl::Event::General, "---------line is inside polygon, line point size: %d: ", lineString.size());
+    return true;
+}
+
 bool pointsWithinPolygons(const mbgl::GeometryTileFeature& feature,
                           const mbgl::CanonicalTileID& canonical,
                           const mbgl::GeoJSON& geoJson) {
     return geoJson.match(
         [&feature, &canonical](const mapbox::geometry::geometry<double>& geometrySet) -> bool {
             mbgl::Feature f(geometrySet);
+
             PolygonFeature polyFeature(f, canonical);
             auto refinedGeoSet = convertGeometry(polyFeature, canonical);
             return refinedGeoSet.match(
@@ -80,7 +185,9 @@ bool pointsWithinPolygons(const mbgl::GeometryTileFeature& feature,
                                     return pointWithinPolygons(p, polygons);
                                 });
                             },
-                            [](const auto&) -> bool { return false; });
+                            [](const auto&) -> bool {
+                                return false;
+                            });
                 },
                 [&feature, &canonical](const mapbox::geometry::polygon<double>& polygon) -> bool {
                     return convertGeometry(feature, canonical)
@@ -98,6 +205,73 @@ bool pointsWithinPolygons(const mbgl::GeometryTileFeature& feature,
                 [](const auto&) -> bool { return false; });
         },
         [](const auto&) -> bool { return false; });
+}
+
+bool lineStringWithinPolygons(const mbgl::LineString<double>& line, const MultiPolygon<double>& polygons) {
+    for (auto polygon : polygons) {
+        if (lineStringWithinPolygon(line, polygon)) return true;
+    }
+    return false;
+}
+
+bool linesWithinPolygons(const mbgl::GeometryTileFeature& feature,
+                         const mbgl::CanonicalTileID& canonical,
+                         const mbgl::GeoJSON& geoJson) {
+    mbgl::Log::Debug(mbgl::Event::General, "------------------------Canonical ID is-------------------------------");
+    mbgl::Log::Debug(
+        mbgl::Event::General, "----- '%d' / '%d' / '%d'-------------", canonical.z, canonical.x, canonical.y);
+
+    return geoJson.match(
+        [&feature, &canonical](const mapbox::geometry::geometry<double>& geometrySet) -> bool {
+            mbgl::Feature f(geometrySet);
+            PolygonFeature polyFeature(f, CanonicalTileID(0, 0, 0));
+            auto refinedGeoSet = convertGeometry(polyFeature, CanonicalTileID(0, 0, 0));
+            return refinedGeoSet.match(
+                [&feature, &canonical](const MultiPolygon<double>& polygons) -> bool {
+                    for (auto polygon : polygons) {
+                        printPolygon(polygon);
+                    }
+                    return convertGeometry(feature, canonical)
+                        .match(
+                            [&polygons](const LineString<double>& line) -> bool {
+                                printLine(line);
+                                return lineStringWithinPolygons(line, polygons);
+                            },
+                            [&polygons](const MultiLineString<double>& lines) -> bool {
+                                return std::all_of(lines.begin(), lines.end(), [&polygons](const auto& line) {
+                                    printLine(line);
+                                    return lineStringWithinPolygons(line, polygons);
+                                });
+                            },
+                            [](const auto&) -> bool {
+                                return false;
+                            });
+                },
+                [&feature, &canonical](const Polygon<double>& polygon) -> bool {
+                    printPolygon(polygon);
+                    return convertGeometry(feature, canonical)
+                        .match(
+                            [&polygon](const LineString<double>& line) -> bool {
+                                printLine(line);
+                                return lineStringWithinPolygon(line, polygon);
+                            },
+                            [&polygon](const MultiLineString<double>& lines) -> bool {
+                                return std::all_of(lines.begin(), lines.end(), [&polygon](const auto& line) {
+                                    printLine(line);
+                                    return lineStringWithinPolygon(line, polygon);
+                                });
+                            },
+                            [](const auto&) -> bool {
+                                return false;
+                            });
+                },
+                [](const auto&) -> bool {
+                    return false;
+                });
+        },
+        [](const auto&) -> bool {
+            return false;
+        });
 }
 
 mbgl::optional<mbgl::GeoJSON> parseValue(const mbgl::style::conversion::Convertible& value_,
@@ -138,7 +312,10 @@ EvaluationResult Within::evaluate(const EvaluationContext& params) const {
     auto geometryType = params.feature->getType();
     // Currently only support Point/Points in Polygon/Polygons
     if (geometryType == FeatureType::Point) {
-        return pointsWithinPolygons(*params.feature, *params.canonical, geoJSONSource);
+        pointsWithinPolygons(*params.feature, *params.canonical, geoJSONSource);
+        return true;
+    } else if (geometryType == FeatureType::LineString) {
+        return linesWithinPolygons(*params.feature, *params.canonical, geoJSONSource);
     }
     mbgl::Log::Warning(mbgl::Event::General, "within expression currently only support 'Point' geometry type");
 
@@ -195,6 +372,22 @@ mbgl::Value Within::serialize() const {
                          "Failed to serialize 'within' expression, converted rapidJSON is not an object");
     }
     return std::vector<mbgl::Value>{{getOperator(), *fromExpressionValue<mbgl::Value>(serialized)}};
+}
+
+bool Within::operator==(const Expression& e) const {
+    if (e.getKind() == Kind::Within) {
+        auto rhs = static_cast<const Within*>(&e);
+        return geoJSONSource == rhs->geoJSONSource;
+    }
+    return false;
+}
+
+std::vector<optional<Value>> Within::possibleOutputs() const {
+    return {{true}, {false}};
+}
+
+std::string Within::getOperator() const {
+    return "within";
 }
 
 } // namespace expression

--- a/src/mbgl/util/geometry_within.cpp
+++ b/src/mbgl/util/geometry_within.cpp
@@ -8,51 +8,41 @@ bool rayIntersect(const Point<double>& p, const Point<double>& p1, const Point<d
     return ((p1.y > p.y) != (p2.y > p.y)) && (p.x < (p2.x - p1.x) * (p.y - p1.y) / (p2.y - p1.y) + p1.x);
 }
 
-// a, b are end point for line segment1, c and d are end points for line segment2
-bool lineIntersectLine(const Point<double>& a,
-                       const Point<double>& b,
-                       const Point<double>& c,
-                       const Point<double>& d) {
-    const auto perp = [](const Point<double>& v1, const Point<double>& v2) {
-        return (v1.x * v2.y - v1.y * v2.x);
-    };
-
-    // check if p1 and p2 are in different sides of line segment q1->q2
-    const auto twoSided = [](const Point<double>& p1,
-                             const Point<double>& p2,
-                             const Point<double>& q1,
-                             const Point<double>& q2) {
-        double x1, y1, x2, y2, x3, y3;
-
-        // q1->p1 (x1, y1), q1->p2 (x2, y2), q1->q2 (x3, y3)
-        x1 = p1.x - q1.x;
-        y1 = p1.y - q1.y;
-        x2 = p2.x - q1.x;
-        y2 = p2.y - q1.y;
-        x3 = q2.x - q1.x;
-        y3 = q2.y - q1.y;
-        if ((x1 * y3 - x3 * y1) * (x2 * y3 - x3 * y2) < 0) return true;
-        return false;
-    };
-
-    auto vectorP = Point<double>(b.x - a.x, b.y - a.y);
-    auto vectorQ = Point<double>(d.x - c.x, d.y - c.y);
+// a, b are end points for line segment1, c and d are end points for line segment2
+bool lineIntersectLine(const Point<double>& a, const Point<double>& b, const Point<double>& c, const Point<double>& d) {
+    const auto perp = [](const Point<double>& v1, const Point<double>& v2) { return (v1.x * v2.y - v1.y * v2.x); };
 
     // check if two segments are parallel or not
-    // precondition is end point a, b is inside polygon, if they line a->b is
-    // parallel to edge c->d, then a->b won't intersect with c->d
+    // precondition is end point a, b is inside polygon, if line a->b is
+    // parallel to polygon edge c->d, then a->b won't intersect with c->d
+    auto vectorP = Point<double>(b.x - a.x, b.y - a.y);
+    auto vectorQ = Point<double>(d.x - c.x, d.y - c.y);
     if (perp(vectorQ, vectorP) == 0) return false;
 
-    // check if there are intersecting with each other
-    // a and b lie in separate side of segment c->d
-    // c and d lie in separate side of segment a->b
+    // check if p1 and p2 are in different sides of line segment q1->q2
+    const auto twoSided =
+        [](const Point<double>& p1, const Point<double>& p2, const Point<double>& q1, const Point<double>& q2) {
+            double x1, y1, x2, y2, x3, y3;
+
+            // q1->p1 (x1, y1), q1->p2 (x2, y2), q1->q2 (x3, y3)
+            x1 = p1.x - q1.x;
+            y1 = p1.y - q1.y;
+            x2 = p2.x - q1.x;
+            y2 = p2.y - q1.y;
+            x3 = q2.x - q1.x;
+            y3 = q2.y - q1.y;
+            if ((x1 * y3 - x3 * y1) * (x2 * y3 - x3 * y2) < 0) return true;
+            return false;
+        };
+
+    // If lines are intersecting with each other, the relative location should be:
+    // a and b lie in different sides of segment c->d
+    // c and d lie in different sides of segment a->b
     if (twoSided(a, b, c, d) && twoSided(c, d, a, b)) return true;
     return false;
 }
 
-bool lineIntersectPolygon(const Point<double>& p1,
-                          const Point<double>& p2,
-                          const Polygon<double>& polygon) {
+bool lineIntersectPolygon(const Point<double>& p1, const Point<double>& p2, const Polygon<double>& polygon) {
     for (auto ring : polygon) {
         auto length = ring.size();
         // loop through every edge of the ring
@@ -64,26 +54,7 @@ bool lineIntersectPolygon(const Point<double>& p1,
     }
     return false;
 }
-}
-
-void printPolygon(const Polygon<double>& polygon) {
-    mbgl::Log::Debug(mbgl::Event::General, "-------Print Polygon------");
-    for (auto ring : polygon) {
-        auto length = ring.size();
-        mbgl::Log::Debug(mbgl::Event::General, "-------Print New ring with size: %d ------", length);
-        // loop through every edge of the ring
-        for (std::size_t i = 0; i < length - 1; ++i) {
-            mbgl::Log::Debug(mbgl::Event::General, "point [%.15f, %.15f],", ring[i].x, ring[i].y);
-        }
-    }
-}
-
-void printLine(const LineString<double>& lineString) {
-    mbgl::Log::Debug(mbgl::Event::General, "-------Print LineString------");
-    for (std::size_t i = 0; i < lineString.size(); ++i) {
-        mbgl::Log::Debug(mbgl::Event::General, "point [%.15f, %.15f],", lineString[i].x, lineString[i].y);
-    }
-}
+} // namespace
 
 // ray casting algorithm for detecting if point is in polygon
 bool pointWithinPolygon(const Point<double>& point, const Polygon<double>& polygon) {
@@ -107,14 +78,11 @@ bool pointWithinPolygons(const Point<double>& point, const MultiPolygon<double>&
     return false;
 }
 
-
-bool lineStringWithinPolygon(const LineString<double>& line,
-                             const Polygon<double>& polygon) {
+bool lineStringWithinPolygon(const LineString<double>& line, const Polygon<double>& polygon) {
     const auto length = line.size();
-    // First, check if endpoints of line are all inside polygon
+    // First, check if geometry points of line segments are all inside polygon
     for (std::size_t i = 0; i < length; ++i) {
         if (!pointWithinPolygon(line[i], polygon)) {
-            mbgl::Log::Debug(mbgl::Event::General, "point %.15f, %.15f is not inside polygon", line[i].x, line[i].y);
             return false;
         }
     }
@@ -122,12 +90,6 @@ bool lineStringWithinPolygon(const LineString<double>& line,
     // Second, check if there is line segment intersecting polygon edge
     for (std::size_t i = 0; i < length - 1; ++i) {
         if (lineIntersectPolygon(line[i], line[i + 1], polygon)) {
-            mbgl::Log::Debug(mbgl::Event::General,
-            "---------line [%.15f, %.15f] to [%.15f, %.15f] is not inside polygon",
-            line[i].x,
-            line[i].y,
-            line[i + 1].x,
-            line[i + 1].y);
             return false;
         }
     }
@@ -140,4 +102,4 @@ bool lineStringWithinPolygons(const LineString<double>& line, const MultiPolygon
     }
     return false;
 }
-}
+} // namespace mbgl

--- a/src/mbgl/util/geometry_within.cpp
+++ b/src/mbgl/util/geometry_within.cpp
@@ -1,5 +1,4 @@
 #include <mbgl/util/geometry_within.hpp>
-#include <mbgl/util/logging.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/util/geometry_within.cpp
+++ b/src/mbgl/util/geometry_within.cpp
@@ -1,0 +1,143 @@
+#include <mbgl/util/geometry_within.hpp>
+#include <mbgl/util/logging.hpp>
+
+namespace mbgl {
+
+namespace {
+bool rayIntersect(const Point<double>& p, const Point<double>& p1, const Point<double>& p2) {
+    return ((p1.y > p.y) != (p2.y > p.y)) && (p.x < (p2.x - p1.x) * (p.y - p1.y) / (p2.y - p1.y) + p1.x);
+}
+
+// a, b are end point for line segment1, c and d are end points for line segment2
+bool lineIntersectLine(const Point<double>& a,
+                       const Point<double>& b,
+                       const Point<double>& c,
+                       const Point<double>& d) {
+    const auto perp = [](const Point<double>& v1, const Point<double>& v2) {
+        return (v1.x * v2.y - v1.y * v2.x);
+    };
+
+    // check if p1 and p2 are in different sides of line segment q1->q2
+    const auto twoSided = [](const Point<double>& p1,
+                             const Point<double>& p2,
+                             const Point<double>& q1,
+                             const Point<double>& q2) {
+        double x1, y1, x2, y2, x3, y3;
+
+        // q1->p1 (x1, y1), q1->p2 (x2, y2), q1->q2 (x3, y3)
+        x1 = p1.x - q1.x;
+        y1 = p1.y - q1.y;
+        x2 = p2.x - q1.x;
+        y2 = p2.y - q1.y;
+        x3 = q2.x - q1.x;
+        y3 = q2.y - q1.y;
+        if ((x1 * y3 - x3 * y1) * (x2 * y3 - x3 * y2) < 0) return true;
+        return false;
+    };
+
+    auto vectorP = Point<double>(b.x - a.x, b.y - a.y);
+    auto vectorQ = Point<double>(d.x - c.x, d.y - c.y);
+
+    // check if two segments are parallel or not
+    // precondition is end point a, b is inside polygon, if they line a->b is
+    // parallel to edge c->d, then a->b won't intersect with c->d
+    if (perp(vectorQ, vectorP) == 0) return false;
+
+    // check if there are intersecting with each other
+    // a and b lie in separate side of segment c->d
+    // c and d lie in separate side of segment a->b
+    if (twoSided(a, b, c, d) && twoSided(c, d, a, b)) return true;
+    return false;
+}
+
+bool lineIntersectPolygon(const Point<double>& p1,
+                          const Point<double>& p2,
+                          const Polygon<double>& polygon) {
+    for (auto ring : polygon) {
+        auto length = ring.size();
+        // loop through every edge of the ring
+        for (std::size_t i = 0; i < length - 1; ++i) {
+            if (lineIntersectLine(p1, p2, ring[i], ring[i + 1])) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+}
+
+void printPolygon(const Polygon<double>& polygon) {
+    mbgl::Log::Debug(mbgl::Event::General, "-------Print Polygon------");
+    for (auto ring : polygon) {
+        auto length = ring.size();
+        mbgl::Log::Debug(mbgl::Event::General, "-------Print New ring with size: %d ------", length);
+        // loop through every edge of the ring
+        for (std::size_t i = 0; i < length - 1; ++i) {
+            mbgl::Log::Debug(mbgl::Event::General, "point [%.15f, %.15f],", ring[i].x, ring[i].y);
+        }
+    }
+}
+
+void printLine(const LineString<double>& lineString) {
+    mbgl::Log::Debug(mbgl::Event::General, "-------Print LineString------");
+    for (std::size_t i = 0; i < lineString.size(); ++i) {
+        mbgl::Log::Debug(mbgl::Event::General, "point [%.15f, %.15f],", lineString[i].x, lineString[i].y);
+    }
+}
+
+// ray casting algorithm for detecting if point is in polygon
+bool pointWithinPolygon(const Point<double>& point, const Polygon<double>& polygon) {
+    bool within = false;
+    for (const auto& ring : polygon) {
+        const auto length = ring.size();
+        // loop through every edge of the ring
+        for (std::size_t i = 0; i < length - 1; ++i) {
+            if (rayIntersect(point, ring[i], ring[i + 1])) {
+                within = !within;
+            }
+        }
+    }
+    return within;
+}
+
+bool pointWithinPolygons(const Point<double>& point, const MultiPolygon<double>& polygons) {
+    for (const auto& polygon : polygons) {
+        if (pointWithinPolygon(point, polygon)) return true;
+    }
+    return false;
+}
+
+
+bool lineStringWithinPolygon(const LineString<double>& line,
+                             const Polygon<double>& polygon) {
+    const auto length = line.size();
+    // First, check if endpoints of line are all inside polygon
+    for (std::size_t i = 0; i < length; ++i) {
+        if (!pointWithinPolygon(line[i], polygon)) {
+            mbgl::Log::Debug(mbgl::Event::General, "point %.15f, %.15f is not inside polygon", line[i].x, line[i].y);
+            return false;
+        }
+    }
+
+    // Second, check if there is line segment intersecting polygon edge
+    for (std::size_t i = 0; i < length - 1; ++i) {
+        if (lineIntersectPolygon(line[i], line[i + 1], polygon)) {
+            mbgl::Log::Debug(mbgl::Event::General,
+            "---------line [%.15f, %.15f] to [%.15f, %.15f] is not inside polygon",
+            line[i].x,
+            line[i].y,
+            line[i + 1].x,
+            line[i + 1].y);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool lineStringWithinPolygons(const LineString<double>& line, const MultiPolygon<double>& polygons) {
+    for (const auto& polygon : polygons) {
+        if (lineStringWithinPolygon(line, polygon)) return true;
+    }
+    return false;
+}
+}

--- a/src/mbgl/util/geometry_within.hpp
+++ b/src/mbgl/util/geometry_within.hpp
@@ -3,17 +3,11 @@
 
 namespace mbgl {
 
-void printPolygon(const Polygon<double>& polygon);
-
-void printLine(const LineString<double>& lineString);
-
-// ray casting algorithm for detecting if point is in polygon
 bool pointWithinPolygon(const Point<double>& point, const Polygon<double>& polygon);
 
 bool pointWithinPolygons(const Point<double>& point, const MultiPolygon<double>& polygons);
 
-bool lineStringWithinPolygon(const LineString<double>& lineString,
-                             const Polygon<double>& polygon);
+bool lineStringWithinPolygon(const LineString<double>& lineString, const Polygon<double>& polygon);
 
 bool lineStringWithinPolygons(const LineString<double>& line, const MultiPolygon<double>& polygons);
-}
+} // namespace mbgl

--- a/src/mbgl/util/geometry_within.hpp
+++ b/src/mbgl/util/geometry_within.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <mbgl/util/geometry.hpp>
+
+namespace mbgl {
+
+void printPolygon(const Polygon<double>& polygon);
+
+void printLine(const LineString<double>& lineString);
+
+// ray casting algorithm for detecting if point is in polygon
+bool pointWithinPolygon(const Point<double>& point, const Polygon<double>& polygon);
+
+bool pointWithinPolygons(const Point<double>& point, const MultiPolygon<double>& polygons);
+
+bool lineStringWithinPolygon(const LineString<double>& lineString,
+                             const Polygon<double>& polygon);
+
+bool lineStringWithinPolygons(const LineString<double>& line, const MultiPolygon<double>& polygons);
+}

--- a/src/mbgl/util/geometry_within.hpp
+++ b/src/mbgl/util/geometry_within.hpp
@@ -1,7 +1,22 @@
 #pragma once
+
+#include <array>
+#include <limits>
 #include <mbgl/util/geometry.hpp>
 
 namespace mbgl {
+
+// contains minX, minY, maxX, maxY
+using WithinBBox = std::array<double, 4>;
+const WithinBBox DefaultBBox = WithinBBox{std::numeric_limits<double>::infinity(),
+                                          std::numeric_limits<double>::infinity(),
+                                          -std::numeric_limits<double>::infinity(),
+                                          -std::numeric_limits<double>::infinity()};
+
+// check if bbox1 is within bbox2
+bool boxWithinBox(const WithinBBox& bbox1, const WithinBBox& bbox2);
+
+WithinBBox calculateBBox(const Geometry<double>& geometries);
 
 bool pointWithinPolygon(const Point<double>& point, const Polygon<double>& polygon);
 
@@ -10,4 +25,5 @@ bool pointWithinPolygons(const Point<double>& point, const MultiPolygon<double>&
 bool lineStringWithinPolygon(const LineString<double>& lineString, const Polygon<double>& polygon);
 
 bool lineStringWithinPolygons(const LineString<double>& line, const MultiPolygon<double>& polygons);
+
 } // namespace mbgl

--- a/test/style/property_expression.test.cpp
+++ b/test/style/property_expression.test.cpp
@@ -266,7 +266,7 @@ TEST(PropertyExpression, WithinExpression) {
     PropertyExpression<bool> propExpr(std::move(expression));
 
     // evaluation test with valid geojson source but FeatureType is not Point/LineString (currently only support
-    // FeatureType::Point)
+    // FeatureType::Point and FeatureType::LineString)
     {
         // testPoly is inside polygon, but will return false
         Polygon<double> testRing{{{-9.228515625, -17.560246503294888},
@@ -280,12 +280,12 @@ TEST(PropertyExpression, WithinExpression) {
     }
     // evaluation test with valid geojson source and valid linestring features
     {
-        // testLine is inside polygon, but will return true
+        // testLine is inside polygon
         LineString<double> testLine0{{-9.228515625, -17.560246503294888}, {-2.4609375, -16.04581345375217}};
         auto geoLine0 = convertGeometry(testLine0, canonicalTileID);
         StubGeometryTileFeature lineFeature0(FeatureType::LineString, geoLine0);
 
-        // testLine is intersecting polygon even though end points are all inside polygon, but will return false
+        // testLine is intersecting polygon even though end points are all inside polygon, will return false
         LineString<double> testLine1{{-10.4150390625, -10.082445532162465}, {-8.8275146484375, -9.194292714912638}};
         auto geoLine1 = convertGeometry(testLine1, canonicalTileID);
         StubGeometryTileFeature lineFeature1(FeatureType::LineString, geoLine1);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)


This pr will enable using `within` expression with features that contain `LineString` geometry type.

Fix: https://github.com/mapbox/mapbox-gl-native-team/issues/188