### PR TITLE
[core] Fix offline region download freezing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## master
 
+### 🐞 Bug fixes
+
+- [core] Fix offline region download freezing ([#16230](https://github.com/mapbox/mapbox-gl-native/pull/16230))
+
+  Downloaded resources are put in the buffer and inserted in the database in batches.
+
+  Before this change, the buffer was flushed only at the network response callback and thus it never got flushed if the last required resources were present locally and did not initiate network requests - it caused freezing.
+
+  Now the buffer is flushed every time the remaining resources container gets empty.
+
 ## maps-v1.2.0 (2020.02-release-vanillashake)
 
 ### ✨ New features

--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -7,12 +7,6 @@
 
 namespace mbgl {
 
-// Properties that may be supported by database file sources.
-
-// Property to set database mode. When set, database opens in read-only mode; database opens in read-write-create mode
-// otherwise. type: bool
-constexpr const char* READ_ONLY_MODE_KEY = "read-only-mode";
-
 class ResourceOptions;
 
 // TODO: Split DatabaseFileSource into Ambient cache and Database interfaces.

--- a/include/mbgl/storage/file_source.hpp
+++ b/include/mbgl/storage/file_source.hpp
@@ -84,4 +84,24 @@ protected:
     FileSource() = default;
 };
 
+// Properties that may be supported by online file sources:
+
+// Property name to set / get an access token.
+// type: std::string
+constexpr const char* ACCESS_TOKEN_KEY = "access-token";
+
+// Property name to set / get base url.
+// type: std::string
+constexpr const char* API_BASE_URL_KEY = "api-base-url";
+
+// Property name to set / get maximum number of concurrent requests.
+// type: unsigned
+constexpr const char* MAX_CONCURRENT_REQUESTS_KEY = "max-concurrent-requests";
+
+// Properties that may be supported by database file sources:
+
+// Property to set database mode. When set, database opens in read-only mode; database opens in read-write-create mode
+// otherwise. type: bool
+constexpr const char* READ_ONLY_MODE_KEY = "read-only-mode";
+
 } // namespace mbgl

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -7,20 +7,6 @@ namespace mbgl {
 
 class ResourceTransform;
 
-// Properties that may be supported by online file sources.
-
-// Property name to set / get an access token.
-// type: std::string
-constexpr const char* ACCESS_TOKEN_KEY = "access-token";
-
-// Property name to set / get base url.
-// type: std::string
-constexpr const char* API_BASE_URL_KEY = "api-base-url";
-
-// Property name to set / get maximum number of concurrent requests.
-// type: unsigned
-constexpr const char* MAX_CONCURRENT_REQUESTS_KEY = "max-concurrent-requests";
-
 class OnlineFileSource : public FileSource {
 public:
     OnlineFileSource();

--- a/platform/default/include/mbgl/storage/offline_download.hpp
+++ b/platform/default/include/mbgl/storage/offline_download.hpp
@@ -40,6 +40,7 @@ private:
     void activateDownload();
     void continueDownload();
     void deactivateDownload();
+    bool flushResourcesBuffer();
 
     /*
      * Ensure that the resource is stored in the database, requesting it if necessary.

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -373,7 +373,7 @@ void OfflineDownload::continueDownload() {
     if (resourcesToBeMarkedAsUsed.size() >= kMarkBatchSize) markPendingUsedResources();
 
     uint32_t maxConcurrentRequests = util::DEFAULT_MAXIMUM_CONCURRENT_REQUESTS;
-    auto value = onlineFileSource.getProperty("max-concurrent-requests");
+    auto value = onlineFileSource.getProperty(MAX_CONCURRENT_REQUESTS_KEY);
     if (uint64_t* maxRequests = value.getUint()) {
         maxConcurrentRequests = static_cast<uint32_t>(*maxRequests);
     }

--- a/render-test/file_source.cpp
+++ b/render-test/file_source.cpp
@@ -20,7 +20,7 @@ ProxyFileSource::ProxyFileSource(std::shared_ptr<FileSource> defaultResourceLoad
     assert(defaultResourceLoader);
     if (offline) {
         auto dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, options);
-        dbfs->setProperty("read-only-mode", true);
+        dbfs->setProperty(READ_ONLY_MODE_KEY, true);
     }
 }
 

--- a/test/src/mbgl/test/stub_file_source.cpp
+++ b/test/src/mbgl/test/stub_file_source.cpp
@@ -70,6 +70,15 @@ void StubFileSource::remove(AsyncRequest* req) {
     }
 }
 
+void StubFileSource::setProperty(const std::string& key, const mapbox::base::Value& value) {
+    properties[key] = value;
+}
+
+mapbox::base::Value StubFileSource::getProperty(const std::string& key) const {
+    auto it = properties.find(key);
+    return (it != properties.end()) ? it->second : mapbox::base::Value();
+}
+
 optional<Response> StubFileSource::defaultResponse(const Resource& resource) {
     switch (resource.kind) {
     case Resource::Kind::Style:

--- a/test/src/mbgl/test/stub_file_source.hpp
+++ b/test/src/mbgl/test/stub_file_source.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/util/timer.hpp>
 
+#include <map>
 #include <unordered_map>
 
 namespace mbgl {
@@ -22,6 +23,8 @@ public:
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
     bool canRequest(const Resource&) const override { return true; }
     void remove(AsyncRequest*);
+    void setProperty(const std::string&, const mapbox::base::Value&) override;
+    mapbox::base::Value getProperty(const std::string&) const override;
 
     using ResponseFunction = std::function<optional<Response> (const Resource&)>;
 
@@ -48,6 +51,7 @@ private:
     std::unordered_map<AsyncRequest*, std::tuple<Resource, ResponseFunction, Callback>> pending;
     ResponseType type;
     util::Timer timer;
+    std::map<std::string, mapbox::base::Value> properties;
 };
 
 } // namespace mbgl

--- a/test/storage/offline_download.test.cpp
+++ b/test/storage/offline_download.test.cpp
@@ -385,7 +385,7 @@ TEST(OfflineDownload, DoesNotFloodTheFileSourceWithRequests) {
     fileSource.respond(Resource::Kind::Style, test.response("style.json"));
     test.loop.runOnce();
 
-    EXPECT_EQ(*fileSource.getProperty("max-concurrent-requests").getUint(), fileSource.requests.size());
+    EXPECT_EQ(*fileSource.getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), fileSource.requests.size());
 }
 
 TEST(OfflineDownload, GetStatusNoResources) {

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -449,7 +449,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
     const std::size_t NUM_REQUESTS = 3;
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
-    fs.setProperty("max-concurrent-requests", 1u);
+    fs.setProperty(MAX_CONCURRENT_REQUESTS_KEY, 1u);
     // After DefaultFileSource was split, OnlineFileSource lives on a separate
     // thread. Pause OnlineFileSource, so that messages are queued for processing.
     fs.pause();
@@ -492,7 +492,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
     int correct_regular = 0;
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
-    fs.setProperty("max-concurrent-requests", 1u);
+    fs.setProperty(MAX_CONCURRENT_REQUESTS_KEY, 1u);
     fs.pause();
 
     std::vector<std::unique_ptr<AsyncRequest>> collector;
@@ -542,10 +542,10 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(MaximumConcurrentRequests)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    ASSERT_EQ(*fs.getProperty("max-concurrent-requests").getUint(), 20u);
+    ASSERT_EQ(*fs.getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), 20u);
 
-    fs.setProperty("max-concurrent-requests", 10u);
-    ASSERT_EQ(*fs.getProperty("max-concurrent-requests").getUint(), 10u);
+    fs.setProperty(MAX_CONCURRENT_REQUESTS_KEY, 10u);
+    ASSERT_EQ(*fs.getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), 10u);
 }
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RequestSameUrlMultipleTimes)) {


### PR DESCRIPTION
Downloaded resources are put in the buffer and inserted in the database in batches.

Before this change, the buffer was flushed only at the network response callback
and thus it never got flushed if the last required resources were present locally
and did not initiate network requests -> it caused freezing.

Now the buffer is flushed every time the remaining resources container gets empty.

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/195