### PR TITLE
[core] Add Layer::serialize() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   
   This is a back porting from GL JS [#9333](https://github.com/mapbox/mapbox-gl-js/pull/9333)
 
+- [core] Add Layer::serialize() method ([#16231](https://github.com/mapbox/mapbox-gl-native/pull/16231))
+
+  New method allows serialization of a layer into a Value type, including all modifications done via runtime style API. New method is also an enabler for Style object serialization (sources, layers, etc).
+
 ## maps-v1.2.0 (2020.02-release-vanillashake)
 
 ### ✨ New features

--- a/include/mbgl/style/conversion_impl.hpp
+++ b/include/mbgl/style/conversion_impl.hpp
@@ -318,7 +318,7 @@ struct ValueFactory<TransitionOptions> {
 
 template <>
 struct ValueFactory<Color> {
-    static Value make(const Color& color) { return color.toObject(); }
+    static Value make(const Color& color) { return color.serialize(); }
 };
 
 template <typename T>
@@ -358,11 +358,14 @@ Value makeValue(T&& arg) {
 template <typename T>
 StyleProperty makeStyleProperty(const PropertyValue<T>& value) {
     return value.match([](const Undefined&) -> StyleProperty { return {}; },
-                       [](const T& t) -> StyleProperty {
-                           return {makeValue(t), StyleProperty::Kind::Constant};
+                       [](const Color& c) -> StyleProperty {
+                           return {makeValue(c), StyleProperty::Kind::Expression};
                        },
                        [](const PropertyExpression<T>& fn) -> StyleProperty {
                            return {fn.getExpression().serialize(), StyleProperty::Kind::Expression};
+                       },
+                       [](const auto& t) -> StyleProperty {
+                           return {makeValue(t), StyleProperty::Kind::Constant};
                        });
 }
 

--- a/include/mbgl/style/conversion_impl.hpp
+++ b/include/mbgl/style/conversion_impl.hpp
@@ -306,14 +306,7 @@ struct ValueFactory<ColorRampPropertyValue> {
 
 template <>
 struct ValueFactory<TransitionOptions> {
-    static Value make(const TransitionOptions& value) {
-        return mapbox::base::ValueArray{
-            {std::chrono::duration_cast<std::chrono::milliseconds>(value.duration.value_or(mbgl::Duration::zero()))
-                 .count(),
-             std::chrono::duration_cast<std::chrono::milliseconds>(value.delay.value_or(mbgl::Duration::zero()))
-                 .count(),
-             value.enablePlacementTransitions}};
-    }
+    static Value make(const TransitionOptions& value) { return value.serialize(); }
 };
 
 template <>
@@ -370,10 +363,12 @@ StyleProperty makeStyleProperty(const PropertyValue<T>& value) {
 }
 
 inline StyleProperty makeStyleProperty(const TransitionOptions& value) {
+    if (!value.isDefined()) return {};
     return {makeValue(value), StyleProperty::Kind::Transition};
 }
 
 inline StyleProperty makeStyleProperty(const ColorRampPropertyValue& value) {
+    if (value.isUndefined()) return {};
     return {makeValue(value), StyleProperty::Kind::Expression};
 }
 

--- a/include/mbgl/style/filter.hpp
+++ b/include/mbgl/style/filter.hpp
@@ -28,6 +28,8 @@ public:
     
     bool operator()(const expression::EvaluationContext& context) const;
 
+    operator bool() const { return expression || legacyFilter; }
+
     friend bool operator==(const Filter& lhs, const Filter& rhs) {
         if (!lhs.expression || !rhs.expression) {
             return lhs.expression == rhs.expression;

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -114,6 +114,7 @@ public:
     optional<conversion::Error> setVisibility(const conversion::Convertible& value);
 
     virtual StyleProperty getProperty(const std::string&) const = 0;
+    virtual Value serialize() const;
 
     // Private implementation
     // TODO : We should not have public mutable data members.
@@ -140,6 +141,7 @@ public:
 
 protected:
     virtual Mutable<Impl> mutableBaseImpl() const = 0;
+    void serializeProperty(Value&, const StyleProperty&, const char* propertyName, bool isPaint) const;
 
     LayerObserver* observer;
     mapbox::base::WeakPtrFactory<Layer> weakFactory {this};

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -24,6 +24,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -24,6 +24,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -24,6 +24,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -24,6 +24,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Layout properties
 

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -25,6 +25,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -24,6 +24,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -40,6 +40,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
 <% if (layoutProperties.length) { -%>
     // Layout properties

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -27,6 +27,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Layout properties
 

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -24,6 +24,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Paint properties
 

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -26,6 +26,7 @@ public:
     optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
 
     StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
 
     // Layout properties
 

--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -3,6 +3,8 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/optional.hpp>
 
+#include <mapbox/value.hpp>
+
 namespace mbgl {
 namespace style {
 
@@ -29,6 +31,17 @@ public:
 
     bool isDefined() const {
         return duration || delay;
+    }
+
+    mapbox::base::Value serialize() const {
+        mapbox::base::ValueObject result;
+        if (duration) {
+            result.emplace("duration", std::chrono::duration_cast<std::chrono::milliseconds>(*duration).count());
+        }
+        if (delay) {
+            result.emplace("delay", std::chrono::duration_cast<std::chrono::milliseconds>(*delay).count());
+        }
+        return result;
     }
 };
 

--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -41,6 +41,7 @@ public:
     std::string stringify() const;
     std::array<double, 4> toArray() const;
     mbgl::Value toObject() const;
+    mbgl::Value serialize() const;
 };
 
 inline bool operator==(const Color& colorA, const Color& colorB) {

--- a/metrics/binary-size/linux-gcc8/metrics.json
+++ b/metrics/binary-size/linux-gcc8/metrics.json
@@ -3,17 +3,17 @@
         [
             "mbgl-glfw",
             "/tmp/attach/install/linux-gcc8-release/bin/mbgl-glfw",
-            7598440
+            7672168
         ],
         [
             "mbgl-offline",
             "/tmp/attach/install/linux-gcc8-release/bin/mbgl-offline",
-            6684904
+            6758632
         ],
         [
             "mbgl-render",
             "/tmp/attach/install/linux-gcc8-release/bin/mbgl-render",
-            7483752
+            7549288
         ]
     ]
 }

--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -126,16 +126,7 @@ Value ValueConverter<mbgl::Value>::toExpressionValue(const mbgl::Value& value) {
 
 mbgl::Value ValueConverter<mbgl::Value>::fromExpressionValue(const Value& value) {
     return value.match(
-        [&](const Color& color) -> mbgl::Value {
-            std::array<double, 4> array = color.toArray();
-            return std::vector<mbgl::Value>{
-                std::string("rgba"),
-                array[0],
-                array[1],
-                array[2],
-                array[3],
-            };
-        },
+        [&](const Color& color) -> mbgl::Value { return color.serialize(); },
         [&](const Collator&) -> mbgl::Value {
             // fromExpressionValue can't be used for Collator values,
             // because they have no meaningful representation as an mbgl::Value

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -91,6 +91,54 @@ void Layer::setMaxZoom(float maxZoom) {
     observer->onLayerChanged(*this);
 }
 
+Value Layer::serialize() const {
+    mapbox::base::ValueObject result;
+    result.emplace(std::make_pair<std::string, Value>("id", getID()));
+    result.emplace(std::make_pair<std::string, Value>("type", Layer::getTypeInfo()->type));
+
+    auto source = getSourceID();
+    if (!source.empty()) {
+        result.emplace(std::make_pair<std::string, Value>("source", std::move(source)));
+    }
+
+    auto sourceLayer = getSourceLayer();
+    if (!sourceLayer.empty()) {
+        result.emplace(std::make_pair<std::string, Value>("source-layer", std::move(sourceLayer)));
+    }
+
+    if (getFilter()) {
+        result.emplace(std::make_pair<std::string, Value>("filter", getFilter().serialize()));
+    }
+
+    if (getMinZoom() != -std::numeric_limits<float>::infinity()) {
+        result.emplace(std::make_pair<std::string, Value>("minzoom", getMinZoom()));
+    }
+
+    if (getMaxZoom() != std::numeric_limits<float>::infinity()) {
+        result.emplace(std::make_pair<std::string, Value>("maxzoom", getMaxZoom()));
+    }
+
+    if (getVisibility() == VisibilityType::None) {
+        result["layout"] = mapbox::base::ValueObject{std::make_pair<std::string, Value>("visibility", "none")};
+    }
+
+    return result;
+}
+
+void Layer::serializeProperty(Value& out, const StyleProperty& property, const char* propertyName, bool isPaint) const {
+    assert(out.getObject());
+    auto& object = *(out.getObject());
+    std::string propertyType = isPaint ? "paint" : "layout";
+    auto it = object.find(propertyType);
+    auto pair = std::make_pair<std::string, Value>(std::string(propertyName), Value{property.getValue()});
+    if (it != object.end()) {
+        assert(it->second.getObject());
+        it->second.getObject()->emplace(std::move(pair));
+    } else {
+        object[propertyType] = mapbox::base::ValueObject{{std::move(pair)}};
+    }
+}
+
 void Layer::setObserver(LayerObserver* observer_) {
     observer = observer_ ? observer_ : &nullObserver;
 }

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -364,6 +364,8 @@ using namespace conversion;
 
 namespace {
 
+constexpr uint8_t kPaintPropertyCount = 22u;
+
 enum class Property : uint8_t {
     CircleBlur,
     CircleColor,
@@ -417,7 +419,77 @@ MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<
      {"circle-stroke-width-transition", toUint8(Property::CircleStrokeWidthTransition)},
      {"circle-translate-transition", toUint8(Property::CircleTranslateTransition)},
      {"circle-translate-anchor-transition", toUint8(Property::CircleTranslateAnchorTransition)}});
+
+StyleProperty getLayerProperty(const CircleLayer& layer, Property property) {
+    switch (property) {
+        case Property::CircleBlur:
+            return makeStyleProperty(layer.getCircleBlur());
+        case Property::CircleColor:
+            return makeStyleProperty(layer.getCircleColor());
+        case Property::CircleOpacity:
+            return makeStyleProperty(layer.getCircleOpacity());
+        case Property::CirclePitchAlignment:
+            return makeStyleProperty(layer.getCirclePitchAlignment());
+        case Property::CirclePitchScale:
+            return makeStyleProperty(layer.getCirclePitchScale());
+        case Property::CircleRadius:
+            return makeStyleProperty(layer.getCircleRadius());
+        case Property::CircleStrokeColor:
+            return makeStyleProperty(layer.getCircleStrokeColor());
+        case Property::CircleStrokeOpacity:
+            return makeStyleProperty(layer.getCircleStrokeOpacity());
+        case Property::CircleStrokeWidth:
+            return makeStyleProperty(layer.getCircleStrokeWidth());
+        case Property::CircleTranslate:
+            return makeStyleProperty(layer.getCircleTranslate());
+        case Property::CircleTranslateAnchor:
+            return makeStyleProperty(layer.getCircleTranslateAnchor());
+        case Property::CircleBlurTransition:
+            return makeStyleProperty(layer.getCircleBlurTransition());
+        case Property::CircleColorTransition:
+            return makeStyleProperty(layer.getCircleColorTransition());
+        case Property::CircleOpacityTransition:
+            return makeStyleProperty(layer.getCircleOpacityTransition());
+        case Property::CirclePitchAlignmentTransition:
+            return makeStyleProperty(layer.getCirclePitchAlignmentTransition());
+        case Property::CirclePitchScaleTransition:
+            return makeStyleProperty(layer.getCirclePitchScaleTransition());
+        case Property::CircleRadiusTransition:
+            return makeStyleProperty(layer.getCircleRadiusTransition());
+        case Property::CircleStrokeColorTransition:
+            return makeStyleProperty(layer.getCircleStrokeColorTransition());
+        case Property::CircleStrokeOpacityTransition:
+            return makeStyleProperty(layer.getCircleStrokeOpacityTransition());
+        case Property::CircleStrokeWidthTransition:
+            return makeStyleProperty(layer.getCircleStrokeWidthTransition());
+        case Property::CircleTranslateTransition:
+            return makeStyleProperty(layer.getCircleTranslateTransition());
+        case Property::CircleTranslateAnchorTransition:
+            return makeStyleProperty(layer.getCircleTranslateAnchorTransition());
+    }
+    return {};
+}
+
+StyleProperty getLayerProperty(const CircleLayer& layer, const std::string& name) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
+        return {};
+    }
+    return getLayerProperty(layer, static_cast<Property>(it->second));
+}
+
 } // namespace
+
+Value CircleLayer::serialize() const {
+    auto result = Layer::serialize();
+    assert(result.getObject());
+    for (const auto& property : layerProperties) {
+        auto styleProperty = getLayerProperty(*this, static_cast<Property>(property.second));
+        if (styleProperty.getKind() == StyleProperty::Kind::Undefined) continue;
+        serializeProperty(result, styleProperty, property.first.c_str(), property.second < kPaintPropertyCount);
+    }
+    return result;
+}
 
 optional<Error> CircleLayer::setProperty(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
@@ -584,58 +656,7 @@ optional<Error> CircleLayer::setProperty(const std::string& name, const Converti
 }
 
 StyleProperty CircleLayer::getProperty(const std::string& name) const {
-    const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        return {};
-    }
-
-    switch (static_cast<Property>(it->second)) {
-        case Property::CircleBlur:
-            return makeStyleProperty(getCircleBlur());
-        case Property::CircleColor:
-            return makeStyleProperty(getCircleColor());
-        case Property::CircleOpacity:
-            return makeStyleProperty(getCircleOpacity());
-        case Property::CirclePitchAlignment:
-            return makeStyleProperty(getCirclePitchAlignment());
-        case Property::CirclePitchScale:
-            return makeStyleProperty(getCirclePitchScale());
-        case Property::CircleRadius:
-            return makeStyleProperty(getCircleRadius());
-        case Property::CircleStrokeColor:
-            return makeStyleProperty(getCircleStrokeColor());
-        case Property::CircleStrokeOpacity:
-            return makeStyleProperty(getCircleStrokeOpacity());
-        case Property::CircleStrokeWidth:
-            return makeStyleProperty(getCircleStrokeWidth());
-        case Property::CircleTranslate:
-            return makeStyleProperty(getCircleTranslate());
-        case Property::CircleTranslateAnchor:
-            return makeStyleProperty(getCircleTranslateAnchor());
-        case Property::CircleBlurTransition:
-            return makeStyleProperty(getCircleBlurTransition());
-        case Property::CircleColorTransition:
-            return makeStyleProperty(getCircleColorTransition());
-        case Property::CircleOpacityTransition:
-            return makeStyleProperty(getCircleOpacityTransition());
-        case Property::CirclePitchAlignmentTransition:
-            return makeStyleProperty(getCirclePitchAlignmentTransition());
-        case Property::CirclePitchScaleTransition:
-            return makeStyleProperty(getCirclePitchScaleTransition());
-        case Property::CircleRadiusTransition:
-            return makeStyleProperty(getCircleRadiusTransition());
-        case Property::CircleStrokeColorTransition:
-            return makeStyleProperty(getCircleStrokeColorTransition());
-        case Property::CircleStrokeOpacityTransition:
-            return makeStyleProperty(getCircleStrokeOpacityTransition());
-        case Property::CircleStrokeWidthTransition:
-            return makeStyleProperty(getCircleStrokeWidthTransition());
-        case Property::CircleTranslateTransition:
-            return makeStyleProperty(getCircleTranslateTransition());
-        case Property::CircleTranslateAnchorTransition:
-            return makeStyleProperty(getCircleTranslateAnchorTransition());
-    }
-    return {};
+    return getLayerProperty(*this, name);
 }
 
 Mutable<Layer::Impl> CircleLayer::mutableBaseImpl() const {

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -283,6 +283,8 @@ using namespace conversion;
 
 namespace {
 
+constexpr uint8_t kPaintPropertyCount = 16u;
+
 enum class Property : uint8_t {
     FillExtrusionBase,
     FillExtrusionColor,
@@ -324,7 +326,65 @@ MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<
      {"fill-extrusion-translate-transition", toUint8(Property::FillExtrusionTranslateTransition)},
      {"fill-extrusion-translate-anchor-transition", toUint8(Property::FillExtrusionTranslateAnchorTransition)},
      {"fill-extrusion-vertical-gradient-transition", toUint8(Property::FillExtrusionVerticalGradientTransition)}});
+
+StyleProperty getLayerProperty(const FillExtrusionLayer& layer, Property property) {
+    switch (property) {
+        case Property::FillExtrusionBase:
+            return makeStyleProperty(layer.getFillExtrusionBase());
+        case Property::FillExtrusionColor:
+            return makeStyleProperty(layer.getFillExtrusionColor());
+        case Property::FillExtrusionHeight:
+            return makeStyleProperty(layer.getFillExtrusionHeight());
+        case Property::FillExtrusionOpacity:
+            return makeStyleProperty(layer.getFillExtrusionOpacity());
+        case Property::FillExtrusionPattern:
+            return makeStyleProperty(layer.getFillExtrusionPattern());
+        case Property::FillExtrusionTranslate:
+            return makeStyleProperty(layer.getFillExtrusionTranslate());
+        case Property::FillExtrusionTranslateAnchor:
+            return makeStyleProperty(layer.getFillExtrusionTranslateAnchor());
+        case Property::FillExtrusionVerticalGradient:
+            return makeStyleProperty(layer.getFillExtrusionVerticalGradient());
+        case Property::FillExtrusionBaseTransition:
+            return makeStyleProperty(layer.getFillExtrusionBaseTransition());
+        case Property::FillExtrusionColorTransition:
+            return makeStyleProperty(layer.getFillExtrusionColorTransition());
+        case Property::FillExtrusionHeightTransition:
+            return makeStyleProperty(layer.getFillExtrusionHeightTransition());
+        case Property::FillExtrusionOpacityTransition:
+            return makeStyleProperty(layer.getFillExtrusionOpacityTransition());
+        case Property::FillExtrusionPatternTransition:
+            return makeStyleProperty(layer.getFillExtrusionPatternTransition());
+        case Property::FillExtrusionTranslateTransition:
+            return makeStyleProperty(layer.getFillExtrusionTranslateTransition());
+        case Property::FillExtrusionTranslateAnchorTransition:
+            return makeStyleProperty(layer.getFillExtrusionTranslateAnchorTransition());
+        case Property::FillExtrusionVerticalGradientTransition:
+            return makeStyleProperty(layer.getFillExtrusionVerticalGradientTransition());
+    }
+    return {};
+}
+
+StyleProperty getLayerProperty(const FillExtrusionLayer& layer, const std::string& name) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
+        return {};
+    }
+    return getLayerProperty(layer, static_cast<Property>(it->second));
+}
+
 } // namespace
+
+Value FillExtrusionLayer::serialize() const {
+    auto result = Layer::serialize();
+    assert(result.getObject());
+    for (const auto& property : layerProperties) {
+        auto styleProperty = getLayerProperty(*this, static_cast<Property>(property.second));
+        if (styleProperty.getKind() == StyleProperty::Kind::Undefined) continue;
+        serializeProperty(result, styleProperty, property.first.c_str(), property.second < kPaintPropertyCount);
+    }
+    return result;
+}
 
 optional<Error> FillExtrusionLayer::setProperty(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
@@ -463,46 +523,7 @@ optional<Error> FillExtrusionLayer::setProperty(const std::string& name, const C
 }
 
 StyleProperty FillExtrusionLayer::getProperty(const std::string& name) const {
-    const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        return {};
-    }
-
-    switch (static_cast<Property>(it->second)) {
-        case Property::FillExtrusionBase:
-            return makeStyleProperty(getFillExtrusionBase());
-        case Property::FillExtrusionColor:
-            return makeStyleProperty(getFillExtrusionColor());
-        case Property::FillExtrusionHeight:
-            return makeStyleProperty(getFillExtrusionHeight());
-        case Property::FillExtrusionOpacity:
-            return makeStyleProperty(getFillExtrusionOpacity());
-        case Property::FillExtrusionPattern:
-            return makeStyleProperty(getFillExtrusionPattern());
-        case Property::FillExtrusionTranslate:
-            return makeStyleProperty(getFillExtrusionTranslate());
-        case Property::FillExtrusionTranslateAnchor:
-            return makeStyleProperty(getFillExtrusionTranslateAnchor());
-        case Property::FillExtrusionVerticalGradient:
-            return makeStyleProperty(getFillExtrusionVerticalGradient());
-        case Property::FillExtrusionBaseTransition:
-            return makeStyleProperty(getFillExtrusionBaseTransition());
-        case Property::FillExtrusionColorTransition:
-            return makeStyleProperty(getFillExtrusionColorTransition());
-        case Property::FillExtrusionHeightTransition:
-            return makeStyleProperty(getFillExtrusionHeightTransition());
-        case Property::FillExtrusionOpacityTransition:
-            return makeStyleProperty(getFillExtrusionOpacityTransition());
-        case Property::FillExtrusionPatternTransition:
-            return makeStyleProperty(getFillExtrusionPatternTransition());
-        case Property::FillExtrusionTranslateTransition:
-            return makeStyleProperty(getFillExtrusionTranslateTransition());
-        case Property::FillExtrusionTranslateAnchorTransition:
-            return makeStyleProperty(getFillExtrusionTranslateAnchorTransition());
-        case Property::FillExtrusionVerticalGradientTransition:
-            return makeStyleProperty(getFillExtrusionVerticalGradientTransition());
-    }
-    return {};
+    return getLayerProperty(*this, name);
 }
 
 Mutable<Layer::Impl> FillExtrusionLayer::mutableBaseImpl() const {

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -204,6 +204,8 @@ using namespace conversion;
 
 namespace {
 
+constexpr uint8_t kPaintPropertyCount = 10u;
+
 enum class Property : uint8_t {
     HeatmapColor,
     HeatmapIntensity,
@@ -233,7 +235,53 @@ MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<
      {"heatmap-opacity-transition", toUint8(Property::HeatmapOpacityTransition)},
      {"heatmap-radius-transition", toUint8(Property::HeatmapRadiusTransition)},
      {"heatmap-weight-transition", toUint8(Property::HeatmapWeightTransition)}});
+
+StyleProperty getLayerProperty(const HeatmapLayer& layer, Property property) {
+    switch (property) {
+        case Property::HeatmapColor:
+            return makeStyleProperty(layer.getHeatmapColor());
+        case Property::HeatmapIntensity:
+            return makeStyleProperty(layer.getHeatmapIntensity());
+        case Property::HeatmapOpacity:
+            return makeStyleProperty(layer.getHeatmapOpacity());
+        case Property::HeatmapRadius:
+            return makeStyleProperty(layer.getHeatmapRadius());
+        case Property::HeatmapWeight:
+            return makeStyleProperty(layer.getHeatmapWeight());
+        case Property::HeatmapColorTransition:
+            return makeStyleProperty(layer.getHeatmapColorTransition());
+        case Property::HeatmapIntensityTransition:
+            return makeStyleProperty(layer.getHeatmapIntensityTransition());
+        case Property::HeatmapOpacityTransition:
+            return makeStyleProperty(layer.getHeatmapOpacityTransition());
+        case Property::HeatmapRadiusTransition:
+            return makeStyleProperty(layer.getHeatmapRadiusTransition());
+        case Property::HeatmapWeightTransition:
+            return makeStyleProperty(layer.getHeatmapWeightTransition());
+    }
+    return {};
+}
+
+StyleProperty getLayerProperty(const HeatmapLayer& layer, const std::string& name) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
+        return {};
+    }
+    return getLayerProperty(layer, static_cast<Property>(it->second));
+}
+
 } // namespace
+
+Value HeatmapLayer::serialize() const {
+    auto result = Layer::serialize();
+    assert(result.getObject());
+    for (const auto& property : layerProperties) {
+        auto styleProperty = getLayerProperty(*this, static_cast<Property>(property.second));
+        if (styleProperty.getKind() == StyleProperty::Kind::Undefined) continue;
+        serializeProperty(result, styleProperty, property.first.c_str(), property.second < kPaintPropertyCount);
+    }
+    return result;
+}
 
 optional<Error> HeatmapLayer::setProperty(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
@@ -324,34 +372,7 @@ optional<Error> HeatmapLayer::setProperty(const std::string& name, const Convert
 }
 
 StyleProperty HeatmapLayer::getProperty(const std::string& name) const {
-    const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        return {};
-    }
-
-    switch (static_cast<Property>(it->second)) {
-        case Property::HeatmapColor:
-            return makeStyleProperty(getHeatmapColor());
-        case Property::HeatmapIntensity:
-            return makeStyleProperty(getHeatmapIntensity());
-        case Property::HeatmapOpacity:
-            return makeStyleProperty(getHeatmapOpacity());
-        case Property::HeatmapRadius:
-            return makeStyleProperty(getHeatmapRadius());
-        case Property::HeatmapWeight:
-            return makeStyleProperty(getHeatmapWeight());
-        case Property::HeatmapColorTransition:
-            return makeStyleProperty(getHeatmapColorTransition());
-        case Property::HeatmapIntensityTransition:
-            return makeStyleProperty(getHeatmapIntensityTransition());
-        case Property::HeatmapOpacityTransition:
-            return makeStyleProperty(getHeatmapOpacityTransition());
-        case Property::HeatmapRadiusTransition:
-            return makeStyleProperty(getHeatmapRadiusTransition());
-        case Property::HeatmapWeightTransition:
-            return makeStyleProperty(getHeatmapWeightTransition());
-    }
-    return {};
+    return getLayerProperty(*this, name);
 }
 
 Mutable<Layer::Impl> HeatmapLayer::mutableBaseImpl() const {

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -200,6 +200,8 @@ using namespace conversion;
 
 namespace {
 
+constexpr uint8_t kPaintPropertyCount = <%- paintProperties.length * 2 -%>u;
+
 enum class Property : uint8_t {
 <% for (const property of paintProperties) { -%>
     <%- camelize(property.name) %>,
@@ -207,8 +209,12 @@ enum class Property : uint8_t {
 <% for (const property of paintProperties) { -%>
     <%- camelize(property.name) %>Transition,
 <% } -%>
-<% for (const property of layoutProperties) { -%>
-    <%- camelize(property.name) %>,
+<% for (let i = 0; i < layoutProperties.length; ++i) { -%>
+<% if (i===0) { -%>
+    <%- camelize(layoutProperties[i].name) %> = kPaintPropertyCount,
+<% } else { -%>
+    <%- camelize(layoutProperties[i].name) %>,
+<% } -%>
 <% } -%>
 };
 
@@ -225,7 +231,45 @@ MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<
      <%- paintProperties.map(p => `{"${p.name}-transition", toUint8(Property::${camelize(p.name)}Transition)}`).join(',\n     ') %>,
      <%- layoutProperties.map(p => `{"${p.name}", toUint8(Property::${camelize(p.name)})}`).join(',\n     ') %>});
 <% } -%>
+
+StyleProperty getLayerProperty(const <%- camelize(type) %>Layer& layer, Property property) {
+    switch (property) {
+<% for (const property of paintProperties) { -%>
+        case Property::<%- camelize(property.name) %>:
+            return makeStyleProperty(layer.get<%- camelize(property.name) %>());
+<% } -%>
+<% for (const property of paintProperties) { -%>
+        case Property::<%- camelize(property.name) %>Transition:
+            return makeStyleProperty(layer.get<%- camelize(property.name) %>Transition());
+<% } -%>
+<% for (const property of layoutProperties) { -%>
+        case Property::<%- camelize(property.name) %>:
+            return makeStyleProperty(layer.get<%- camelize(property.name) %>());
+<% } -%>
+    }
+    return {};
+}
+
+StyleProperty getLayerProperty(const <%- camelize(type) -%>Layer& layer, const std::string& name) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
+        return {};
+    }
+    return getLayerProperty(layer, static_cast<Property>(it->second));
+}
+
 } // namespace
+
+Value <%- camelize(type) %>Layer::serialize() const {
+    auto result = Layer::serialize();
+    assert(result.getObject());
+    for (const auto& property : layerProperties) {
+        auto styleProperty = getLayerProperty(*this, static_cast<Property>(property.second));
+        if (styleProperty.getKind() == StyleProperty::Kind::Undefined) continue;
+        serializeProperty(result, styleProperty, property.first.c_str(), property.second < kPaintPropertyCount);
+    }
+    return result;
+}
 
 optional<Error> <%- camelize(type) %>Layer::setProperty(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
@@ -289,26 +333,7 @@ optional<Error> <%- camelize(type) %>Layer::setProperty(const std::string& name,
 }
 
 StyleProperty <%- camelize(type) %>Layer::getProperty(const std::string& name) const {
-    const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        return {};
-    }
-
-    switch (static_cast<Property>(it->second)) {
-<% for (const property of paintProperties) { -%>
-        case Property::<%- camelize(property.name) %>:
-            return makeStyleProperty(get<%- camelize(property.name) %>());
-<% } -%>
-<% for (const property of paintProperties) { -%>
-        case Property::<%- camelize(property.name) %>Transition:
-            return makeStyleProperty(get<%- camelize(property.name) %>Transition());
-<% } -%>
-<% for (const property of layoutProperties) { -%>
-        case Property::<%- camelize(property.name) %>:
-            return makeStyleProperty(get<%- camelize(property.name) %>());
-<% } -%>
-    }
-    return {};
+    return getLayerProperty(*this, name);
 }
 
 Mutable<Layer::Impl> <%- camelize(type) %>Layer::mutableBaseImpl() const {

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -441,6 +441,8 @@ using namespace conversion;
 
 namespace {
 
+constexpr uint8_t kPaintPropertyCount = 22u;
+
 enum class Property : uint8_t {
     LineBlur,
     LineColor,
@@ -464,7 +466,7 @@ enum class Property : uint8_t {
     LineTranslateTransition,
     LineTranslateAnchorTransition,
     LineWidthTransition,
-    LineCap,
+    LineCap = kPaintPropertyCount,
     LineJoin,
     LineMiterLimit,
     LineRoundLimit,
@@ -504,7 +506,87 @@ MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<
      {"line-miter-limit", toUint8(Property::LineMiterLimit)},
      {"line-round-limit", toUint8(Property::LineRoundLimit)},
      {"line-sort-key", toUint8(Property::LineSortKey)}});
+
+StyleProperty getLayerProperty(const LineLayer& layer, Property property) {
+    switch (property) {
+        case Property::LineBlur:
+            return makeStyleProperty(layer.getLineBlur());
+        case Property::LineColor:
+            return makeStyleProperty(layer.getLineColor());
+        case Property::LineDasharray:
+            return makeStyleProperty(layer.getLineDasharray());
+        case Property::LineGapWidth:
+            return makeStyleProperty(layer.getLineGapWidth());
+        case Property::LineGradient:
+            return makeStyleProperty(layer.getLineGradient());
+        case Property::LineOffset:
+            return makeStyleProperty(layer.getLineOffset());
+        case Property::LineOpacity:
+            return makeStyleProperty(layer.getLineOpacity());
+        case Property::LinePattern:
+            return makeStyleProperty(layer.getLinePattern());
+        case Property::LineTranslate:
+            return makeStyleProperty(layer.getLineTranslate());
+        case Property::LineTranslateAnchor:
+            return makeStyleProperty(layer.getLineTranslateAnchor());
+        case Property::LineWidth:
+            return makeStyleProperty(layer.getLineWidth());
+        case Property::LineBlurTransition:
+            return makeStyleProperty(layer.getLineBlurTransition());
+        case Property::LineColorTransition:
+            return makeStyleProperty(layer.getLineColorTransition());
+        case Property::LineDasharrayTransition:
+            return makeStyleProperty(layer.getLineDasharrayTransition());
+        case Property::LineGapWidthTransition:
+            return makeStyleProperty(layer.getLineGapWidthTransition());
+        case Property::LineGradientTransition:
+            return makeStyleProperty(layer.getLineGradientTransition());
+        case Property::LineOffsetTransition:
+            return makeStyleProperty(layer.getLineOffsetTransition());
+        case Property::LineOpacityTransition:
+            return makeStyleProperty(layer.getLineOpacityTransition());
+        case Property::LinePatternTransition:
+            return makeStyleProperty(layer.getLinePatternTransition());
+        case Property::LineTranslateTransition:
+            return makeStyleProperty(layer.getLineTranslateTransition());
+        case Property::LineTranslateAnchorTransition:
+            return makeStyleProperty(layer.getLineTranslateAnchorTransition());
+        case Property::LineWidthTransition:
+            return makeStyleProperty(layer.getLineWidthTransition());
+        case Property::LineCap:
+            return makeStyleProperty(layer.getLineCap());
+        case Property::LineJoin:
+            return makeStyleProperty(layer.getLineJoin());
+        case Property::LineMiterLimit:
+            return makeStyleProperty(layer.getLineMiterLimit());
+        case Property::LineRoundLimit:
+            return makeStyleProperty(layer.getLineRoundLimit());
+        case Property::LineSortKey:
+            return makeStyleProperty(layer.getLineSortKey());
+    }
+    return {};
+}
+
+StyleProperty getLayerProperty(const LineLayer& layer, const std::string& name) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
+        return {};
+    }
+    return getLayerProperty(layer, static_cast<Property>(it->second));
+}
+
 } // namespace
+
+Value LineLayer::serialize() const {
+    auto result = Layer::serialize();
+    assert(result.getObject());
+    for (const auto& property : layerProperties) {
+        auto styleProperty = getLayerProperty(*this, static_cast<Property>(property.second));
+        if (styleProperty.getKind() == StyleProperty::Kind::Undefined) continue;
+        serializeProperty(result, styleProperty, property.first.c_str(), property.second < kPaintPropertyCount);
+    }
+    return result;
+}
 
 optional<Error> LineLayer::setProperty(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
@@ -716,68 +798,7 @@ optional<Error> LineLayer::setProperty(const std::string& name, const Convertibl
 }
 
 StyleProperty LineLayer::getProperty(const std::string& name) const {
-    const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        return {};
-    }
-
-    switch (static_cast<Property>(it->second)) {
-        case Property::LineBlur:
-            return makeStyleProperty(getLineBlur());
-        case Property::LineColor:
-            return makeStyleProperty(getLineColor());
-        case Property::LineDasharray:
-            return makeStyleProperty(getLineDasharray());
-        case Property::LineGapWidth:
-            return makeStyleProperty(getLineGapWidth());
-        case Property::LineGradient:
-            return makeStyleProperty(getLineGradient());
-        case Property::LineOffset:
-            return makeStyleProperty(getLineOffset());
-        case Property::LineOpacity:
-            return makeStyleProperty(getLineOpacity());
-        case Property::LinePattern:
-            return makeStyleProperty(getLinePattern());
-        case Property::LineTranslate:
-            return makeStyleProperty(getLineTranslate());
-        case Property::LineTranslateAnchor:
-            return makeStyleProperty(getLineTranslateAnchor());
-        case Property::LineWidth:
-            return makeStyleProperty(getLineWidth());
-        case Property::LineBlurTransition:
-            return makeStyleProperty(getLineBlurTransition());
-        case Property::LineColorTransition:
-            return makeStyleProperty(getLineColorTransition());
-        case Property::LineDasharrayTransition:
-            return makeStyleProperty(getLineDasharrayTransition());
-        case Property::LineGapWidthTransition:
-            return makeStyleProperty(getLineGapWidthTransition());
-        case Property::LineGradientTransition:
-            return makeStyleProperty(getLineGradientTransition());
-        case Property::LineOffsetTransition:
-            return makeStyleProperty(getLineOffsetTransition());
-        case Property::LineOpacityTransition:
-            return makeStyleProperty(getLineOpacityTransition());
-        case Property::LinePatternTransition:
-            return makeStyleProperty(getLinePatternTransition());
-        case Property::LineTranslateTransition:
-            return makeStyleProperty(getLineTranslateTransition());
-        case Property::LineTranslateAnchorTransition:
-            return makeStyleProperty(getLineTranslateAnchorTransition());
-        case Property::LineWidthTransition:
-            return makeStyleProperty(getLineWidthTransition());
-        case Property::LineCap:
-            return makeStyleProperty(getLineCap());
-        case Property::LineJoin:
-            return makeStyleProperty(getLineJoin());
-        case Property::LineMiterLimit:
-            return makeStyleProperty(getLineMiterLimit());
-        case Property::LineRoundLimit:
-            return makeStyleProperty(getLineRoundLimit());
-        case Property::LineSortKey:
-            return makeStyleProperty(getLineSortKey());
-    }
-    return {};
+    return getLayerProperty(*this, name);
 }
 
 Mutable<Layer::Impl> LineLayer::mutableBaseImpl() const {

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -283,6 +283,8 @@ using namespace conversion;
 
 namespace {
 
+constexpr uint8_t kPaintPropertyCount = 16u;
+
 enum class Property : uint8_t {
     RasterBrightnessMax,
     RasterBrightnessMin,
@@ -324,7 +326,65 @@ MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<
      {"raster-opacity-transition", toUint8(Property::RasterOpacityTransition)},
      {"raster-resampling-transition", toUint8(Property::RasterResamplingTransition)},
      {"raster-saturation-transition", toUint8(Property::RasterSaturationTransition)}});
+
+StyleProperty getLayerProperty(const RasterLayer& layer, Property property) {
+    switch (property) {
+        case Property::RasterBrightnessMax:
+            return makeStyleProperty(layer.getRasterBrightnessMax());
+        case Property::RasterBrightnessMin:
+            return makeStyleProperty(layer.getRasterBrightnessMin());
+        case Property::RasterContrast:
+            return makeStyleProperty(layer.getRasterContrast());
+        case Property::RasterFadeDuration:
+            return makeStyleProperty(layer.getRasterFadeDuration());
+        case Property::RasterHueRotate:
+            return makeStyleProperty(layer.getRasterHueRotate());
+        case Property::RasterOpacity:
+            return makeStyleProperty(layer.getRasterOpacity());
+        case Property::RasterResampling:
+            return makeStyleProperty(layer.getRasterResampling());
+        case Property::RasterSaturation:
+            return makeStyleProperty(layer.getRasterSaturation());
+        case Property::RasterBrightnessMaxTransition:
+            return makeStyleProperty(layer.getRasterBrightnessMaxTransition());
+        case Property::RasterBrightnessMinTransition:
+            return makeStyleProperty(layer.getRasterBrightnessMinTransition());
+        case Property::RasterContrastTransition:
+            return makeStyleProperty(layer.getRasterContrastTransition());
+        case Property::RasterFadeDurationTransition:
+            return makeStyleProperty(layer.getRasterFadeDurationTransition());
+        case Property::RasterHueRotateTransition:
+            return makeStyleProperty(layer.getRasterHueRotateTransition());
+        case Property::RasterOpacityTransition:
+            return makeStyleProperty(layer.getRasterOpacityTransition());
+        case Property::RasterResamplingTransition:
+            return makeStyleProperty(layer.getRasterResamplingTransition());
+        case Property::RasterSaturationTransition:
+            return makeStyleProperty(layer.getRasterSaturationTransition());
+    }
+    return {};
+}
+
+StyleProperty getLayerProperty(const RasterLayer& layer, const std::string& name) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
+        return {};
+    }
+    return getLayerProperty(layer, static_cast<Property>(it->second));
+}
+
 } // namespace
+
+Value RasterLayer::serialize() const {
+    auto result = Layer::serialize();
+    assert(result.getObject());
+    for (const auto& property : layerProperties) {
+        auto styleProperty = getLayerProperty(*this, static_cast<Property>(property.second));
+        if (styleProperty.getKind() == StyleProperty::Kind::Undefined) continue;
+        serializeProperty(result, styleProperty, property.first.c_str(), property.second < kPaintPropertyCount);
+    }
+    return result;
+}
 
 optional<Error> RasterLayer::setProperty(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
@@ -441,46 +501,7 @@ optional<Error> RasterLayer::setProperty(const std::string& name, const Converti
 }
 
 StyleProperty RasterLayer::getProperty(const std::string& name) const {
-    const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        return {};
-    }
-
-    switch (static_cast<Property>(it->second)) {
-        case Property::RasterBrightnessMax:
-            return makeStyleProperty(getRasterBrightnessMax());
-        case Property::RasterBrightnessMin:
-            return makeStyleProperty(getRasterBrightnessMin());
-        case Property::RasterContrast:
-            return makeStyleProperty(getRasterContrast());
-        case Property::RasterFadeDuration:
-            return makeStyleProperty(getRasterFadeDuration());
-        case Property::RasterHueRotate:
-            return makeStyleProperty(getRasterHueRotate());
-        case Property::RasterOpacity:
-            return makeStyleProperty(getRasterOpacity());
-        case Property::RasterResampling:
-            return makeStyleProperty(getRasterResampling());
-        case Property::RasterSaturation:
-            return makeStyleProperty(getRasterSaturation());
-        case Property::RasterBrightnessMaxTransition:
-            return makeStyleProperty(getRasterBrightnessMaxTransition());
-        case Property::RasterBrightnessMinTransition:
-            return makeStyleProperty(getRasterBrightnessMinTransition());
-        case Property::RasterContrastTransition:
-            return makeStyleProperty(getRasterContrastTransition());
-        case Property::RasterFadeDurationTransition:
-            return makeStyleProperty(getRasterFadeDurationTransition());
-        case Property::RasterHueRotateTransition:
-            return makeStyleProperty(getRasterHueRotateTransition());
-        case Property::RasterOpacityTransition:
-            return makeStyleProperty(getRasterOpacityTransition());
-        case Property::RasterResamplingTransition:
-            return makeStyleProperty(getRasterResamplingTransition());
-        case Property::RasterSaturationTransition:
-            return makeStyleProperty(getRasterSaturationTransition());
-    }
-    return {};
+    return getLayerProperty(*this, name);
 }
 
 Mutable<Layer::Impl> RasterLayer::mutableBaseImpl() const {

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1061,6 +1061,8 @@ using namespace conversion;
 
 namespace {
 
+constexpr uint8_t kPaintPropertyCount = 28u;
+
 enum class Property : uint8_t {
     IconColor,
     IconHaloBlur,
@@ -1090,7 +1092,7 @@ enum class Property : uint8_t {
     TextOpacityTransition,
     TextTranslateTransition,
     TextTranslateAnchorTransition,
-    IconAllowOverlap,
+    IconAllowOverlap = kPaintPropertyCount,
     IconAnchor,
     IconIgnorePlacement,
     IconImage,
@@ -1208,7 +1210,171 @@ MAPBOX_ETERNAL_CONSTEXPR const auto layerProperties = mapbox::eternal::hash_map<
      {"text-transform", toUint8(Property::TextTransform)},
      {"text-variable-anchor", toUint8(Property::TextVariableAnchor)},
      {"text-writing-mode", toUint8(Property::TextWritingMode)}});
+
+StyleProperty getLayerProperty(const SymbolLayer& layer, Property property) {
+    switch (property) {
+        case Property::IconColor:
+            return makeStyleProperty(layer.getIconColor());
+        case Property::IconHaloBlur:
+            return makeStyleProperty(layer.getIconHaloBlur());
+        case Property::IconHaloColor:
+            return makeStyleProperty(layer.getIconHaloColor());
+        case Property::IconHaloWidth:
+            return makeStyleProperty(layer.getIconHaloWidth());
+        case Property::IconOpacity:
+            return makeStyleProperty(layer.getIconOpacity());
+        case Property::IconTranslate:
+            return makeStyleProperty(layer.getIconTranslate());
+        case Property::IconTranslateAnchor:
+            return makeStyleProperty(layer.getIconTranslateAnchor());
+        case Property::TextColor:
+            return makeStyleProperty(layer.getTextColor());
+        case Property::TextHaloBlur:
+            return makeStyleProperty(layer.getTextHaloBlur());
+        case Property::TextHaloColor:
+            return makeStyleProperty(layer.getTextHaloColor());
+        case Property::TextHaloWidth:
+            return makeStyleProperty(layer.getTextHaloWidth());
+        case Property::TextOpacity:
+            return makeStyleProperty(layer.getTextOpacity());
+        case Property::TextTranslate:
+            return makeStyleProperty(layer.getTextTranslate());
+        case Property::TextTranslateAnchor:
+            return makeStyleProperty(layer.getTextTranslateAnchor());
+        case Property::IconColorTransition:
+            return makeStyleProperty(layer.getIconColorTransition());
+        case Property::IconHaloBlurTransition:
+            return makeStyleProperty(layer.getIconHaloBlurTransition());
+        case Property::IconHaloColorTransition:
+            return makeStyleProperty(layer.getIconHaloColorTransition());
+        case Property::IconHaloWidthTransition:
+            return makeStyleProperty(layer.getIconHaloWidthTransition());
+        case Property::IconOpacityTransition:
+            return makeStyleProperty(layer.getIconOpacityTransition());
+        case Property::IconTranslateTransition:
+            return makeStyleProperty(layer.getIconTranslateTransition());
+        case Property::IconTranslateAnchorTransition:
+            return makeStyleProperty(layer.getIconTranslateAnchorTransition());
+        case Property::TextColorTransition:
+            return makeStyleProperty(layer.getTextColorTransition());
+        case Property::TextHaloBlurTransition:
+            return makeStyleProperty(layer.getTextHaloBlurTransition());
+        case Property::TextHaloColorTransition:
+            return makeStyleProperty(layer.getTextHaloColorTransition());
+        case Property::TextHaloWidthTransition:
+            return makeStyleProperty(layer.getTextHaloWidthTransition());
+        case Property::TextOpacityTransition:
+            return makeStyleProperty(layer.getTextOpacityTransition());
+        case Property::TextTranslateTransition:
+            return makeStyleProperty(layer.getTextTranslateTransition());
+        case Property::TextTranslateAnchorTransition:
+            return makeStyleProperty(layer.getTextTranslateAnchorTransition());
+        case Property::IconAllowOverlap:
+            return makeStyleProperty(layer.getIconAllowOverlap());
+        case Property::IconAnchor:
+            return makeStyleProperty(layer.getIconAnchor());
+        case Property::IconIgnorePlacement:
+            return makeStyleProperty(layer.getIconIgnorePlacement());
+        case Property::IconImage:
+            return makeStyleProperty(layer.getIconImage());
+        case Property::IconKeepUpright:
+            return makeStyleProperty(layer.getIconKeepUpright());
+        case Property::IconOffset:
+            return makeStyleProperty(layer.getIconOffset());
+        case Property::IconOptional:
+            return makeStyleProperty(layer.getIconOptional());
+        case Property::IconPadding:
+            return makeStyleProperty(layer.getIconPadding());
+        case Property::IconPitchAlignment:
+            return makeStyleProperty(layer.getIconPitchAlignment());
+        case Property::IconRotate:
+            return makeStyleProperty(layer.getIconRotate());
+        case Property::IconRotationAlignment:
+            return makeStyleProperty(layer.getIconRotationAlignment());
+        case Property::IconSize:
+            return makeStyleProperty(layer.getIconSize());
+        case Property::IconTextFit:
+            return makeStyleProperty(layer.getIconTextFit());
+        case Property::IconTextFitPadding:
+            return makeStyleProperty(layer.getIconTextFitPadding());
+        case Property::SymbolAvoidEdges:
+            return makeStyleProperty(layer.getSymbolAvoidEdges());
+        case Property::SymbolPlacement:
+            return makeStyleProperty(layer.getSymbolPlacement());
+        case Property::SymbolSortKey:
+            return makeStyleProperty(layer.getSymbolSortKey());
+        case Property::SymbolSpacing:
+            return makeStyleProperty(layer.getSymbolSpacing());
+        case Property::SymbolZOrder:
+            return makeStyleProperty(layer.getSymbolZOrder());
+        case Property::TextAllowOverlap:
+            return makeStyleProperty(layer.getTextAllowOverlap());
+        case Property::TextAnchor:
+            return makeStyleProperty(layer.getTextAnchor());
+        case Property::TextField:
+            return makeStyleProperty(layer.getTextField());
+        case Property::TextFont:
+            return makeStyleProperty(layer.getTextFont());
+        case Property::TextIgnorePlacement:
+            return makeStyleProperty(layer.getTextIgnorePlacement());
+        case Property::TextJustify:
+            return makeStyleProperty(layer.getTextJustify());
+        case Property::TextKeepUpright:
+            return makeStyleProperty(layer.getTextKeepUpright());
+        case Property::TextLetterSpacing:
+            return makeStyleProperty(layer.getTextLetterSpacing());
+        case Property::TextLineHeight:
+            return makeStyleProperty(layer.getTextLineHeight());
+        case Property::TextMaxAngle:
+            return makeStyleProperty(layer.getTextMaxAngle());
+        case Property::TextMaxWidth:
+            return makeStyleProperty(layer.getTextMaxWidth());
+        case Property::TextOffset:
+            return makeStyleProperty(layer.getTextOffset());
+        case Property::TextOptional:
+            return makeStyleProperty(layer.getTextOptional());
+        case Property::TextPadding:
+            return makeStyleProperty(layer.getTextPadding());
+        case Property::TextPitchAlignment:
+            return makeStyleProperty(layer.getTextPitchAlignment());
+        case Property::TextRadialOffset:
+            return makeStyleProperty(layer.getTextRadialOffset());
+        case Property::TextRotate:
+            return makeStyleProperty(layer.getTextRotate());
+        case Property::TextRotationAlignment:
+            return makeStyleProperty(layer.getTextRotationAlignment());
+        case Property::TextSize:
+            return makeStyleProperty(layer.getTextSize());
+        case Property::TextTransform:
+            return makeStyleProperty(layer.getTextTransform());
+        case Property::TextVariableAnchor:
+            return makeStyleProperty(layer.getTextVariableAnchor());
+        case Property::TextWritingMode:
+            return makeStyleProperty(layer.getTextWritingMode());
+    }
+    return {};
+}
+
+StyleProperty getLayerProperty(const SymbolLayer& layer, const std::string& name) {
+    const auto it = layerProperties.find(name.c_str());
+    if (it == layerProperties.end()) {
+        return {};
+    }
+    return getLayerProperty(layer, static_cast<Property>(it->second));
+}
+
 } // namespace
+
+Value SymbolLayer::serialize() const {
+    auto result = Layer::serialize();
+    assert(result.getObject());
+    for (const auto& property : layerProperties) {
+        auto styleProperty = getLayerProperty(*this, static_cast<Property>(property.second));
+        if (styleProperty.getKind() == StyleProperty::Kind::Undefined) continue;
+        serializeProperty(result, styleProperty, property.first.c_str(), property.second < kPaintPropertyCount);
+    }
+    return result;
+}
 
 optional<Error> SymbolLayer::setProperty(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
@@ -1707,152 +1873,7 @@ optional<Error> SymbolLayer::setProperty(const std::string& name, const Converti
 }
 
 StyleProperty SymbolLayer::getProperty(const std::string& name) const {
-    const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        return {};
-    }
-
-    switch (static_cast<Property>(it->second)) {
-        case Property::IconColor:
-            return makeStyleProperty(getIconColor());
-        case Property::IconHaloBlur:
-            return makeStyleProperty(getIconHaloBlur());
-        case Property::IconHaloColor:
-            return makeStyleProperty(getIconHaloColor());
-        case Property::IconHaloWidth:
-            return makeStyleProperty(getIconHaloWidth());
-        case Property::IconOpacity:
-            return makeStyleProperty(getIconOpacity());
-        case Property::IconTranslate:
-            return makeStyleProperty(getIconTranslate());
-        case Property::IconTranslateAnchor:
-            return makeStyleProperty(getIconTranslateAnchor());
-        case Property::TextColor:
-            return makeStyleProperty(getTextColor());
-        case Property::TextHaloBlur:
-            return makeStyleProperty(getTextHaloBlur());
-        case Property::TextHaloColor:
-            return makeStyleProperty(getTextHaloColor());
-        case Property::TextHaloWidth:
-            return makeStyleProperty(getTextHaloWidth());
-        case Property::TextOpacity:
-            return makeStyleProperty(getTextOpacity());
-        case Property::TextTranslate:
-            return makeStyleProperty(getTextTranslate());
-        case Property::TextTranslateAnchor:
-            return makeStyleProperty(getTextTranslateAnchor());
-        case Property::IconColorTransition:
-            return makeStyleProperty(getIconColorTransition());
-        case Property::IconHaloBlurTransition:
-            return makeStyleProperty(getIconHaloBlurTransition());
-        case Property::IconHaloColorTransition:
-            return makeStyleProperty(getIconHaloColorTransition());
-        case Property::IconHaloWidthTransition:
-            return makeStyleProperty(getIconHaloWidthTransition());
-        case Property::IconOpacityTransition:
-            return makeStyleProperty(getIconOpacityTransition());
-        case Property::IconTranslateTransition:
-            return makeStyleProperty(getIconTranslateTransition());
-        case Property::IconTranslateAnchorTransition:
-            return makeStyleProperty(getIconTranslateAnchorTransition());
-        case Property::TextColorTransition:
-            return makeStyleProperty(getTextColorTransition());
-        case Property::TextHaloBlurTransition:
-            return makeStyleProperty(getTextHaloBlurTransition());
-        case Property::TextHaloColorTransition:
-            return makeStyleProperty(getTextHaloColorTransition());
-        case Property::TextHaloWidthTransition:
-            return makeStyleProperty(getTextHaloWidthTransition());
-        case Property::TextOpacityTransition:
-            return makeStyleProperty(getTextOpacityTransition());
-        case Property::TextTranslateTransition:
-            return makeStyleProperty(getTextTranslateTransition());
-        case Property::TextTranslateAnchorTransition:
-            return makeStyleProperty(getTextTranslateAnchorTransition());
-        case Property::IconAllowOverlap:
-            return makeStyleProperty(getIconAllowOverlap());
-        case Property::IconAnchor:
-            return makeStyleProperty(getIconAnchor());
-        case Property::IconIgnorePlacement:
-            return makeStyleProperty(getIconIgnorePlacement());
-        case Property::IconImage:
-            return makeStyleProperty(getIconImage());
-        case Property::IconKeepUpright:
-            return makeStyleProperty(getIconKeepUpright());
-        case Property::IconOffset:
-            return makeStyleProperty(getIconOffset());
-        case Property::IconOptional:
-            return makeStyleProperty(getIconOptional());
-        case Property::IconPadding:
-            return makeStyleProperty(getIconPadding());
-        case Property::IconPitchAlignment:
-            return makeStyleProperty(getIconPitchAlignment());
-        case Property::IconRotate:
-            return makeStyleProperty(getIconRotate());
-        case Property::IconRotationAlignment:
-            return makeStyleProperty(getIconRotationAlignment());
-        case Property::IconSize:
-            return makeStyleProperty(getIconSize());
-        case Property::IconTextFit:
-            return makeStyleProperty(getIconTextFit());
-        case Property::IconTextFitPadding:
-            return makeStyleProperty(getIconTextFitPadding());
-        case Property::SymbolAvoidEdges:
-            return makeStyleProperty(getSymbolAvoidEdges());
-        case Property::SymbolPlacement:
-            return makeStyleProperty(getSymbolPlacement());
-        case Property::SymbolSortKey:
-            return makeStyleProperty(getSymbolSortKey());
-        case Property::SymbolSpacing:
-            return makeStyleProperty(getSymbolSpacing());
-        case Property::SymbolZOrder:
-            return makeStyleProperty(getSymbolZOrder());
-        case Property::TextAllowOverlap:
-            return makeStyleProperty(getTextAllowOverlap());
-        case Property::TextAnchor:
-            return makeStyleProperty(getTextAnchor());
-        case Property::TextField:
-            return makeStyleProperty(getTextField());
-        case Property::TextFont:
-            return makeStyleProperty(getTextFont());
-        case Property::TextIgnorePlacement:
-            return makeStyleProperty(getTextIgnorePlacement());
-        case Property::TextJustify:
-            return makeStyleProperty(getTextJustify());
-        case Property::TextKeepUpright:
-            return makeStyleProperty(getTextKeepUpright());
-        case Property::TextLetterSpacing:
-            return makeStyleProperty(getTextLetterSpacing());
-        case Property::TextLineHeight:
-            return makeStyleProperty(getTextLineHeight());
-        case Property::TextMaxAngle:
-            return makeStyleProperty(getTextMaxAngle());
-        case Property::TextMaxWidth:
-            return makeStyleProperty(getTextMaxWidth());
-        case Property::TextOffset:
-            return makeStyleProperty(getTextOffset());
-        case Property::TextOptional:
-            return makeStyleProperty(getTextOptional());
-        case Property::TextPadding:
-            return makeStyleProperty(getTextPadding());
-        case Property::TextPitchAlignment:
-            return makeStyleProperty(getTextPitchAlignment());
-        case Property::TextRadialOffset:
-            return makeStyleProperty(getTextRadialOffset());
-        case Property::TextRotate:
-            return makeStyleProperty(getTextRotate());
-        case Property::TextRotationAlignment:
-            return makeStyleProperty(getTextRotationAlignment());
-        case Property::TextSize:
-            return makeStyleProperty(getTextSize());
-        case Property::TextTransform:
-            return makeStyleProperty(getTextTransform());
-        case Property::TextVariableAnchor:
-            return makeStyleProperty(getTextVariableAnchor());
-        case Property::TextWritingMode:
-            return makeStyleProperty(getTextWritingMode());
-    }
-    return {};
+    return getLayerProperty(*this, name);
 }
 
 Mutable<Layer::Impl> SymbolLayer::mutableBaseImpl() const {

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -48,4 +48,15 @@ mbgl::Value Color::toObject() const {
     return mapbox::base::ValueObject{{"r", double(r)}, {"g", double(g)}, {"b", double(b)}, {"a", double(a)}};
 }
 
+mbgl::Value Color::serialize() const {
+    std::array<double, 4> array = toArray();
+    return std::vector<mbgl::Value>{
+        std::string("rgba"),
+        array[0],
+        array[1],
+        array[2],
+        array[3],
+    };
+}
+
 } // namespace mbgl

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1035,7 +1035,11 @@ TEST(Map, UniversalStyleGetter) {
             "paint": {
                 "line-color": "red",
                 "line-opacity": 0.5,
-                "line-width": ["get", "width"]
+                "line-width": ["get", "width"],
+                "line-opacity-transition": {
+                    "duration": 400,
+                    "delay": 500
+                }
             },
             "layout": {
                 "line-cap": "butt"
@@ -1056,13 +1060,15 @@ TEST(Map, UniversalStyleGetter) {
 
     StyleProperty lineColor = lineLayer->getProperty("line-color");
     ASSERT_TRUE(lineColor.getValue());
-    EXPECT_EQ(StyleProperty::Kind::Constant, lineColor.getKind());
-    ASSERT_TRUE(lineColor.getValue().getObject());
-    const auto& color = *(lineColor.getValue().getObject());
-    EXPECT_EQ(1.0, *color.at("r").getDouble());
-    EXPECT_EQ(0.0, *color.at("g").getDouble());
-    EXPECT_EQ(0.0, *color.at("b").getDouble());
-    EXPECT_EQ(1.0, *color.at("a").getDouble());
+    EXPECT_EQ(StyleProperty::Kind::Expression, lineColor.getKind());
+    ASSERT_TRUE(lineColor.getValue().getArray());
+    const auto& color = *(lineColor.getValue().getArray());
+    EXPECT_EQ(5u, color.size());
+    EXPECT_EQ("rgba", *color[0].getString());
+    EXPECT_EQ(255.0, *color[1].getDouble());
+    EXPECT_EQ(0.0, *color[2].getDouble());
+    EXPECT_EQ(0.0, *color[3].getDouble());
+    EXPECT_EQ(1.0, *color[4].getDouble());
 
     StyleProperty lineOpacity = lineLayer->getProperty("line-opacity");
     ASSERT_TRUE(lineOpacity.getValue());
@@ -1073,8 +1079,11 @@ TEST(Map, UniversalStyleGetter) {
     StyleProperty lineOpacityTransition = lineLayer->getProperty("line-opacity-transition");
     ASSERT_TRUE(lineOpacityTransition.getValue());
     EXPECT_EQ(StyleProperty::Kind::Transition, lineOpacityTransition.getKind());
-    ASSERT_TRUE(lineOpacityTransition.getValue().getArray());
-    EXPECT_EQ(3u, lineOpacityTransition.getValue().getArray()->size());
+    ASSERT_TRUE(lineOpacityTransition.getValue().getObject());
+    EXPECT_EQ(2u, lineOpacityTransition.getValue().getObject()->size());
+
+    StyleProperty lineColorTransition = lineLayer->getProperty("line-color-transition");
+    EXPECT_EQ(StyleProperty::Kind::Undefined, lineColorTransition.getKind());
 
     StyleProperty lineWidth = lineLayer->getProperty("line-width");
     ASSERT_TRUE(lineWidth.getValue());

--- a/test/style/conversion/layer.test.cpp
+++ b/test/style/conversion/layer.test.cpp
@@ -4,6 +4,8 @@
 #include <mbgl/style/conversion/layer.hpp>
 #include <mbgl/style/layers/background_layer_impl.hpp>
 
+#include <rapidjson/prettywriter.h>
+
 using namespace mbgl;
 using namespace mbgl::style;
 using namespace mbgl::style::conversion;
@@ -11,7 +13,17 @@ using namespace std::literals::chrono_literals;
 
 std::unique_ptr<Layer> parseLayer(const std::string& src) {
     Error error;
-    return std::move(*convertJSON<std::unique_ptr<Layer>>(src, error));
+    auto layer = convertJSON<std::unique_ptr<Layer>>(src, error);
+    if (layer) return std::move(*layer);
+    return nullptr;
+}
+
+std::string stringifyLayer(const Value& value) {
+    rapidjson::StringBuffer s;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(s);
+    writer.SetIndent(' ', 2u);
+    stringify(writer, value);
+    return s.GetString();
 }
 
 TEST(StyleConversion, LayerTransition) {
@@ -30,4 +42,86 @@ TEST(StyleConversion, LayerTransition) {
         .get<BackgroundColor>().options.duration);
     ASSERT_EQ(500ms, *static_cast<BackgroundLayer*>(layer.get())->impl().paint
         .get<BackgroundColor>().options.delay);
+}
+
+TEST(StyleConversion, SerializeDefaults) {
+    auto layer = parseLayer(R"JSON({
+        "type": "background",
+        "id": "background"
+    })JSON");
+
+    EXPECT_NE(nullptr, layer);
+    auto value = layer->serialize();
+    EXPECT_NE(nullptr, value.getObject());
+    EXPECT_EQ(2u, value.getObject()->size());
+}
+
+TEST(StyleConversion, RoundtripWithTransitions) {
+    auto layer = parseLayer(R"JSON({
+        "type": "background",
+        "id": "background",
+        "paint": {
+            "background-color-transition": {
+                "duration": 400,
+                "delay": 500
+            }
+        }
+    })JSON");
+
+    EXPECT_NE(nullptr, layer);
+    auto value = layer->serialize();
+    EXPECT_NE(nullptr, value.getObject());
+    EXPECT_EQ(3u, value.getObject()->size());
+
+    auto roundTripped = parseLayer(stringifyLayer(value));
+    EXPECT_NE(nullptr, roundTripped);
+    auto roundTrippedValue = roundTripped->serialize();
+    EXPECT_NE(nullptr, roundTrippedValue.getObject());
+    EXPECT_EQ(3u, roundTrippedValue.getObject()->size());
+}
+
+TEST(StyleConversion, OverrideDefaults) {
+    auto layer = parseLayer(R"JSON({
+        "type": "symbol",
+        "id": "symbol",
+        "source": "composite",
+        "source-layer": "landmarks",
+        "filter": ["has", "monuments"],
+        "minzoom": 12,
+        "maxzoom": 18,
+        "layout": {
+            "visibility": "none",
+            "text-field": ["format",
+                            "Hello",
+                            ["image", ["get", "world"]],
+                            "Example", {"text-color": "rgba(128, 255, 39, 1)"}
+                          ],
+            "icon-image": ["image", ["get", "landmark_image"]],
+            "text-size": 24
+        },
+        "paint": {
+            "text-color": "turquoise",
+            "text-color-transition": {
+                "duration": 300,
+                "delay": 100
+            }
+        }
+    })JSON");
+
+    EXPECT_NE(nullptr, layer);
+    auto value = layer->serialize();
+    EXPECT_NE(nullptr, value.getObject());
+    const auto& object = *(value.getObject());
+    EXPECT_EQ(9u, object.size());
+    EXPECT_EQ(4u, object.at("layout").getObject()->size());
+    EXPECT_EQ(2u, object.at("paint").getObject()->size());
+
+    auto roundTripped = parseLayer(stringifyLayer(value));
+    EXPECT_NE(nullptr, roundTripped);
+    auto roundTrippedValue = roundTripped->serialize();
+    const auto& roundTrippedObject = *(roundTrippedValue.getObject());
+    EXPECT_NE(nullptr, roundTrippedValue.getObject());
+    EXPECT_EQ(9u, roundTrippedObject.size());
+    EXPECT_EQ(4u, roundTrippedObject.at("layout").getObject()->size());
+    EXPECT_EQ(2u, roundTrippedObject.at("paint").getObject()->size());
 }


### PR DESCRIPTION
New method allows serialization of a layer into a Value type, including all modifications done via runtime style API. New method is also an enabler for `Style` object serialization (sources, layers, etc). PR also fixes several issues in universal style setter / getter code.

Related issues: https://github.com/mapbox/mapbox-gl-native/issues/7600
Fixes: https://github.com/mapbox/mapbox-gl-native-team/issues/194

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] tagged `@mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk` if this PR adds or updates a public API
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)

/cc @mapbox/core-sdk