### PR TITLE
[core] Fix within expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   
   But `within` expression need to accept an Object and then convert to GeoJSON object, now `toGeoJSON` method can convert both string and Object to GeoJSON.
 
+- [core] Fix `within` expression algorithm so that `false` value will be returned when point is on the boundary.  Allow using different GeoJSON formats as arguments of `within` expression.([#16232](https://github.com/mapbox/mapbox-gl-native/pull/16232))
+
+  A valid GeoJSON argument should contain one of the following types:  `"Feature"`, `"FeatureCollection"`,`"Polygon"` or `"MultiPolygon"`. 
+
 ### 🧩  Architectural changes
 
 - Changes to `MapSnapshotter` threading model ([#16268](https://github.com/mapbox/mapbox-gl-native/pull/16268))

--- a/include/mbgl/style/expression/within.hpp
+++ b/include/mbgl/style/expression/within.hpp
@@ -11,7 +11,7 @@ namespace expression {
 
 class Within final : public Expression {
 public:
-    explicit Within(GeoJSON geojson, Feature::geometry_type geometries_, WithinBBox polygonBBox_);
+    explicit Within(GeoJSON geojson, Feature::geometry_type geometries_, const WithinBBox& polygonBBox_);
 
     ~Within() override;
 

--- a/src/mbgl/util/geometry_within.cpp
+++ b/src/mbgl/util/geometry_within.cpp
@@ -9,6 +9,14 @@ bool rayIntersect(const Point<double>& p, const Point<double>& p1, const Point<d
     return ((p1.y > p.y) != (p2.y > p.y)) && (p.x < (p2.x - p1.x) * (p.y - p1.y) / (p2.y - p1.y) + p1.x);
 }
 
+bool onBoundary(const Point<double>& p, const Point<double>& p1, const Point<double>& p2) {
+    const auto x1 = p.x - p1.x;
+    const auto y1 = p.y - p1.y;
+    const auto x2 = p.x - p2.x;
+    const auto y2 = p.y - p2.y;
+    return (x1 * y2 - x2 * y1 == 0) && (x1 * x2 <= 0) && (y1 * y2 <= 0);
+}
+
 // a, b are end points for line segment1, c and d are end points for line segment2
 bool lineIntersectLine(const Point<double>& a, const Point<double>& b, const Point<double>& c, const Point<double>& d) {
     const auto perp = [](const Point<double>& v1, const Point<double>& v2) { return (v1.x * v2.y - v1.y * v2.x); };
@@ -134,6 +142,7 @@ bool pointWithinPolygon(const Point<double>& point, const Polygon<double>& polyg
         const auto length = ring.size();
         // loop through every edge of the ring
         for (std::size_t i = 0; i < length - 1; ++i) {
+            if (onBoundary(point, ring[i], ring[i + 1])) return false;
             if (rayIntersect(point, ring[i], ring[i + 1])) {
                 within = !within;
             }

--- a/src/mbgl/util/geometry_within.cpp
+++ b/src/mbgl/util/geometry_within.cpp
@@ -9,7 +9,11 @@ bool rayIntersect(const Point<double>& p, const Point<double>& p1, const Point<d
     return ((p1.y > p.y) != (p2.y > p.y)) && (p.x < (p2.x - p1.x) * (p.y - p1.y) / (p2.y - p1.y) + p1.x);
 }
 
+// check if point p in on line segment with end points p1 and p2
 bool onBoundary(const Point<double>& p, const Point<double>& p1, const Point<double>& p2) {
+    // requirements of point p on line segment:
+    // 1. colinear: cross product of vector p->p1(x1, y1) and vector p->p2(x2, y2) equals to 0
+    // 2. p is between p1 and p2
     const auto x1 = p.x - p1.x;
     const auto y1 = p.y - p1.y;
     const auto x2 = p.x - p2.x;

--- a/test/style/property_expression.test.cpp
+++ b/test/style/property_expression.test.cpp
@@ -334,5 +334,9 @@ TEST(PropertyExpression, WithinExpression) {
         pointFeature = getPointFeature(Point<double>(-15.5126953125, -11.73830237143684));
         evaluatedResult = propExpr.evaluate(EvaluationContext(&pointFeature).withCanonicalTileID(&canonicalTileID));
         EXPECT_TRUE(evaluatedResult);
+
+        pointFeature = getPointFeature(Point<double>(-5.9765625, -5.659718554577273));
+        evaluatedResult = propExpr.evaluate(EvaluationContext(&pointFeature).withCanonicalTileID(&canonicalTileID));
+        EXPECT_FALSE(evaluatedResult);
     }
 }

--- a/test/style/property_expression.test.cpp
+++ b/test/style/property_expression.test.cpp
@@ -335,7 +335,8 @@ TEST(PropertyExpression, WithinExpression) {
         evaluatedResult = propExpr.evaluate(EvaluationContext(&pointFeature).withCanonicalTileID(&canonicalTileID));
         EXPECT_TRUE(evaluatedResult);
 
-        pointFeature = getPointFeature(Point<double>(-5.9765625, -5.659718554577273));
+        // On the boundary
+        pointFeature = getPointFeature(Point<double>(3.076171875, -7.01366792756663));
         evaluatedResult = propExpr.evaluate(EvaluationContext(&pointFeature).withCanonicalTileID(&canonicalTileID));
         EXPECT_FALSE(evaluatedResult);
     }


### PR DESCRIPTION
- Fix error within decision when point is on Polygon line
- This patch will allow different geojson variants to be used as arguments of within expression, like 

```
{
    "type": "Feature",
    "geometry": {
      "type": "Point",
      "coordinates": [
        -199.68749999999997,
        33.137551192346145
      ]
    }
 }
```
```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Point",
        "coordinates": [
          -34.80468749999999,
          32.24997445586331
        ]
      }
    }
]
}
```
```
{
    "type": "Point",
    "coordinates": [
      -199.68749999999997,
      33.137551192346145
    ]
}
```