### PR TITLE
[android] Add jni binding for min and max pitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
   New method allows serialization of a layer into a Value type, including all modifications done via runtime style API. New method is also an enabler for Style object serialization (sources, layers, etc).
 
+- [android] Add jni binding for min and max pitch ([#16236](https://github.com/mapbox/mapbox-gl-native/pull/16236))
+
 ##### ⚠️  Breaking changes
 
 - Changes to `mbgl::FileSourceManager::getFileSource()` ([#16238](https://github.com/mapbox/mapbox-gl-native/pull/16238))

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -479,6 +479,22 @@ jni::jdouble NativeMapView::getMaxZoom(jni::JNIEnv&) {
     return *map->getBounds().maxZoom;
 }
 
+void NativeMapView::setMinPitch(jni::JNIEnv&, jni::jdouble pitch) {
+    map->setBounds(BoundOptions().withMinPitch(pitch));
+}
+
+jni::jdouble NativeMapView::getMinPitch(jni::JNIEnv&) {
+    return *map->getBounds().minPitch;
+}
+
+void NativeMapView::setMaxPitch(jni::JNIEnv&, jni::jdouble pitch) {
+    map->setBounds(BoundOptions().withMaxPitch(pitch));
+}
+
+jni::jdouble NativeMapView::getMaxPitch(jni::JNIEnv&) {
+    return *map->getBounds().maxPitch;
+}
+
 void NativeMapView::rotateBy(jni::JNIEnv&, jni::jdouble sx, jni::jdouble sy, jni::jdouble ex, jni::jdouble ey, jni::jlong duration) {
     mbgl::ScreenCoordinate first(sx, sy);
     mbgl::ScreenCoordinate second(ex, ey);
@@ -1172,6 +1188,10 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
         METHOD(&NativeMapView::getMinZoom, "nativeGetMinZoom"),
         METHOD(&NativeMapView::setMaxZoom, "nativeSetMaxZoom"),
         METHOD(&NativeMapView::getMaxZoom, "nativeGetMaxZoom"),
+        METHOD(&NativeMapView::setMinPitch, "nativeSetMinPitch"),
+        METHOD(&NativeMapView::getMinPitch, "nativeGetMinPitch"),
+        METHOD(&NativeMapView::setMaxPitch, "nativeSetMaxPitch"),
+        METHOD(&NativeMapView::getMaxPitch, "nativeGetMaxPitch"),
         METHOD(&NativeMapView::rotateBy, "nativeRotateBy"),
         METHOD(&NativeMapView::setBearing, "nativeSetBearing"),
         METHOD(&NativeMapView::setBearingXY, "nativeSetBearingXY"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -127,6 +127,14 @@ public:
 
     jni::jdouble getMaxZoom(jni::JNIEnv&);
 
+    void setMinPitch(jni::JNIEnv&, jni::jdouble);
+
+    jni::jdouble getMinPitch(jni::JNIEnv&);
+
+    void setMaxPitch(jni::JNIEnv&, jni::jdouble);
+
+    jni::jdouble getMaxPitch(jni::JNIEnv&);
+
     void rotateBy(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
 
     void setBearing(jni::JNIEnv&, jni::jdouble, jni::jlong);


### PR DESCRIPTION
min and max pitch method will be added to android sdk. This pr add the jni binding for them. The related pr in map sdk: https://github.com/mapbox/mapbox-gl-native-android/pull/199