### PR TITLE
[core] FileSource API improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,33 @@
   
   This is a back porting from GL JS [#9333](https://github.com/mapbox/mapbox-gl-js/pull/9333)
 
+### ✨ New features
+
 - [core] Add Layer::serialize() method ([#16231](https://github.com/mapbox/mapbox-gl-native/pull/16231))
 
   New method allows serialization of a layer into a Value type, including all modifications done via runtime style API. New method is also an enabler for Style object serialization (sources, layers, etc).
+
+##### ⚠️  Breaking changes
+
+- Changes to `mbgl::FileSourceManager::getFileSource()` ([#16238](https://github.com/mapbox/mapbox-gl-native/pull/16238))
+
+  It returns now `mbgl::PassRefPtr<FileSource>` (previously was `std::shared_ptr<FileSource>`) in order to enforce keeping the strong reference to the returned object.
+
+  Breaking code example:
+  `auto fs = FileSourceManager::getFileSource(); fs->..`
+  
+  Posible fix:
+  `std::shared_ptr<FileSource> fs = `;
+
+- The `mbgl::OnlineFileSource` class cannot be used directly ([#16238](https://github.com/mapbox/mapbox-gl-native/pull/16238))
+
+  Clients must use the parent `mbgl::FileSource` interface instead.
+
+  Breaking code example:
+  `std::shared_ptr<OnlineFileSource> onlineSource = std::static_pointer_cast<OnlineFileSource>(FileSourceManager::get()->getFileSource(..));`
+
+  Possible fix:
+  `std::shared_ptr<FileSource> onlineSource = FileSourceManager::get()->getFileSource(..);`
 
 ## maps-v1.2.0 (2020.02-release-vanillashake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/logging.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/noncopyable.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/optional.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/util/pass_types.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/platform.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/premultiply.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/projection.hpp

--- a/bin/cache.cpp
+++ b/bin/cache.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
     }
 
     mbgl::util::RunLoop loop;
-    auto dbfs = mbgl::FileSourceManager::get()->getFileSource(
+    std::shared_ptr<mbgl::FileSource> dbfs = mbgl::FileSourceManager::get()->getFileSource(
         mbgl::FileSourceType::Database, mbgl::ResourceOptions().withCachePath(args::get(cacheValue)));
     dbfs->forward(resource, response, [&loop] { loop.stop(); });
     loop.run();

--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -163,10 +163,10 @@ int main(int argc, char *argv[]) {
 
 
     util::RunLoop loop;
-    std::shared_ptr<DatabaseFileSource> fileSource =
-        std::static_pointer_cast<DatabaseFileSource>(FileSourceManager::get()->getFileSource(
+    std::shared_ptr<DatabaseFileSource> fileSource = std::static_pointer_cast<DatabaseFileSource>(
+        std::shared_ptr<FileSource>(FileSourceManager::get()->getFileSource(
             FileSourceType::Database,
-            ResourceOptions().withAccessToken(token).withBaseURL(apiBaseURL).withCachePath(output)));
+            ResourceOptions().withAccessToken(token).withBaseURL(apiBaseURL).withCachePath(output))));
 
     std::unique_ptr<OfflineRegion> region;
 

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mbgl/util/pass_types.hpp>
+
 #include <mapbox/weak.hpp>
 
 #include <functional>
@@ -8,23 +10,6 @@
 namespace mbgl {
 
 class Mailbox;
-
-// Using this type as a return type enforces the client to retain the returned object.
-// TODO:  Move to a separate file if/when other clients for this aux API turn up.
-template <typename T>
-class Pass {
-public:
-    Pass(T&& obj_) : obj(std::forward<T>(obj_)) {}
-    Pass(Pass&&) = default;
-    Pass(const Pass&) = delete;
-    operator T() && { return std::move(obj); }
-
-private:
-    T obj;
-};
-
-template <typename T>
-using PassRefPtr = Pass<std::shared_ptr<T>>;
 
 /*
     A `Scheduler` is responsible for coordinating the processing of messages by

--- a/include/mbgl/storage/file_source.hpp
+++ b/include/mbgl/storage/file_source.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/storage/resource_transform.hpp>
 #include <mbgl/storage/response.hpp>
 
 #include <mapbox/value.hpp>
@@ -79,6 +80,9 @@ public:
      */
     virtual void setProperty(const std::string&, const mapbox::base::Value&){};
     virtual mapbox::base::Value getProperty(const std::string&) const { return {}; };
+
+    // When supported, sets the modifier of the requested resources.
+    virtual void setResourceTransform(ResourceTransform) {}
 
 protected:
     FileSource() = default;

--- a/include/mbgl/storage/file_source_manager.hpp
+++ b/include/mbgl/storage/file_source_manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/storage/file_source.hpp>
+#include <mbgl/util/pass_types.hpp>
 
 namespace mbgl {
 
@@ -29,7 +30,7 @@ public:
     // Returns shared instance of a file source for (type, options) tuple.
     // Creates new instance via registered factory if needed. If new instance cannot be
     // created, nullptr would be returned.
-    std::shared_ptr<FileSource> getFileSource(FileSourceType, const ResourceOptions&) noexcept;
+    PassRefPtr<FileSource> getFileSource(FileSourceType, const ResourceOptions&) noexcept;
 
     // Registers file source factory for a provided FileSourceType type. If factory for the
     // same type was already registered, will unregister previously registered factory.

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -10,6 +10,7 @@ public:
     OnlineFileSource();
     ~OnlineFileSource() override;
 
+private:
     // FileSource overrides
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
     bool canRequest(const Resource&) const override;
@@ -19,7 +20,6 @@ public:
     mapbox::base::Value getProperty(const std::string&) const override;
     void setResourceTransform(ResourceTransform) override;
 
-private:
     class Impl;
     const std::unique_ptr<Impl> impl;
 };

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -5,8 +5,6 @@
 
 namespace mbgl {
 
-class ResourceTransform;
-
 class OnlineFileSource : public FileSource {
 public:
     OnlineFileSource();
@@ -19,10 +17,7 @@ public:
     void resume() override;
     void setProperty(const std::string&, const mapbox::base::Value&) override;
     mapbox::base::Value getProperty(const std::string&) const override;
-
-    // OnlineFileSource interface.
-    // TODO: Would be nice to drop it to get uniform interface.
-    virtual void setResourceTransform(ResourceTransform);
+    void setResourceTransform(ResourceTransform) override;
 
 private:
     class Impl;

--- a/include/mbgl/util/pass_types.hpp
+++ b/include/mbgl/util/pass_types.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 template <typename T>
 class Pass {
 public:
-    Pass(T&& obj_) : obj(std::forward<T>(obj_)) {}
+    Pass(T obj_) : obj(std::move(obj_)) {}
     Pass(Pass&&) noexcept = default;
     Pass(const Pass&) = delete;
     Pass& operator=(const Pass&) = delete;

--- a/include/mbgl/util/pass_types.hpp
+++ b/include/mbgl/util/pass_types.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+
+namespace mbgl {
+
+// Using this type as a return type enforces the client to retain the returned object.
+template <typename T>
+class Pass {
+public:
+    Pass(T&& obj_) : obj(std::forward<T>(obj_)) {}
+    Pass(Pass&&) noexcept = default;
+    Pass(const Pass&) = delete;
+    Pass& operator=(const Pass&) = delete;
+    operator T() && { return std::move(obj); }
+
+private:
+    T obj;
+};
+
+template <typename T>
+using PassRefPtr = Pass<std::shared_ptr<T>>;
+
+} // namespace mbgl

--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -43,8 +43,7 @@ FileSource::FileSource(jni::JNIEnv& _env, const jni::String& accessToken, const 
         mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, resourceOptions);
     databaseSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(
         mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions)));
-    onlineSource = std::static_pointer_cast<mbgl::OnlineFileSource>(std::shared_ptr<mbgl::FileSource>(
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions)));
+    onlineSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions);
 }
 
 FileSource::~FileSource() {

--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -41,10 +41,10 @@ FileSource::FileSource(jni::JNIEnv& _env, const jni::String& accessToken, const 
     // TODO: Split Android FileSource API to smaller interfaces
     resourceLoader =
         mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, resourceOptions);
-    databaseSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions));
-    onlineSource = std::static_pointer_cast<mbgl::OnlineFileSource>(
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions));
+    databaseSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(
+        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions)));
+    onlineSource = std::static_pointer_cast<mbgl::OnlineFileSource>(std::shared_ptr<mbgl::FileSource>(
+        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions)));
 }
 
 FileSource::~FileSource() {

--- a/platform/android/src/file_source.hpp
+++ b/platform/android/src/file_source.hpp
@@ -75,7 +75,7 @@ private:
     std::unique_ptr<Actor<ResourceTransform::TransformCallback>> resourceTransform;
     std::function<void()> pathChangeCallback;
     std::shared_ptr<mbgl::DatabaseFileSource> databaseSource;
-    std::shared_ptr<mbgl::OnlineFileSource> onlineSource;
+    std::shared_ptr<mbgl::FileSource> onlineSource;
     std::shared_ptr<mbgl::FileSource> resourceLoader;
 };
 

--- a/platform/android/src/offline/offline_manager.cpp
+++ b/platform/android/src/offline/offline_manager.cpp
@@ -25,8 +25,9 @@ void handleException(std::exception_ptr exception,
 
 // OfflineManager //
 OfflineManager::OfflineManager(jni::JNIEnv& env, const jni::Object<FileSource>& jFileSource)
-    : fileSource(std::static_pointer_cast<mbgl::DatabaseFileSource>(mbgl::FileSourceManager::get()->getFileSource(
-          mbgl::FileSourceType::Database, FileSource::getSharedResourceOptions(env, jFileSource)))) {
+    : fileSource(std::static_pointer_cast<mbgl::DatabaseFileSource>(
+          std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(
+              mbgl::FileSourceType::Database, FileSource::getSharedResourceOptions(env, jFileSource))))) {
     if (!fileSource) {
         ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"), "Offline functionality is disabled.");
     }

--- a/platform/android/src/offline/offline_region.cpp
+++ b/platform/android/src/offline/offline_region.cpp
@@ -16,8 +16,9 @@ namespace android {
 
 OfflineRegion::OfflineRegion(jni::JNIEnv& env, jni::jlong offlineRegionPtr, const jni::Object<FileSource>& jFileSource)
     : region(reinterpret_cast<mbgl::OfflineRegion*>(offlineRegionPtr)),
-      fileSource(std::static_pointer_cast<mbgl::DatabaseFileSource>(mbgl::FileSourceManager::get()->getFileSource(
-          mbgl::FileSourceType::Database, FileSource::getSharedResourceOptions(env, jFileSource)))) {
+      fileSource(std::static_pointer_cast<mbgl::DatabaseFileSource>(
+          std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(
+              mbgl::FileSourceType::Database, FileSource::getSharedResourceOptions(env, jFileSource))))) {
     if (!fileSource) {
         ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"), "Offline functionality is disabled.");
     }

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -46,7 +46,7 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
 
 @property (nonatomic, strong, readwrite) NSMutableArray<MGLOfflinePack *> *packs;
 @property (nonatomic) std::shared_ptr<mbgl::DatabaseFileSource> mbglDatabaseFileSource;
-@property (nonatomic) std::shared_ptr<mbgl::OnlineFileSource> mbglOnlineFileSource;
+@property (nonatomic) std::shared_ptr<mbgl::FileSource> mbglOnlineFileSource;
 @property (nonatomic) std::shared_ptr<mbgl::FileSource> mbglFileSource;
 @property (nonatomic) std::string mbglCachePath;
 @property (nonatomic, getter=isPaused) BOOL paused;
@@ -233,7 +233,7 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
         options.withCachePath(_mbglCachePath)
                .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
         _mbglFileSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, options);
-        _mbglOnlineFileSource = std::static_pointer_cast<mbgl::OnlineFileSource>(std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, options)));
+        _mbglOnlineFileSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, options);
         _mbglDatabaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, options)));
 
         // Observe for changes to the API base URL (and find out the current one).

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -233,8 +233,8 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
         options.withCachePath(_mbglCachePath)
                .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
         _mbglFileSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, options);
-        _mbglOnlineFileSource = std::static_pointer_cast<mbgl::OnlineFileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, options));
-        _mbglDatabaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, options));
+        _mbglOnlineFileSource = std::static_pointer_cast<mbgl::OnlineFileSource>(std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, options)));
+        _mbglDatabaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, options)));
 
         // Observe for changes to the API base URL (and find out the current one).
         [[MGLAccountManager sharedManager] addObserver:self

--- a/platform/darwin/src/MGLOfflineStorage_Private.h
+++ b/platform/darwin/src/MGLOfflineStorage_Private.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The shared online file source object owned by the shared offline storage object.
  */
-@property (nonatomic) std::shared_ptr<mbgl::OnlineFileSource> mbglOnlineFileSource;
+@property (nonatomic) std::shared_ptr<mbgl::FileSource> mbglOnlineFileSource;
 
 /**
  The shared resource loader file source object owned by the shared offline storage object.

--- a/platform/default/src/mbgl/storage/file_source_manager.cpp
+++ b/platform/default/src/mbgl/storage/file_source_manager.cpp
@@ -27,7 +27,7 @@ public:
                                   [](const ResourceOptions&) { return std::make_unique<LocalFileSource>(); });
 
         registerFileSourceFactory(FileSourceType::Network, [](const ResourceOptions& options) {
-            auto networkSource = std::make_unique<OnlineFileSource>();
+            std::unique_ptr<FileSource> networkSource = std::make_unique<OnlineFileSource>();
             networkSource->setProperty(ACCESS_TOKEN_KEY, options.accessToken());
             networkSource->setProperty(API_BASE_URL_KEY, options.baseURL());
             return networkSource;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[]) {
     mbgl::ResourceOptions resourceOptions;
     resourceOptions.withCachePath(cacheDB).withAccessToken(token);
 
-    auto onlineFileSource =
+    std::shared_ptr<mbgl::FileSource> onlineFileSource =
         mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions);
     if (!settings.online) {
         if (onlineFileSource) {
@@ -165,7 +165,7 @@ int main(int argc, char *argv[]) {
     });
 
     // Resource loader controls top-level request processing and can resume / pause all managed sources simultaneously.
-    auto resourceLoader =
+    std::shared_ptr<mbgl::FileSource> resourceLoader =
         mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, resourceOptions);
     view->setPauseResumeCallback([resourceLoader]() {
         static bool isPaused = false;
@@ -180,8 +180,8 @@ int main(int argc, char *argv[]) {
     });
 
     // Database file source.
-    auto databaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions));
+    auto databaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(
+        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions)));
     view->setResetCacheCallback([databaseFileSource]() {
         databaseFileSource->resetDatabase([](std::exception_ptr ex) {
             if (ex) {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1751,7 +1751,8 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
                                                mbgl::ResourceTransform::FinishedCallback onFinished) {
              actorRef.invoke(&mbgl::ResourceTransform::TransformCallback::operator(), kind, url, std::move(onFinished));
          }};
-         auto fs = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions);
+         std::shared_ptr<mbgl::FileSource> fs =
+             mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions);
          std::static_pointer_cast<mbgl::OnlineFileSource>(fs)->setResourceTransform(std::move(transform));
      }
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1753,7 +1753,7 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
          }};
          std::shared_ptr<mbgl::FileSource> fs =
              mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions);
-         std::static_pointer_cast<mbgl::OnlineFileSource>(fs)->setResourceTransform(std::move(transform));
+         fs->setResourceTransform(std::move(transform));
      }
 
     // Needs to be Queued to give time to discard redundant draw calls via the `renderQueued` flag.

--- a/render-test/file_source.cpp
+++ b/render-test/file_source.cpp
@@ -19,7 +19,7 @@ ProxyFileSource::ProxyFileSource(std::shared_ptr<FileSource> defaultResourceLoad
     : defaultResourceLoader(std::move(defaultResourceLoader_)) {
     assert(defaultResourceLoader);
     if (offline) {
-        auto dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, options);
+        std::shared_ptr<FileSource> dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, options);
         dbfs->setProperty(READ_ONLY_MODE_KEY, true);
     }
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -33,7 +33,9 @@ Map::Map(RendererFrontend& frontend,
     : impl(std::make_unique<Impl>(
           frontend,
           observer,
-          FileSourceManager::get() ? FileSourceManager::get()->getFileSource(ResourceLoader, resourceOptions) : nullptr,
+          FileSourceManager::get()
+              ? std::shared_ptr<FileSource>(FileSourceManager::get()->getFileSource(ResourceLoader, resourceOptions))
+              : nullptr,
           mapOptions)) {}
 
 Map::Map(std::unique_ptr<Impl> impl_) : impl(std::move(impl_)) {}

--- a/src/mbgl/storage/file_source_manager.cpp
+++ b/src/mbgl/storage/file_source_manager.cpp
@@ -30,8 +30,7 @@ FileSourceManager::FileSourceManager() : impl(std::make_unique<Impl>()) {}
 
 FileSourceManager::~FileSourceManager() = default;
 
-std::shared_ptr<FileSource> FileSourceManager::getFileSource(FileSourceType type,
-                                                             const ResourceOptions& options) noexcept {
+PassRefPtr<FileSource> FileSourceManager::getFileSource(FileSourceType type, const ResourceOptions& options) noexcept {
     std::lock_guard<std::recursive_mutex> lock(impl->mutex);
 
     // Remove released file sources.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/util/merge_lines.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/number_conversions.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/offscreen_texture.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/util/pass.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/position.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/projection.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/run_loop.test.cpp

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -342,7 +342,8 @@ TEST(Map, Offline) {
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
     const std::string prefix = "http://127.0.0.1:3000/";
-    auto dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
+    std::shared_ptr<FileSource> dbfs =
+        FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
     dbfs->forward(Resource::style(prefix + "style.json"), expiredItem("style.json"));
     dbfs->forward(Resource::source(prefix + "streets.json"), expiredItem("streets.json"));
     dbfs->forward(Resource::spriteJSON(prefix + "sprite", 1.0), expiredItem("sprite.json"));
@@ -882,7 +883,8 @@ TEST(Map, NoContentTiles) {
     Response response;
     response.noContent = true;
     response.expires = util::now() + 1h;
-    auto dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
+    std::shared_ptr<FileSource> dbfs =
+        FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
     dbfs->forward(
         Resource::tile("http://example.com/{z}-{x}-{y}.vector.pbf", 1.0, 0, 0, 0, Tileset::Scheme::XYZ), response, [&] {
             test.map.getStyle().loadJSON(R"STYLE({
@@ -1327,7 +1329,8 @@ TEST(Map, TEST_REQUIRES_SERVER(ExpiredSpriteSheet)) {
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
     const std::string prefix = "http://127.0.0.1:3000/online/";
-    auto dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
+    std::shared_ptr<FileSource> dbfs =
+        FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
     dbfs->forward(Resource::style(prefix + "style.json"), makeResponse("style.json"));
     dbfs->forward(Resource::source(prefix + "streets.json"), makeResponse("streets.json"));
     dbfs->forward(Resource::spriteJSON(prefix + "sprite", 1.0), makeResponse("sprite.json", true));

--- a/test/src/mbgl/test/fake_file_source.hpp
+++ b/test/src/mbgl/test/fake_file_source.hpp
@@ -75,10 +75,10 @@ public:
     }
 
     mapbox::base::Value getProperty(const std::string& property) const override {
-        return onlineFs.getProperty(property);
+        return onlineFs->getProperty(property);
     }
 
-    OnlineFileSource onlineFs;
+    std::unique_ptr<FileSource> onlineFs = std::make_unique<OnlineFileSource>();
 };
 
 } // namespace mbgl

--- a/test/storage/database_file_source.test.cpp
+++ b/test/storage/database_file_source.test.cpp
@@ -12,7 +12,8 @@ using namespace mbgl;
 TEST(DatabaseFileSource, PauseResume) {
     util::RunLoop loop;
 
-    auto dbfs = FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
+    std::shared_ptr<FileSource> dbfs =
+        FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
     dbfs->pause();
 
     const Resource res{Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::LoadingMethod::CacheOnly};

--- a/test/storage/main_resource_loader.test.cpp
+++ b/test/storage/main_resource_loader.test.cpp
@@ -530,9 +530,8 @@ TEST(MainResourceLoader, TEST_REQUIRES_SERVER(NoCacheRefreshModifiedModified)) {
 TEST(MainResourceLoader, TEST_REQUIRES_SERVER(SetResourceTransform)) {
     util::RunLoop loop;
     MainResourceLoader resourceLoader(ResourceOptions{});
-    std::shared_ptr<FileSource> fs =
+    std::shared_ptr<FileSource> onlinefs =
         FileSourceManager::get()->getFileSource(FileSourceType::Network, ResourceOptions{});
-    auto onlinefs = std::static_pointer_cast<OnlineFileSource>(fs);
 
     // Translates the URL "localhost://test to http://127.0.0.1:3000/test
     Actor<ResourceTransform::TransformCallback> transform(

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -14,25 +14,23 @@ using namespace mbgl;
 
 TEST(OnlineFileSource, Cancel) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, [&](Response) {
-        ADD_FAILURE() << "Callback should not be called";
-    });
+    fs->request({Resource::Unknown, "http://127.0.0.1:3000/test"},
+                [&](Response) { ADD_FAILURE() << "Callback should not be called"; });
 
     loop.runOnce();
 }
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(CancelMultiple)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
-    std::unique_ptr<AsyncRequest> req2 = fs.request(resource, [&](Response) {
-        ADD_FAILURE() << "Callback should not be called";
-    });
-    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req2 =
+        fs->request(resource, [&](Response) { ADD_FAILURE() << "Callback should not be called"; });
+    std::unique_ptr<AsyncRequest> req = fs->request(resource, [&](Response res) {
         req.reset();
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
@@ -50,38 +48,38 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(CancelMultiple)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(TemporaryError)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     const auto start = Clock::now();
     int counter = 0;
 
-    auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/temporary-error" }, [&](Response res) {
+    auto req = fs->request({Resource::Unknown, "http://127.0.0.1:3000/temporary-error"}, [&](Response res) {
         switch (counter++) {
-        case 0: {
-            const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();
-            EXPECT_GT(0.2, duration) << "Initial error request took too long";
-            ASSERT_NE(nullptr, res.error);
-            EXPECT_EQ(Response::Error::Reason::Server, res.error->reason);
-            EXPECT_EQ("HTTP status code 500", res.error->message);
-            ASSERT_FALSE(bool(res.data));
-            EXPECT_FALSE(bool(res.expires));
-            EXPECT_FALSE(res.mustRevalidate);
-            EXPECT_FALSE(bool(res.modified));
-            EXPECT_FALSE(bool(res.etag));
-        } break;
-        case 1: {
-            const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();
-            EXPECT_LT(0.99, duration) << "Backoff timer didn't wait 1 second";
-            EXPECT_GT(1.2, duration) << "Backoff timer fired too late";
-            EXPECT_EQ(nullptr, res.error);
-            ASSERT_TRUE(res.data.get());
-            EXPECT_EQ("Hello World!", *res.data);
-            EXPECT_FALSE(bool(res.expires));
-            EXPECT_FALSE(res.mustRevalidate);
-            EXPECT_FALSE(bool(res.modified));
-            EXPECT_FALSE(bool(res.etag));
-            loop.stop();
-        } break;
+            case 0: {
+                const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();
+                EXPECT_GT(0.2, duration) << "Initial error request took too long";
+                ASSERT_NE(nullptr, res.error);
+                EXPECT_EQ(Response::Error::Reason::Server, res.error->reason);
+                EXPECT_EQ("HTTP status code 500", res.error->message);
+                ASSERT_FALSE(bool(res.data));
+                EXPECT_FALSE(bool(res.expires));
+                EXPECT_FALSE(res.mustRevalidate);
+                EXPECT_FALSE(bool(res.modified));
+                EXPECT_FALSE(bool(res.etag));
+            } break;
+            case 1: {
+                const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();
+                EXPECT_LT(0.99, duration) << "Backoff timer didn't wait 1 second";
+                EXPECT_GT(1.2, duration) << "Backoff timer fired too late";
+                EXPECT_EQ(nullptr, res.error);
+                ASSERT_TRUE(res.data.get());
+                EXPECT_EQ("Hello World!", *res.data);
+                EXPECT_FALSE(bool(res.expires));
+                EXPECT_FALSE(res.mustRevalidate);
+                EXPECT_FALSE(bool(res.modified));
+                EXPECT_FALSE(bool(res.etag));
+                loop.stop();
+            } break;
         }
     });
 
@@ -90,13 +88,13 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(TemporaryError)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(ConnectionError)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     const auto start = Clock::now();
     int counter = 0;
     int wait = 0;
 
-    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3001/" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs->request({Resource::Unknown, "http://127.0.0.1:3001/"}, [&](Response res) {
         const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();
         EXPECT_LT(wait - 0.01, duration) << "Backoff timer didn't wait 1 second";
         EXPECT_GT(wait + 0.3, duration) << "Backoff timer fired too late";
@@ -121,12 +119,12 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(ConnectionError)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Timeout)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     int counter = 0;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=1" };
-    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs->request(resource, [&](Response res) {
         counter++;
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
@@ -148,12 +146,12 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Timeout)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryDelayOnExpiredTile)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     int counter = 0;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test?expires=10000" };
-    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs->request(resource, [&](Response res) {
         counter++;
         EXPECT_EQ(nullptr, res.error);
         EXPECT_GT(util::now(), *res.expires);
@@ -168,27 +166,27 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryDelayOnExpiredTile)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryOnClockSkew)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     int counter = 0;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/clockskew" };
-    std::unique_ptr<AsyncRequest> req1 = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req1 = fs->request(resource, [&](Response res) {
         EXPECT_FALSE(res.mustRevalidate);
         switch (counter++) {
-        case 0: {
-            EXPECT_EQ(nullptr, res.error);
-            EXPECT_GT(util::now(), *res.expires);
-        } break;
-        case 1: {
-            EXPECT_EQ(nullptr, res.error);
+            case 0: {
+                EXPECT_EQ(nullptr, res.error);
+                EXPECT_GT(util::now(), *res.expires);
+            } break;
+            case 1: {
+                EXPECT_EQ(nullptr, res.error);
 
-            auto now = util::now();
-            EXPECT_LT(now + Seconds(40), *res.expires) << "Expiration not interpolated to 60s";
-            EXPECT_GT(now + Seconds(80), *res.expires) << "Expiration not interpolated to 60s";
+                auto now = util::now();
+                EXPECT_LT(now + Seconds(40), *res.expires) << "Expiration not interpolated to 60s";
+                EXPECT_GT(now + Seconds(80), *res.expires) << "Expiration not interpolated to 60s";
 
-            loop.stop();
-        } break;
+                loop.stop();
+            } break;
         }
     });
 
@@ -197,37 +195,31 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RetryOnClockSkew)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectPriorExpires)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     // Very long expiration time, should never arrive.
     Resource resource1{ Resource::Unknown, "http://127.0.0.1:3000/test" };
     resource1.priorExpires = util::now() + Seconds(100000);
 
-    std::unique_ptr<AsyncRequest> req1 = fs.request(resource1, [&](Response) {
-        FAIL() << "Should never be called";
-    });
+    std::unique_ptr<AsyncRequest> req1 = fs->request(resource1, [&](Response) { FAIL() << "Should never be called"; });
 
     // No expiration time, should be requested immediately.
     Resource resource2{ Resource::Unknown, "http://127.0.0.1:3000/test" };
 
-    std::unique_ptr<AsyncRequest> req2 = fs.request(resource2, [&](Response) {
-        loop.stop();
-    });
+    std::unique_ptr<AsyncRequest> req2 = fs->request(resource2, [&](Response) { loop.stop(); });
 
     // Very long expiration time, should never arrive.
     Resource resource3{ Resource::Unknown, "http://127.0.0.1:3000/test" };
     resource3.priorExpires = util::now() + Seconds(100000);
 
-    std::unique_ptr<AsyncRequest> req3 = fs.request(resource3, [&](Response) {
-        FAIL() << "Should never be called";
-    });
+    std::unique_ptr<AsyncRequest> req3 = fs->request(resource3, [&](Response) { FAIL() << "Should never be called"; });
 
     loop.run();
 }
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Load)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     const int concurrency = 50;
     const int max = 10000;
@@ -237,24 +229,23 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Load)) {
 
     std::function<void(int)> req = [&](int i) {
         const auto current = number++;
-        reqs[i] = fs.request({ Resource::Unknown,
-                     std::string("http://127.0.0.1:3000/load/") + util::toString(current) },
-                   [&, i, current](Response res) {
-            reqs[i].reset();
-            EXPECT_EQ(nullptr, res.error);
-            ASSERT_TRUE(res.data.get());
-            EXPECT_EQ(std::string("Request ") +  util::toString(current), *res.data);
-            EXPECT_FALSE(bool(res.expires));
-            EXPECT_FALSE(res.mustRevalidate);
-            EXPECT_FALSE(bool(res.modified));
-            EXPECT_FALSE(bool(res.etag));
+        reqs[i] = fs->request({Resource::Unknown, std::string("http://127.0.0.1:3000/load/") + util::toString(current)},
+                              [&, i, current](Response res) {
+                                  reqs[i].reset();
+                                  EXPECT_EQ(nullptr, res.error);
+                                  ASSERT_TRUE(res.data.get());
+                                  EXPECT_EQ(std::string("Request ") + util::toString(current), *res.data);
+                                  EXPECT_FALSE(bool(res.expires));
+                                  EXPECT_FALSE(res.mustRevalidate);
+                                  EXPECT_FALSE(bool(res.modified));
+                                  EXPECT_FALSE(bool(res.etag));
 
-            if (number <= max) {
-                req(i);
-            } else if (current == max) {
-                loop.stop();
-            }
-        });
+                                  if (number <= max) {
+                                      req(i);
+                                  } else if (current == max) {
+                                      loop.stop();
+                                  }
+                              });
     };
 
     for (int i = 0; i < concurrency; i++) {
@@ -272,21 +263,21 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(Load)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChange)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/delayed" };
 
     // This request takes 200 milliseconds to answer.
-    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
-         req.reset();
-         EXPECT_EQ(nullptr, res.error);
-         ASSERT_TRUE(res.data.get());
-         EXPECT_EQ("Response", *res.data);
-         EXPECT_FALSE(bool(res.expires));
-         EXPECT_FALSE(res.mustRevalidate);
-         EXPECT_FALSE(bool(res.modified));
-         EXPECT_FALSE(bool(res.etag));
-         loop.stop();
+    std::unique_ptr<AsyncRequest> req = fs->request(resource, [&](Response res) {
+        req.reset();
+        EXPECT_EQ(nullptr, res.error);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Response", *res.data);
+        EXPECT_FALSE(bool(res.expires));
+        EXPECT_FALSE(res.mustRevalidate);
+        EXPECT_FALSE(bool(res.modified));
+        EXPECT_FALSE(bool(res.etag));
+        loop.stop();
     });
 
     // After 50 milliseconds, we're going to trigger a NetworkStatus change.
@@ -302,14 +293,14 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChange)) {
 // reachability issues.
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChangePreempt)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
-    fs.pause();
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
+    fs->pause();
 
     const auto start = Clock::now();
     int counter = 0;
 
     const Resource resource{ Resource::Unknown, "http://127.0.0.1:3001/test" };
-    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs->request(resource, [&](Response res) {
         const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();
         if (counter == 0) {
             EXPECT_GT(0.2, duration) << "Response came in too late";
@@ -339,13 +330,13 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusChangePreempt)) {
         mbgl::NetworkStatus::Reachable();
     });
 
-    fs.resume();
+    fs->resume();
     loop.run();
 }
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusOnlineOffline)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
@@ -357,7 +348,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusOnlineOffline)) {
         NetworkStatus::Set(NetworkStatus::Status::Online);
     });
 
-    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs->request(resource, [&](Response res) {
         req.reset();
 
         EXPECT_EQ(nullptr, res.error);
@@ -373,9 +364,9 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(NetworkStatusOnlineOffline)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitStandard)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
-    auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/rate-limit?std=true" }, [&](Response res) {
+    auto req = fs->request({Resource::Unknown, "http://127.0.0.1:3000/rate-limit?std=true"}, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::RateLimit, res.error->reason);
         ASSERT_EQ(true, bool(res.error->retryAfter));
@@ -388,9 +379,9 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitStandard)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitMBX)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
-    auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/rate-limit?mbx=true" }, [&](Response res) {
+    auto req = fs->request({Resource::Unknown, "http://127.0.0.1:3000/rate-limit?mbx=true"}, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::RateLimit, res.error->reason);
         ASSERT_EQ(true, bool(res.error->retryAfter));
@@ -403,9 +394,9 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitMBX)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitDefault)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
-    auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/rate-limit" }, [&](Response res) {
+    auto req = fs->request({Resource::Unknown, "http://127.0.0.1:3000/rate-limit"}, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::RateLimit, res.error->reason);
         ASSERT_FALSE(res.error->retryAfter);
@@ -417,46 +408,46 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitDefault)) {
 
 TEST(OnlineFileSource, GetBaseURLAndAccessTokenWhilePaused) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
-    fs.pause();
+    fs->pause();
 
     auto baseURL = "http://url";
     auto accessToken = "access_token";
 
-    fs.setProperty(API_BASE_URL_KEY, baseURL);
-    fs.setProperty(ACCESS_TOKEN_KEY, accessToken);
+    fs->setProperty(API_BASE_URL_KEY, baseURL);
+    fs->setProperty(ACCESS_TOKEN_KEY, accessToken);
 
-    EXPECT_EQ(*fs.getProperty(API_BASE_URL_KEY).getString(), baseURL);
-    EXPECT_EQ(*fs.getProperty(ACCESS_TOKEN_KEY).getString(), accessToken);
+    EXPECT_EQ(*fs->getProperty(API_BASE_URL_KEY).getString(), baseURL);
+    EXPECT_EQ(*fs->getProperty(ACCESS_TOKEN_KEY).getString(), accessToken);
 }
 
 TEST(OnlineFileSource, ChangeAPIBaseURL){
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
-    EXPECT_EQ(mbgl::util::API_BASE_URL, *fs.getProperty(API_BASE_URL_KEY).getString());
+    EXPECT_EQ(mbgl::util::API_BASE_URL, *fs->getProperty(API_BASE_URL_KEY).getString());
     const std::string customURL = "test.domain";
-    fs.setProperty(API_BASE_URL_KEY, customURL);
-    EXPECT_EQ(customURL, *fs.getProperty(API_BASE_URL_KEY).getString());
+    fs->setProperty(API_BASE_URL_KEY, customURL);
+    EXPECT_EQ(customURL, *fs->getProperty(API_BASE_URL_KEY).getString());
 }
 
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
     std::size_t response_counter = 0;
     const std::size_t NUM_REQUESTS = 3;
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
-    fs.setProperty(MAX_CONCURRENT_REQUESTS_KEY, 1u);
+    fs->setProperty(MAX_CONCURRENT_REQUESTS_KEY, 1u);
     // After DefaultFileSource was split, OnlineFileSource lives on a separate
     // thread. Pause OnlineFileSource, so that messages are queued for processing.
-    fs.pause();
+    fs->pause();
 
     // First regular request.
     Resource regular1{Resource::Unknown, "http://127.0.0.1:3000/load/1"};
-    std::unique_ptr<AsyncRequest> req_0 = fs.request(regular1, [&](Response) {
+    std::unique_ptr<AsyncRequest> req_0 = fs->request(regular1, [&](Response) {
         response_counter++;
         req_0.reset();
     });
@@ -464,7 +455,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
     // Low priority request that will be queued and should be requested last.
     Resource low_prio{Resource::Unknown, "http://127.0.0.1:3000/load/2"};
     low_prio.setPriority(Resource::Priority::Low);
-    std::unique_ptr<AsyncRequest> req_1 = fs.request(low_prio, [&](Response) {
+    std::unique_ptr<AsyncRequest> req_1 = fs->request(low_prio, [&](Response) {
         response_counter++;
         req_1.reset();
         EXPECT_EQ(response_counter, NUM_REQUESTS); // make sure this is responded last
@@ -473,12 +464,12 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
 
     // Second regular priority request that should de-preoritize low priority request.
     Resource regular2{ Resource::Unknown, "http://127.0.0.1:3000/load/3" };
-    std::unique_ptr<AsyncRequest> req_2 = fs.request(regular2, [&](Response) {
+    std::unique_ptr<AsyncRequest> req_2 = fs->request(regular2, [&](Response) {
         response_counter++;
         req_2.reset();
     });
 
-    fs.resume();
+    fs->resume();
     NetworkStatus::Set(NetworkStatus::Status::Online);
     loop.run();
 }
@@ -486,33 +477,34 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequests)) {
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
     int response_counter = 0;
     int correct_low = 0;
     int correct_regular = 0;
 
     NetworkStatus::Set(NetworkStatus::Status::Offline);
-    fs.setProperty(MAX_CONCURRENT_REQUESTS_KEY, 1u);
-    fs.pause();
+    fs->setProperty(MAX_CONCURRENT_REQUESTS_KEY, 1u);
+    fs->pause();
 
     std::vector<std::unique_ptr<AsyncRequest>> collector;
 
     for (int num_reqs = 0; num_reqs < 20; num_reqs++) {
         if (num_reqs % 2 == 0) {
-            std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/load/" + std::to_string(num_reqs) }, [&](Response) {
-                response_counter++;
+            std::unique_ptr<AsyncRequest> req = fs->request(
+                {Resource::Unknown, "http://127.0.0.1:3000/load/" + std::to_string(num_reqs)}, [&](Response) {
+                    response_counter++;
 
-                if (response_counter <= 10) { // count the high priority requests that arrive late correctly
-                    correct_regular++;
-                }
-            });
+                    if (response_counter <= 10) { // count the high priority requests that arrive late correctly
+                        correct_regular++;
+                    }
+                });
             collector.push_back(std::move(req));
         }
         else {
             Resource resource = { Resource::Unknown, "http://127.0.0.1:3000/load/" + std::to_string(num_reqs) };
             resource.setPriority(Resource::Priority::Low);
 
-            std::unique_ptr<AsyncRequest> req = fs.request(std::move(resource), [&](Response) {
+            std::unique_ptr<AsyncRequest> req = fs->request(std::move(resource), [&](Response) {
                 response_counter++;
 
                 if (response_counter > 10) { // count the low priority requests that arrive late correctly
@@ -533,30 +525,30 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(LowHighPriorityRequestsMany)) {
         }
     }
 
-    fs.resume();
+    fs->resume();
     NetworkStatus::Set(NetworkStatus::Status::Online);
     loop.run();
 }
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(MaximumConcurrentRequests)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
-    ASSERT_EQ(*fs.getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), 20u);
+    ASSERT_EQ(*fs->getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), 20u);
 
-    fs.setProperty(MAX_CONCURRENT_REQUESTS_KEY, 10u);
-    ASSERT_EQ(*fs.getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), 10u);
+    fs->setProperty(MAX_CONCURRENT_REQUESTS_KEY, 10u);
+    ASSERT_EQ(*fs->getProperty(MAX_CONCURRENT_REQUESTS_KEY).getUint(), 10u);
 }
 
 TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RequestSameUrlMultipleTimes)) {
     util::RunLoop loop;
-    OnlineFileSource fs;
+    std::unique_ptr<FileSource> fs = std::make_unique<OnlineFileSource>();
 
     int count = 0;
     std::vector<std::unique_ptr<AsyncRequest>> requests;
 
     for (int i = 0; i < 100; ++i) {
-        requests.emplace_back(fs.request({ Resource::Unknown, "http://127.0.0.1:3000/load" }, [&](Response) {
+        requests.emplace_back(fs->request({Resource::Unknown, "http://127.0.0.1:3000/load"}, [&](Response) {
             if (++count == 100) {
                 loop.stop();
             }

--- a/test/util/pass.test.cpp
+++ b/test/util/pass.test.cpp
@@ -1,0 +1,16 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/util/pass_types.hpp>
+
+TEST(Pass, NoCopy) {
+    static int copyCount = 0;
+    struct A {
+        A() = default;
+        A(A&&) = default;
+        A(const A&) { ++copyCount; }
+        static mbgl::Pass<A> create() { return A(); }
+    };
+    A a = A::create();
+    (void)a;
+    EXPECT_EQ(0, copyCount);
+}


### PR DESCRIPTION
 - [x]  FileSourceManager::getFileSource() returns `PassRefPtr`: enforcing ownership model
 - [x]  Move `setResourceTransform()` to the parent interface, clients never access `OnlineFileSource` directly