### PR TITLE
Decouple database storage and file source APIs

### DIFF
--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -231,6 +231,7 @@ public:
     explicit DatabaseFileSource(const ResourceOptions& options);
     ~DatabaseFileSource() override;
 
+private:
     // JointDatabaseStorage overrides
     void setDatabasePath(const std::string&, std::function<void()> callback) override;
     void resetDatabase(std::function<void(std::exception_ptr)>) override;

--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -15,14 +15,6 @@ public:
     explicit DatabaseFileSource(const ResourceOptions& options);
     ~DatabaseFileSource() override;
 
-    // FileSource overrides
-    std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
-    void forward(const Resource&, const Response&, std::function<void()> callback) override;
-    bool canRequest(const Resource&) const override;
-    void setProperty(const std::string&, const mapbox::base::Value&) override;
-    void pause() override;
-    void resume() override;
-
     // Methods common to Ambient cache and Offline functionality
 
     /*
@@ -233,6 +225,14 @@ public:
     virtual void setOfflineMapboxTileCountLimit(uint64_t) const;
 
 private:
+    // FileSource overrides
+    std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
+    void forward(const Resource&, const Response&, std::function<void()> callback) override;
+    bool canRequest(const Resource&) const override;
+    void setProperty(const std::string&, const mapbox::base::Value&) override;
+    void pause() override;
+    void resume() override;
+
     class Impl;
     const std::unique_ptr<Impl> impl;
 };

--- a/include/mbgl/storage/file_source_manager.hpp
+++ b/include/mbgl/storage/file_source_manager.hpp
@@ -6,7 +6,7 @@
 namespace mbgl {
 
 class ResourceOptions;
-
+class JointDatabaseStorage;
 /**
  * @brief A singleton class responsible for managing file sources.
  *
@@ -31,6 +31,10 @@ public:
     // Creates new instance via registered factory if needed. If new instance cannot be
     // created, nullptr would be returned.
     PassRefPtr<FileSource> getFileSource(FileSourceType, const ResourceOptions&) noexcept;
+
+    // Returns shared instance of a joint database storage for the given options.
+    // Creates new instance, if needed. If new instance cannot be created, nullptr would be returned.
+    virtual PassRefPtr<JointDatabaseStorage> getDatabaseStorage(const ResourceOptions&) noexcept;
 
     // Registers file source factory for a provided FileSourceType type. If factory for the
     // same type was already registered, will unregister previously registered factory.

--- a/platform/android/src/file_source.cpp
+++ b/platform/android/src/file_source.cpp
@@ -41,8 +41,7 @@ FileSource::FileSource(jni::JNIEnv& _env, const jni::String& accessToken, const 
     // TODO: Split Android FileSource API to smaller interfaces
     resourceLoader =
         mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::ResourceLoader, resourceOptions);
-    databaseSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions)));
+    databaseStorage = mbgl::FileSourceManager::get()->getDatabaseStorage(resourceOptions);
     onlineSource = mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Network, resourceOptions);
 }
 
@@ -110,7 +109,7 @@ void FileSource::setResourceTransform(jni::JNIEnv& env, const jni::Object<FileSo
 void FileSource::setResourceCachePath(jni::JNIEnv& env,
                                       const jni::String& path,
                                       const jni::Object<FileSource::ResourcesCachePathChangeCallback>& _callback) {
-    if (!databaseSource) {
+    if (!databaseStorage) {
         ThrowNew(env, jni::FindClass(env, "java/lang/IllegalStateException"), "Offline functionality is disabled.");
         return;
     }
@@ -132,7 +131,7 @@ void FileSource::setResourceCachePath(jni::JNIEnv& env,
             pathChangeCallback = {};
         });
 
-    databaseSource->setDatabasePath(newPath + DATABASE_FILE, pathChangeCallback);
+    databaseStorage->setDatabasePath(newPath + DATABASE_FILE, pathChangeCallback);
 }
 
 void FileSource::resume(jni::JNIEnv&) {

--- a/platform/android/src/file_source.hpp
+++ b/platform/android/src/file_source.hpp
@@ -74,7 +74,7 @@ private:
     mbgl::ResourceOptions resourceOptions;
     std::unique_ptr<Actor<ResourceTransform::TransformCallback>> resourceTransform;
     std::function<void()> pathChangeCallback;
-    std::shared_ptr<mbgl::DatabaseFileSource> databaseSource;
+    std::shared_ptr<mbgl::JointDatabaseStorage> databaseStorage;
     std::shared_ptr<mbgl::FileSource> onlineSource;
     std::shared_ptr<mbgl::FileSource> resourceLoader;
 };

--- a/platform/android/src/offline/offline_manager.hpp
+++ b/platform/android/src/offline/offline_manager.hpp
@@ -104,7 +104,7 @@ public:
     void runPackDatabaseAutomatically(jni::JNIEnv&, jboolean autopack);
 
 private:
-    std::shared_ptr<mbgl::DatabaseFileSource> fileSource;
+    std::shared_ptr<JointDatabaseStorage> databaseStorage;
 };
 
 } // namespace android

--- a/platform/android/src/offline/offline_region.hpp
+++ b/platform/android/src/offline/offline_region.hpp
@@ -85,7 +85,7 @@ public:
 
 private:
     std::unique_ptr<mbgl::OfflineRegion> region;
-    std::shared_ptr<mbgl::DatabaseFileSource> fileSource;
+    std::shared_ptr<mbgl::JointDatabaseStorage> databaseStorage;
 };
 
 } // namespace android

--- a/platform/darwin/src/MGLOfflineStorage_Private.h
+++ b/platform/darwin/src/MGLOfflineStorage_Private.h
@@ -12,9 +12,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MGLOfflineStorage (Private)
 
 /**
- The shared database file source object owned by the shared offline storage object.
+ The shared database file storage object.
  */
-@property (nonatomic) std::shared_ptr<mbgl::DatabaseFileSource> mbglDatabaseFileSource;
+@property (nonatomic) std::shared_ptr<mbgl::JointDatabaseStorage> mbglDatabaseStorage;
 
 /**
  The shared online file source object owned by the shared offline storage object.

--- a/platform/default/src/mbgl/storage/file_source_manager.cpp
+++ b/platform/default/src/mbgl/storage/file_source_manager.cpp
@@ -33,6 +33,12 @@ public:
             return networkSource;
         });
     }
+
+    PassRefPtr<JointDatabaseStorage> getDatabaseStorage(const ResourceOptions& options) noexcept override {
+        auto dbFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(
+            std::shared_ptr<FileSource>(getFileSource(FileSourceType::Database, options)));
+        return std::shared_ptr<JointDatabaseStorage>(dbFileSource);
+    }
 };
 
 FileSourceManager* FileSourceManager::get() noexcept {

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -180,10 +180,11 @@ int main(int argc, char *argv[]) {
     });
 
     // Database file source.
-    auto databaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(
-        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions)));
-    view->setResetCacheCallback([databaseFileSource]() {
-        databaseFileSource->resetDatabase([](std::exception_ptr ex) {
+    std::shared_ptr<mbgl::JointDatabaseStorage> database =
+        mbgl::FileSourceManager::get()->getDatabaseStorage(resourceOptions);
+    assert(database);
+    view->setResetCacheCallback([database]() {
+        database->resetDatabase([](std::exception_ptr ex) {
             if (ex) {
                 mbgl::Log::Error(mbgl::Event::Database, "Failed to reset cache:: %s", mbgl::util::toString(ex).c_str());
             }

--- a/src/mbgl/storage/file_source_manager.cpp
+++ b/src/mbgl/storage/file_source_manager.cpp
@@ -62,6 +62,10 @@ PassRefPtr<FileSource> FileSourceManager::getFileSource(FileSourceType type, con
     return fileSource;
 }
 
+PassRefPtr<JointDatabaseStorage> FileSourceManager::getDatabaseStorage(const ResourceOptions&) noexcept {
+    return {nullptr};
+}
+
 void FileSourceManager::registerFileSourceFactory(FileSourceType type, FileSourceFactory&& factory) noexcept {
     assert(factory);
     std::lock_guard<std::recursive_mutex> lock(impl->mutex);

--- a/test/storage/main_resource_loader.test.cpp
+++ b/test/storage/main_resource_loader.test.cpp
@@ -586,10 +586,9 @@ TEST(MainResourceLoader, TEST_REQUIRES_SERVER(SetResourceTransform)) {
 TEST(MainResourceLoader, SetResourceCachePath) {
     util::RunLoop loop;
     MainResourceLoader resourceLoader(ResourceOptions{});
-    std::shared_ptr<FileSource> fs =
-        FileSourceManager::get()->getFileSource(FileSourceType::Database, ResourceOptions{});
-    auto dbfs = std::static_pointer_cast<DatabaseFileSource>(fs);
-    dbfs->setDatabasePath("./new_offline.db", [&loop] { loop.stop(); });
+    std::shared_ptr<mbgl::JointDatabaseStorage> database =
+        mbgl::FileSourceManager::get()->getDatabaseStorage(ResourceOptions{});
+    database->setDatabasePath("./new_offline.db", [&loop] { loop.stop(); });
     loop.run();
 }
 


### PR DESCRIPTION
This patches provides the following improvements:
- decouples `FileSource` implementation and the database control logic 
- introduces separate interfaces for ambient cache and offline regions storage
- introduces `FileSourceManager::getDatabaseStorage()` API returning pointer to `JointDatabaseStorage`, thus we obviate downcasting of `FileSource` to `DatabaseFileSource`