### PR TITLE
Improve behavior on getting error 404 during offline regions loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 
 - [android] Add jni binding for min and max pitch ([#16236](https://github.com/mapbox/mapbox-gl-native/pull/16236))
 
+- [offline] Offline tool does not hang on 404 error ([#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
+
+  The missing resource gets skipped and teh offline region download continues.
+
 ##### ⚠️  Breaking changes
 
 - Changes to `mbgl::FileSourceManager::getFileSource()` ([#16238](https://github.com/mapbox/mapbox-gl-native/pull/16238))

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -484,6 +484,13 @@ void OfflineDownload::ensureResource(Resource&& resource,
         *fileRequestsIt = onlineFileSource.request(resource, [=](Response onlineResponse) {
             if (onlineResponse.error) {
                 observer->responseError(*onlineResponse.error);
+                if (onlineResponse.error->reason == Response::Error::Reason::NotFound) {
+                    // On error 404, we skip this request and go further.
+                    requests.erase(fileRequestsIt);
+                    assert(status.requiredResourceCount > 0);
+                    status.requiredResourceCount--;
+                    continueDownload();
+                }
                 return;
             }
 


### PR DESCRIPTION
If error `404` turns up during offline regions loading, the behavior is changed in the following way:
- Offline download does not hang
- The error message contains URL protocol and host

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/186
Fixes https://github.com/mapbox/mapbox-gl-native/issues/15819
Fixes https://github.com/mapbox/mapbox-gl-native/issues/15932