### PR TITLE
Restore support for iOS 9–11 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   
   This is a back porting from GL JS [#9333](https://github.com/mapbox/mapbox-gl-js/pull/9333)
 
+- [ios] Restored support for iOS 9–11 by default ([#16241](https://github.com/mapbox/mapbox-gl-native/pull/16242))
+
 ### ✨ New features
 
 - [core] Add Layer::serialize() method ([#16231](https://github.com/mapbox/mapbox-gl-native/pull/16231))

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -1,5 +1,5 @@
 if(NOT DEFINED IOS_DEPLOYMENT_TARGET)
-    set(IOS_DEPLOYMENT_TARGET "12.0")
+    set(IOS_DEPLOYMENT_TARGET "9.0")
 endif()
 
 macro(initialize_ios_target target)


### PR DESCRIPTION
Reverted part of #16158, reducing the minimum deployment target back from iOS 12.0 to iOS 9.0.

Fixes #16241.

/cc @mapbox/gl-native @mapbox/maps-ios