### PR TITLE
[android] Update toGeoJSON in android_conversion.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 - [default] Fix possible crash at RunLoop::wake() ([#16255](https://github.com/mapbox/mapbox-gl-native/pull/16255))
 
+- [android] Update toGeoJSON in android_conversion.hpp [#16243](https://github.com/mapbox/mapbox-gl-native/pull/16243)
+  
+  Before this chage, `toGeoJSON` method in `android_conversion.hpp` can't convert Object(Map in android) to GeoJSON object. 
+  
+  But `within` expression need to accept an Object and then convert to GeoJSON object, now `toGeoJSON` method can convert both string and Object to GeoJSON.
+ 
 ## maps-v1.3.0 (2020.02-relvanillashake)
 
 ### 🐞 Bug fixes

--- a/platform/android/src/style/android_conversion.hpp
+++ b/platform/android/src/style/android_conversion.hpp
@@ -113,16 +113,24 @@ public:
         if (value.isNull()) {
             error = { "no json data found" };
             return {};
-        } else if (value.isString()) {
+        }
+
+        if (value.isString()) {
             return parseGeoJSON(value.toString(), error);
-        } else if (value.isObject()) {
+        }
+
+        if (value.isObject()) {
             mbgl::android::Value keys = value.keyArray();
             std::size_t length = arrayLength(keys);
             for (std::size_t i = 0; i < length; ++i) {
                 const auto k = keys.get(i).toString();
                 if (k == "json") {
-                    auto v = value.get(k.c_str());
-                    return parseGeoJSON(v.toString(), error);
+                    auto v = value.get("json");
+                    if (v.isString()) {
+                        return parseGeoJSON(v.toString(), error);
+                    } else {
+                        break;
+                    }
                 }
             }
         }

--- a/platform/android/src/style/android_conversion.hpp
+++ b/platform/android/src/style/android_conversion.hpp
@@ -110,11 +110,24 @@ public:
     }
 
     static optional<GeoJSON> toGeoJSON(const mbgl::android::Value &value, Error &error) {
-        if (value.isNull() || !value.isString()) {
+        if (value.isNull()) {
             error = { "no json data found" };
             return {};
+        } else if (value.isString()) {
+            return parseGeoJSON(value.toString(), error);
+        } else if (value.isObject()) {
+            mbgl::android::Value keys = value.keyArray();
+            std::size_t length = arrayLength(keys);
+            for (std::size_t i = 0; i < length; ++i) {
+                const auto k = keys.get(i).toString();
+                if (k == "json") {
+                    auto v = value.get(k.c_str());
+                    return parseGeoJSON(v.toString(), error);
+                }
+            }
         }
-        return parseGeoJSON(value.toString(), error);
+        error = {"no json data found"};
+        return {};
     }
 };
 

--- a/platform/android/src/style/android_conversion.hpp
+++ b/platform/android/src/style/android_conversion.hpp
@@ -123,8 +123,7 @@ public:
             mbgl::android::Value keys = value.keyArray();
             std::size_t length = arrayLength(keys);
             for (std::size_t i = 0; i < length; ++i) {
-                const auto k = keys.get(i).toString();
-                if (k == "json") {
+                if (keys.get(i).toString() == "json") {
                     auto v = value.get("json");
                     if (v.isString()) {
                         return parseGeoJSON(v.toString(), error);


### PR DESCRIPTION
The `within` expression need its parameter be an Object(map in android) and  then convert it to a Geojon object.

`toGeoJSON` method in `android_conversion.hpp` can't handle Object before and it seems not easy to convert an Object to string and then convert the string to GeoJSON object. So I put the whole json body of Polygon into the Object with key `json`. Maybe this's not a good idea, it will be nice if a better solution could be brought up。

Related pr in android sdk: https://github.com/mapbox/mapbox-gl-native-android/pull/198