### PR TITLE
[default] Fix possible crash at RunLoop::wake()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
   Fixes possible crashes when using styles with line patterns.
 
+- [default] Fix possible crash at RunLoop::wake() ([#16255](https://github.com/mapbox/mapbox-gl-native/pull/16255))
+
 ## maps-v1.3.0 (2020.02-relvanillashake)
 
 ### 🐞 Bug fixes

--- a/platform/default/src/mbgl/util/run_loop.cpp
+++ b/platform/default/src/mbgl/util/run_loop.cpp
@@ -130,7 +130,7 @@ LOOP_HANDLE RunLoop::getLoopHandle() {
 }
 
 void RunLoop::wake() {
-    impl->async->send();
+    if (impl->async) impl->async->send();
 }
 
 void RunLoop::run() {


### PR DESCRIPTION
The `runOnce()` call during run loop destruction might cause `invoke()` calls.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/16250
