### PR TITLE
[android] Add jni binding for line-sort-key and fill-sort-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   
   But `within` expression need to accept an Object and then convert to GeoJSON object, now `toGeoJSON` method can convert both string and Object to GeoJSON.
  
+### ✨ New features
+
+- [android] Add jni binding for line-sort-key and fill-sort-key ([#16256](https://github.com/mapbox/mapbox-gl-native/pull/16256))
+
+  With this change, android sdk will be able to get sort key for LineLayer and FillLayer.
+  
 ## maps-v1.3.0 (2020.02-relvanillashake)
 
 ### 🐞 Bug fixes

--- a/platform/android/src/style/layers/fill_layer.cpp
+++ b/platform/android/src/style/layers/fill_layer.cpp
@@ -41,6 +41,11 @@ namespace android {
 
     // Property getters
 
+    jni::Local<jni::Object<>> FillLayer::getFillSortKey(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillSortKey()));
+    }
+
     jni::Local<jni::Object<>> FillLayer::getFillAntialias(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillAntialias()));
@@ -172,10 +177,13 @@ namespace android {
 
         // Register the peer
         jni::RegisterNativePeer<FillLayer>(
-            env, javaClass, "nativePtr",
+            env,
+            javaClass,
+            "nativePtr",
             jni::MakePeer<FillLayer, jni::String&, jni::String&>,
             "initialize",
             "finalize",
+            METHOD(&FillLayer::getFillSortKey, "nativeGetFillSortKey"),
             METHOD(&FillLayer::getFillAntialias, "nativeGetFillAntialias"),
             METHOD(&FillLayer::getFillOpacityTransition, "nativeGetFillOpacityTransition"),
             METHOD(&FillLayer::setFillOpacityTransition, "nativeSetFillOpacityTransition"),

--- a/platform/android/src/style/layers/fill_layer.hpp
+++ b/platform/android/src/style/layers/fill_layer.hpp
@@ -26,6 +26,8 @@ public:
 
     // Properties
 
+    jni::Local<jni::Object<jni::ObjectTag>> getFillSortKey(jni::JNIEnv&);
+
     jni::Local<jni::Object<jni::ObjectTag>> getFillAntialias(jni::JNIEnv&);
 
     jni::Local<jni::Object<jni::ObjectTag>> getFillOpacity(jni::JNIEnv&);

--- a/platform/android/src/style/layers/layer.cpp.ejs
+++ b/platform/android/src/style/layers/layer.cpp.ejs
@@ -118,7 +118,9 @@ namespace android {
 
         // Register the peer
         jni::RegisterNativePeer<<%- camelize(type) %>Layer>(
-            env, javaClass, "nativePtr",
+            env,
+            javaClass,
+            "nativePtr",
 <% if (type === 'background') { -%>
             jni::MakePeer<<%- camelize(type) %>Layer, jni::String&>,
 <% } else { -%>

--- a/platform/android/src/style/layers/line_layer.cpp
+++ b/platform/android/src/style/layers/line_layer.cpp
@@ -61,6 +61,11 @@ namespace android {
         return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineRoundLimit()));
     }
 
+    jni::Local<jni::Object<>> LineLayer::getLineSortKey(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineSortKey()));
+    }
+
     jni::Local<jni::Object<>> LineLayer::getLineOpacity(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineOpacity()));
@@ -264,7 +269,9 @@ namespace android {
 
         // Register the peer
         jni::RegisterNativePeer<LineLayer>(
-            env, javaClass, "nativePtr",
+            env,
+            javaClass,
+            "nativePtr",
             jni::MakePeer<LineLayer, jni::String&, jni::String&>,
             "initialize",
             "finalize",
@@ -272,6 +279,7 @@ namespace android {
             METHOD(&LineLayer::getLineJoin, "nativeGetLineJoin"),
             METHOD(&LineLayer::getLineMiterLimit, "nativeGetLineMiterLimit"),
             METHOD(&LineLayer::getLineRoundLimit, "nativeGetLineRoundLimit"),
+            METHOD(&LineLayer::getLineSortKey, "nativeGetLineSortKey"),
             METHOD(&LineLayer::getLineOpacityTransition, "nativeGetLineOpacityTransition"),
             METHOD(&LineLayer::setLineOpacityTransition, "nativeSetLineOpacityTransition"),
             METHOD(&LineLayer::getLineOpacity, "nativeGetLineOpacity"),

--- a/platform/android/src/style/layers/line_layer.hpp
+++ b/platform/android/src/style/layers/line_layer.hpp
@@ -34,6 +34,8 @@ public:
 
     jni::Local<jni::Object<jni::ObjectTag>> getLineRoundLimit(jni::JNIEnv&);
 
+    jni::Local<jni::Object<jni::ObjectTag>> getLineSortKey(jni::JNIEnv&);
+
     jni::Local<jni::Object<jni::ObjectTag>> getLineOpacity(jni::JNIEnv&);
     void setLineOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
     jni::Local<jni::Object<TransitionOptions>> getLineOpacityTransition(jni::JNIEnv&);


### PR DESCRIPTION
This PR add jni binding for line-sort-key and fill-sort-key that was add into core sdk in https://github.com/mapbox/mapbox-gl-native/pull/15839

The related android pr: https://github.com/mapbox/mapbox-gl-native-android/pull/209