### PR TITLE
[test] Add test manifest for the nightly build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -671,7 +671,7 @@ jobs:
           command: |
             /tmp/attach/install/linux-gcc8-release/bin/mbgl-render-test-runner -u rebaseline -p metrics/binary-size.json
       - run:
-          name: 'Matrics Baselines'
+          name: 'Metrics Baselines'
           command: |
             cp -r /tmp/attach/metrics .
             git add -A && git diff --staged --exit-code | tee baselines.patch

--- a/metrics/linux-gcc8-debug-coverage-nightly-style.json
+++ b/metrics/linux-gcc8-debug-coverage-nightly-style.json
@@ -1,0 +1,1 @@
+linux-gcc8-debug-coverage-style.json


### PR DESCRIPTION
Use the same test manifest for the development and nightly
coverage CI builds. Add manifest for the nightly build by
creating a symbolic link to the existing manifest.