### PR TITLE
[core] Refactor symbol sort key handling

### DIFF
--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -123,11 +123,6 @@ public:
     static constexpr uint32_t invalidCrossTileID() { return std::numeric_limits<uint32_t>::max(); }
 };
 
-class SortKeyRange {
-public:
-    float sortKey;
-    size_t symbolInstanceStart;
-    size_t symbolInstanceEnd;
-};
+using SymbolInstanceReferences = std::vector<std::reference_wrapper<const SymbolInstance>>;
 
 } // namespace mbgl

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -613,8 +613,8 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
                                          iconType);
 
             if (sortFeaturesByKey) {
-                if (sortKeyRanges.size() && sortKeyRanges.back().sortKey == feature.sortKey) {
-                    sortKeyRanges.back().symbolInstanceEnd = symbolInstances.size();
+                if (!sortKeyRanges.empty() && sortKeyRanges.back().sortKey == feature.sortKey) {
+                    sortKeyRanges.back().end = symbolInstances.size();
                 } else {
                     sortKeyRanges.push_back({feature.sortKey, symbolInstances.size() - 1, symbolInstances.size()});
                 }

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -19,7 +19,7 @@ class PatternDependency;
 using PatternLayerMap = std::map<std::string, PatternDependency>;
 class Placement;
 class TransformState;
-class BucketPlacementParameters;
+class BucketPlacementData;
 class RenderTile;
 
 class Bucket {
@@ -64,7 +64,7 @@ public:
         return std::make_pair(0u, false);
     }
     // Places this bucket to the given placement.
-    virtual void place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) {}
+    virtual void place(Placement&, const BucketPlacementData&, std::set<uint32_t>&) {}
     virtual void updateVertices(
         const Placement&, bool /*updateOpacities*/, const TransformState&, const RenderTile&, std::set<uint32_t>&) {}
 

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -314,8 +314,8 @@ std::pair<uint32_t, bool> SymbolBucket::registerAtCrossTileIndex(CrossTileSymbol
     return std::make_pair(bucketInstanceId, firstTimeAdded);
 }
 
-void SymbolBucket::place(Placement& placement, const BucketPlacementParameters& params, std::set<uint32_t>& seenIds) {
-    placement.placeBucket(*this, params, seenIds);
+void SymbolBucket::place(Placement& placement, const BucketPlacementData& data, std::set<uint32_t>& seenIds) {
+    placement.placeSymbolBucket(data, seenIds);
 }
 
 void SymbolBucket::updateVertices(const Placement& placement,

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -275,8 +275,8 @@ void SymbolBucket::sortFeatures(const float angle) {
     featureSortOrder = std::move(symbolsSortOrder);
 }
 
-std::vector<std::reference_wrapper<const SymbolInstance>> SymbolBucket::getSortedSymbols(const float angle) const {
-    std::vector<std::reference_wrapper<const SymbolInstance>> result(symbolInstances.begin(), symbolInstances.end());
+SymbolInstanceReferences SymbolBucket::getSortedSymbols(const float angle) const {
+    SymbolInstanceReferences result(symbolInstances.begin(), symbolInstances.end());
     const float sin = std::sin(angle);
     const float cos = std::cos(angle);
 
@@ -290,6 +290,15 @@ std::vector<std::reference_wrapper<const SymbolInstance>> SymbolBucket::getSorte
     });
 
     return result;
+}
+
+SymbolInstanceReferences SymbolBucket::getSymbols(const optional<SortKeyRange>& range) const {
+    if (!range) return SymbolInstanceReferences(symbolInstances.begin(), symbolInstances.end());
+    assert(range->start < range->end);
+    assert(range->end <= symbolInstances.size());
+    auto begin = symbolInstances.begin() + range->start;
+    auto end = symbolInstances.begin() + range->end;
+    return SymbolInstanceReferences(begin, end);
 }
 
 bool SymbolBucket::hasFormatSectionOverrides() const {

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -1,16 +1,17 @@
 #pragma once
 
-#include <mbgl/renderer/bucket.hpp>
-#include <mbgl/map/mode.hpp>
-#include <mbgl/gfx/vertex_buffer.hpp>
 #include <mbgl/gfx/index_buffer.hpp>
-#include <mbgl/programs/segment.hpp>
-#include <mbgl/programs/symbol_program.hpp>
-#include <mbgl/programs/collision_box_program.hpp>
-#include <mbgl/text/glyph_range.hpp>
-#include <mbgl/style/layers/symbol_layer_properties.hpp>
+#include <mbgl/gfx/vertex_buffer.hpp>
 #include <mbgl/layout/symbol_feature.hpp>
 #include <mbgl/layout/symbol_instance.hpp>
+#include <mbgl/map/mode.hpp>
+#include <mbgl/programs/collision_box_program.hpp>
+#include <mbgl/programs/segment.hpp>
+#include <mbgl/programs/symbol_program.hpp>
+#include <mbgl/renderer/bucket.hpp>
+#include <mbgl/style/layers/symbol_layer_properties.hpp>
+#include <mbgl/text/glyph_range.hpp>
+#include <mbgl/text/placement.hpp>
 
 #include <vector>
 
@@ -97,8 +98,11 @@ public:
 
 
     void sortFeatures(const float angle);
-    // The result contains references to the `symbolInstances` items, sorted by viewport Y.
-    std::vector<std::reference_wrapper<const SymbolInstance>> getSortedSymbols(const float angle) const;
+    // Returns references to the `symbolInstances` items, sorted by viewport Y.
+    SymbolInstanceReferences getSortedSymbols(const float angle) const;
+    // Returns references to the `symbolInstances` items, which belong to the `sortKeyRange` range;
+    // returns references to all the symbols if |sortKeyRange| is `nullopt`.
+    SymbolInstanceReferences getSymbols(const optional<SortKeyRange>& sortKeyRange = nullopt) const;
 
     Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> layout;
     const std::string bucketLeaderID;
@@ -118,7 +122,7 @@ public:
     bool hasUninitializedSymbols : 1;
 
     std::vector<SymbolInstance> symbolInstances;
-    std::vector<SortKeyRange> sortKeyRanges;
+    const std::vector<SortKeyRange> sortKeyRanges;
 
     struct PaintProperties {
         SymbolIconProgram::Binders iconBinders;

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -84,7 +84,7 @@ public:
     void upload(gfx::UploadPass&) override;
     bool hasData() const override;
     std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const RenderTile&) override;
-    void place(Placement&, const BucketPlacementParameters&, std::set<uint32_t>&) override;
+    void place(Placement&, const BucketPlacementData&, std::set<uint32_t>&) override;
     void updateVertices(
         const Placement&, bool updateOpacities, const TransformState&, const RenderTile&, std::set<uint32_t>&) override;
     bool hasTextData() const;

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -589,7 +589,7 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
                 placementData.push_back({*bucket, renderTile, featureIndex, nullopt});
             } else {
                 for (const auto& sortKeyRange : bucket->sortKeyRanges) {
-                    LayerPlacementData layerData{*bucket, renderTile, featureIndex, sortKeyRange};
+                    BucketPlacementData layerData{*bucket, renderTile, featureIndex, sortKeyRange};
                     auto sortPosition = std::upper_bound(
                         placementData.cbegin(), placementData.cend(), layerData, [](const auto& lhs, const auto& rhs) {
                             assert(lhs.sortKeyRange && rhs.sortKeyRange);

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -575,6 +575,7 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
     addRenderPassesFromTiles();
 
     placementData.clear();
+
     for (const RenderTile& renderTile : *renderTiles) {
         auto* bucket = static_cast<SymbolBucket*>(renderTile.getBucket(*baseImpl));
         if (bucket && bucket->bucketLeaderID == getID()) {
@@ -586,10 +587,10 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
             auto featureIndex = static_cast<const GeometryTile*>(tile)->getFeatureIndex();
 
             if (bucket->sortKeyRanges.empty()) {
-                placementData.push_back({*bucket, renderTile, featureIndex, nullopt});
+                placementData.push_back({*bucket, renderTile, featureIndex, baseImpl->source, nullopt});
             } else {
                 for (const auto& sortKeyRange : bucket->sortKeyRanges) {
-                    BucketPlacementData layerData{*bucket, renderTile, featureIndex, sortKeyRange};
+                    BucketPlacementData layerData{*bucket, renderTile, featureIndex, baseImpl->source, sortKeyRange};
                     auto sortPosition = std::upper_bound(
                         placementData.cbegin(), placementData.cend(), layerData, [](const auto& lhs, const auto& rhs) {
                             assert(lhs.sortKeyRange && rhs.sortKeyRange);

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -583,21 +583,19 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
             assert(tile);
             assert(tile->kind == Tile::Kind::Geometry);
 
-            bool firstInBucket = true;
             auto featureIndex = static_cast<const GeometryTile*>(tile)->getFeatureIndex();
 
             if (bucket->sortKeyRanges.empty()) {
-                placementData.push_back({*bucket, renderTile, featureIndex, firstInBucket, nullopt});
+                placementData.push_back({*bucket, renderTile, featureIndex, nullopt});
             } else {
                 for (const auto& sortKeyRange : bucket->sortKeyRanges) {
-                    LayerPlacementData layerData{*bucket, renderTile, featureIndex, firstInBucket, sortKeyRange};
+                    LayerPlacementData layerData{*bucket, renderTile, featureIndex, sortKeyRange};
                     auto sortPosition = std::upper_bound(
                         placementData.cbegin(), placementData.cend(), layerData, [](const auto& lhs, const auto& rhs) {
                             assert(lhs.sortKeyRange && rhs.sortKeyRange);
                             return lhs.sortKeyRange->sortKey < rhs.sortKeyRange->sortKey;
                         });
                     placementData.insert(sortPosition, std::move(layerData));
-                    firstInBucket = false;
                 }
             }
         }

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -36,13 +36,15 @@ public:
     size_t end;
 };
 
-class LayerPlacementData {
+class BucketPlacementData {
 public:
     std::reference_wrapper<Bucket> bucket;
     std::reference_wrapper<const RenderTile> tile;
     std::shared_ptr<FeatureIndex> featureIndex;
     optional<SortKeyRange> sortKeyRange;
 };
+
+using LayerPlacementData = std::list<BucketPlacementData>;
 
 class LayerPrepareParameters {
 public:
@@ -105,7 +107,7 @@ public:
 
     virtual void prepare(const LayerPrepareParameters&);
 
-    const std::list<LayerPlacementData>& getPlacementData() const { return placementData; }
+    const LayerPlacementData& getPlacementData() const { return placementData; }
 
     // Latest evaluated properties.
     Immutable<style::LayerProperties> evaluatedProperties;
@@ -134,7 +136,7 @@ protected:
     // evaluated StyleProperties object and is updated accordingly.
     RenderPass passes = RenderPass::None;
 
-    std::list<LayerPlacementData> placementData;
+    LayerPlacementData placementData;
 
 private:
     // Some layers may not render correctly on some hardware when the vertex attribute limit of

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -41,6 +41,7 @@ public:
     std::reference_wrapper<Bucket> bucket;
     std::reference_wrapper<const RenderTile> tile;
     std::shared_ptr<FeatureIndex> featureIndex;
+    std::string sourceId;
     optional<SortKeyRange> sortKeyRange;
 };
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -30,6 +30,7 @@ public:
 
 class SortKeyRange {
 public:
+    bool isFirstRange() const { return start == 0u; }
     float sortKey;
     size_t start;
     size_t end;
@@ -40,7 +41,6 @@ public:
     std::reference_wrapper<Bucket> bucket;
     std::reference_wrapper<const RenderTile> tile;
     std::shared_ptr<FeatureIndex> featureIndex;
-    bool firstInBucket;
     optional<SortKeyRange> sortKeyRange;
 };
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -28,18 +28,20 @@ public:
     Immutable<style::LayerProperties> layerProperties;
 };
 
+class SortKeyRange {
+public:
+    float sortKey;
+    size_t start;
+    size_t end;
+};
+
 class LayerPlacementData {
 public:
-    friend bool operator<(const LayerPlacementData& lhs, const LayerPlacementData& rhs) {
-        return lhs.sortKey < rhs.sortKey;
-    }
     std::reference_wrapper<Bucket> bucket;
     std::reference_wrapper<const RenderTile> tile;
     std::shared_ptr<FeatureIndex> featureIndex;
     bool firstInBucket;
-    float sortKey;
-    size_t symbolInstanceStart;
-    size_t symbolInstanceEnd;
+    optional<SortKeyRange> sortKeyRange;
 };
 
 class LayerPrepareParameters {

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -144,7 +144,7 @@ void Placement::placeBucket(const SymbolBucket& bucket,
                             std::set<uint32_t>& seenCrossTileIDs) {
     assert(updateParameters);
     const auto& layout = *bucket.layout;
-    const auto& renderTile = params.tile;
+    const RenderTile& renderTile = params.tile;
     const auto& state = collisionIndex.getTransformState();
     const float pixelsToTileUnits = renderTile.id.pixelsToTileUnits(1, placementZoom);
     const OverscaledTileID& overscaledID = renderTile.getOverscaledTileID();
@@ -735,7 +735,7 @@ void Placement::commit() {
 void Placement::updateLayerBuckets(const RenderLayer& layer, const TransformState& state, bool updateOpacities) const {
     std::set<uint32_t> seenCrossTileIDs;
     for (const auto& item : layer.getPlacementData()) {
-        if (item.firstInBucket) {
+        if (!item.sortKeyRange || item.sortKeyRange->isFirstRange()) {
             item.bucket.get().updateVertices(*this, updateOpacities, state, item.tile, seenCrossTileIDs);
         }
     }

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -113,12 +113,7 @@ void Placement::placeLayer(const RenderLayer& layer) {
     std::set<uint32_t> seenCrossTileIDs;
     for (const auto& item : layer.getPlacementData()) {
         Bucket& bucket = item.bucket;
-        BucketPlacementParameters params{item.tile,
-                                         layer.baseImpl->source,
-                                         item.featureIndex,
-                                         item.sortKey,
-                                         item.symbolInstanceStart,
-                                         item.symbolInstanceEnd};
+        BucketPlacementParameters params{item.tile, layer.baseImpl->source, item.featureIndex, item.sortKeyRange};
         bucket.place(*this, params, seenCrossTileIDs);
     }
 }
@@ -661,12 +656,8 @@ void Placement::placeBucket(const SymbolBucket& bucket,
         }
 
     } else {
-        auto beginIt = bucket.symbolInstances.begin() + params.symbolInstanceStart;
-        auto endIt = bucket.symbolInstances.begin() + params.symbolInstanceEnd;
-        assert(params.symbolInstanceStart < params.symbolInstanceEnd);
-        assert(params.symbolInstanceEnd <= bucket.symbolInstances.size());
-        for (auto it = beginIt; it != endIt; ++it) {
-            placeSymbol(*it);
+        for (const SymbolInstance& symbol : bucket.getSymbols(params.sortKeyRange)) {
+            placeSymbol(symbol);
         }
     }
 

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -111,10 +111,9 @@ Placement::Placement() : collisionIndex({}, MapMode::Static), collisionGroups(tr
 
 void Placement::placeLayer(const RenderLayer& layer) {
     std::set<uint32_t> seenCrossTileIDs;
-    for (const auto& item : layer.getPlacementData()) {
-        Bucket& bucket = item.bucket;
-        BucketPlacementParameters params{item.tile, layer.baseImpl->source, item.featureIndex, item.sortKeyRange};
-        bucket.place(*this, params, seenCrossTileIDs);
+    for (const BucketPlacementData& data : layer.getPlacementData()) {
+        Bucket& bucket = data.bucket;
+        bucket.place(*this, data, seenCrossTileIDs);
     }
 }
 
@@ -139,10 +138,9 @@ Point<float> calculateVariableLayoutOffset(style::SymbolAnchorType anchor,
 }
 } // namespace
 
-void Placement::placeBucket(const SymbolBucket& bucket,
-                            const BucketPlacementParameters& params,
-                            std::set<uint32_t>& seenCrossTileIDs) {
+void Placement::placeSymbolBucket(const BucketPlacementData& params, std::set<uint32_t>& seenCrossTileIDs) {
     assert(updateParameters);
+    const auto& bucket = static_cast<const SymbolBucket&>(params.bucket.get());
     const auto& layout = *bucket.layout;
     const RenderTile& renderTile = params.tile;
     const auto& state = collisionIndex.getTransformState();

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -91,9 +91,7 @@ public:
     const RenderTile& tile;
     std::string sourceId;
     std::shared_ptr<FeatureIndex> featureIndex;
-    float sortKey;
-    size_t symbolInstanceStart;
-    size_t symbolInstanceEnd;
+    optional<SortKeyRange> sortKeyRange;
 };
 
 class Placement;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -86,14 +86,6 @@ private:
     bool crossSourceCollisions;
 };
 
-class BucketPlacementParameters {
-public:
-    std::reference_wrapper<const RenderTile> tile;
-    std::string sourceId;
-    std::shared_ptr<FeatureIndex> featureIndex;
-    optional<SortKeyRange> sortKeyRange;
-};
-
 class Placement;
 
 class PlacementController {
@@ -132,7 +124,7 @@ public:
 
 private:
     friend SymbolBucket;
-    void placeBucket(const SymbolBucket&, const BucketPlacementParameters&, std::set<uint32_t>& seenCrossTileIDs);
+    void placeSymbolBucket(const BucketPlacementData&, std::set<uint32_t>& seenCrossTileIDs);
     // Returns `true` if bucket vertices were updated; returns `false` otherwise.
     bool updateBucketDynamicVertices(SymbolBucket&, const TransformState&, const RenderTile& tile) const;
     void updateBucketOpacities(SymbolBucket&, const TransformState&, std::set<uint32_t>&) const;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -88,7 +88,7 @@ private:
 
 class BucketPlacementParameters {
 public:
-    const RenderTile& tile;
+    std::reference_wrapper<const RenderTile> tile;
     std::string sourceId;
     std::shared_ptr<FeatureIndex> featureIndex;
     optional<SortKeyRange> sortKeyRange;


### PR DESCRIPTION
- Encapsulate placement code handling symbols sort ranges inside `SymbolBucket`
- Get rid of `LayerPlacementData::firstInBucket` - simplification
- Split `LayerPlacementData` and `BucketPlacementData` - improvements to `RenderLayer` API

Tag https://github.com/mapbox/mapbox-gl-native-team/issues/132
