### PR TITLE
[core] Fix using `in` expression with `filter`

### DIFF
--- a/metrics/android-render-test-runner/render-tests/filter/in/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/filter/in/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            3,
+            3,
+            10,
+            1,
+            [
+                32768,
+                32768
+            ],
+            [
+                214,
+                214
+            ],
+            [
+                664,
+                664
+            ]
+        ]
+    ]
+}

--- a/metrics/ios-render-test-runner/render-tests/filter/in/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/filter/in/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            3,
+            3,
+            10,
+            1,
+            [
+                32768,
+                32768
+            ],
+            [
+                214,
+                214
+            ],
+            [
+                664,
+                664
+            ]
+        ]
+    ]
+}

--- a/metrics/linux-clang8-release/render-tests/filter/in/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/filter/in/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            3,
+            3,
+            10,
+            1,
+            [
+                32768,
+                32768
+            ],
+            [
+                214,
+                214
+            ],
+            [
+                664,
+                664
+            ]
+        ]
+    ]
+}

--- a/metrics/linux-gcc8-release/render-tests/filter/in/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/filter/in/metrics.json
@@ -1,0 +1,35 @@
+{
+    "network": [
+        [
+            "probeNetwork - default - end",
+            0,
+            0
+        ],
+        [
+            "probeNetwork - default - start",
+            0,
+            0
+        ]
+    ],
+    "gfx": [
+        [
+            "probeGFX - default - end",
+            3,
+            3,
+            10,
+            1,
+            [
+                32768,
+                32768
+            ],
+            [
+                214,
+                214
+            ],
+            [
+                664,
+                664
+            ]
+        ]
+    ]
+}

--- a/src/mbgl/style/conversion/filter.cpp
+++ b/src/mbgl/style/conversion/filter.cpp
@@ -53,8 +53,13 @@ bool isExpression(const Convertible& filter) {
         optional<std::string> operand = toString(arrayMember(filter, 1));
         return operand && *operand != "$id" && *operand != "$type";
 
-    } else if (*op == "in" || *op == "!in" || *op == "!has" || *op == "none") {
+    } else if (*op == "!in" || *op == "!has" || *op == "none") {
         return false;
+
+    } else if (*op == "in") {
+        optional<std::string> str = toString(arrayMember(filter, 1));
+
+        return arrayLength(filter) >= 3 && (!str || isArray(arrayMember(filter, 2)));
 
     } else if (*op == "==" || *op == "!=" || *op == ">" || *op == ">=" || *op == "<" || *op == "<=") {
         return arrayLength(filter) != 3 || isArray(arrayMember(filter, 1)) || isArray(arrayMember(filter, 2));


### PR DESCRIPTION
Resolves #16262 
`mbgl::style::conversion::isExpression()` always returns false for expression `in`, this PR fix this issue.

The test in added in android test app in this pr: https://github.com/mapbox/mapbox-gl-native-android/pull/218

I'm not sure where should add test cases for this change, @alexshalamov any suggestions for it?
