### PR TITLE
[build] Collect code coverage from macOS builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -152,8 +152,9 @@ workflows:
           target_is_macos: true
           requires:
             - macos-xcode11-release
-          config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug'
+          config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DMBGL_WITH_COVERAGE=ON'
           style_tests: true
+          upload_coverage: true
       - build-template:
           name: ios-xcode11-release
           executor_name: macos-11_3_1
@@ -174,6 +175,15 @@ workflows:
           executor_name: ubuntu-disco
           target_is_linux: true
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_BUILD_TYPE=Debug -DMBGL_WITH_COVERAGE=ON'
+          style_tests: true
+          upload_coverage: true
+      - build-template:
+          name: macos-xcode11-debug-coverage-nightly
+          executor_name: macos-11_1_0
+          target_is_macos: true
+          requires:
+            - linux-gcc8-debug-coverage-nightly
+          config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DMBGL_WITH_COVERAGE=ON'
           style_tests: true
           upload_coverage: true
           publish_coverage: true

--- a/metrics/macos-xcode11-debug-coverage-nightly-style.json
+++ b/metrics/macos-xcode11-debug-coverage-nightly-style.json
@@ -1,0 +1,1 @@
+macos-xcode11-debug-style.json


### PR DESCRIPTION
Collect coverage from development builds and add a nightly build to collect metrics.

This gives us coverage for [platform/darwin](https://codecov.io/gh/mapbox/mapbox-gl-native/compare/dc510e44c085e87233b628a995b6957ad9c0ab9b...fb2c7f58dbfff05ab25472f7730e883e96d05d94/tree/platform).