### PR TITLE
[build] Minor build changes to enable extra modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1013,3 +1013,7 @@ endif()
 add_subdirectory(${PROJECT_SOURCE_DIR}/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
 add_subdirectory(${PROJECT_SOURCE_DIR}/render-test)
+
+if(EXISTS ${PROJECT_SOURCE_DIR}/internal/internal.cmake)
+    include(${PROJECT_SOURCE_DIR}/internal/internal.cmake)
+endif()

--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -348,20 +348,16 @@ if(ANDROID_NATIVE_API_LEVEL VERSION_LESS 24)
         PRIVATE ${PROJECT_SOURCE_DIR}/platform/android/src/test/http_file_source_test_stub.cpp
     )
 else()
-    set(CURL_DIR ${PROJECT_SOURCE_DIR}/vendor/curl-android-ios/prebuilt-with-ssl/android)
-    set(CURL_LIBRARY ${CURL_DIR}/${ANDROID_ABI}/libcurl.a)
-
     target_sources(
         mbgl-test-runner
         PRIVATE ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp
     )
-    target_include_directories(
-        mbgl-test-runner
-        PRIVATE ${CURL_DIR}/include
-    )
+
+    include(${PROJECT_SOURCE_DIR}/vendor/curl.cmake)
+
     target_link_libraries(
         mbgl-test-runner
-        PRIVATE ${CURL_LIBRARY}
+        PRIVATE mbgl-vendor-curl
     )
 endif()
 

--- a/vendor/curl.cmake
+++ b/vendor/curl.cmake
@@ -1,0 +1,17 @@
+if(TARGET mbgl-vendor-curl)
+    return()
+endif()
+
+add_library(
+    mbgl-vendor-curl INTERFACE
+)
+
+target_link_libraries(
+    mbgl-vendor-curl
+    INTERFACE $<$<PLATFORM_ID:Android>:${CMAKE_CURRENT_LIST_DIR}/curl-android-ios/prebuilt-with-ssl/android/${ANDROID_ABI}/libcurl.a>
+)
+
+target_include_directories(
+    mbgl-vendor-curl SYSTEM
+    INTERFACE ${CMAKE_CURRENT_LIST_DIR}/curl-android-ios/curl/include
+)


### PR DESCRIPTION
The buildsystem will look for an extra path to include if available. This will allow to extend GL Native.