### PR TITLE
Disable ccache on iOS

### DIFF
--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -73,7 +73,7 @@ target_include_directories(
 )
 
 include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
-include(${PROJECT_SOURCE_DIR}/platform/ios/ccache.cmake)
+# include(${PROJECT_SOURCE_DIR}/platform/ios/ccache.cmake)
 include(${PROJECT_SOURCE_DIR}/platform/ios/ios-test-runners.cmake)
 
 initialize_ios_target(mbgl-core)


### PR DESCRIPTION
Disabled ccache on iOS, partially rolling back mapbox/mapbox-gl-native@7a9f8027ac1aa93c5e073d4fe138414059125fa8 from mapbox/mapbox-gl-native#16158, due to the iOS map SDK build failure reported in https://github.com/mapbox/mapbox-gl-native-ios/pull/199#issuecomment-596021296.

/cc @mapbox/gl-native @mapbox/maps-ios