### PR TITLE
v1.3.1+ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## maps-v1.3.1+ios (2020.02-release-vanillashake)
+
+This release disables ccache in iOS builds. ([#16289](https://github.com/mapbox/mapbox-gl-native/pull/16289))
+
 ## maps-v1.3.1 (2020.02-release-vanillashake)
 
 ### 🐞 Bug fixes

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -73,7 +73,7 @@ target_include_directories(
 )
 
 include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
-include(${PROJECT_SOURCE_DIR}/platform/ios/ccache.cmake)
+# include(${PROJECT_SOURCE_DIR}/platform/ios/ccache.cmake)
 include(${PROJECT_SOURCE_DIR}/platform/ios/ios-test-runners.cmake)
 
 initialize_ios_target(mbgl-core)


### PR DESCRIPTION
Cherry-picked #16289 into the 2020.02-release-vanillashake branch for a v1.3.1+ios release to unblock iOS map SDK v5.8.0-alpha.1. This commit will be tagged as maps-v1.3.1+ios, using a semver convention to indicate that it’s binary- and source-equivalent to v1.3.1 but is built differently.

/ref mapbox/mapbox-gl-native-ios#199
/cc @mapbox/gl-native @mapbox/maps-ios