### PR TITLE
[build] Bump docker

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -190,7 +190,7 @@ executors:
   ubuntu-disco:
     docker:
       # FIXME: Move the image to mbgl/
-      - image: tmpsantos/mbgl_ci:1.7
+      - image: tmpsantos/mbgl_ci:1.8
     resource_class: xlarge
     working_directory: /src
     environment:

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -47,6 +47,7 @@ RUN pip3 install cmake-format==0.5.5
 RUN set -eu && apt-get install -y \
     libcurl4-openssl-dev \
     libgl1-mesa-dev \
+    libgles2-mesa-dev \
     libglfw3-dev \
     libicu-dev \
     libjpeg-turbo8-dev \


### PR DESCRIPTION
Allow building with OpenGL ES 2.0 headers on Linux.