### PR TITLE
[core] Add a callback for platform RunLoop integration

### DIFF
--- a/test/util/run_loop.test.cpp
+++ b/test/util/run_loop.test.cpp
@@ -3,6 +3,10 @@
 
 #include <mbgl/test/util.hpp>
 
+#include <atomic>
+#include <condition_variable>
+#include <thread>
+
 using namespace mbgl::util;
 
 TEST(RunLoop, Stop) {
@@ -63,4 +67,49 @@ TEST(RunLoop, Priorities) {
     loop.run();
 
     EXPECT_EQ((std::vector<int>{ 2, 4, 1, 3 }), order);
+}
+
+TEST(RunLoop, PlatformIntegration) {
+    std::atomic<int> count1(0);
+
+    // No need to be atomic, it will run
+    // on the main thread.
+    int count2(0);
+
+    std::thread::id mainThread = std::this_thread::get_id();
+
+    RunLoop loop;
+
+    std::mutex mutex;
+    std::condition_variable cv;
+
+    loop.setPlatformCallback([&] {
+        EXPECT_NE(mainThread, std::this_thread::get_id());
+        count1++;
+        cv.notify_one();
+    });
+
+    auto threadBody = [&]() {
+        for (unsigned i = 0; i < 100000; ++i) {
+            loop.invoke([&] {
+                EXPECT_EQ(mainThread, std::this_thread::get_id());
+                count2++;
+            });
+        }
+    };
+
+    std::thread thread1(threadBody);
+    std::thread thread2(threadBody);
+
+    while (count2 < 200000) {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock);
+        loop.runOnce();
+    }
+
+    EXPECT_EQ(count1, 200000);
+    EXPECT_EQ(count2, 200000);
+
+    thread1.join();
+    thread2.join();
 }


### PR DESCRIPTION
Platform integration callback for platforms that do not have full run loop integration or don't want to block at the Mapbox GL Native loop. It will be called from any thread and is up to the platform to, after receiving the callback, call RunLoop::runOnce() from the same thread as the Map object lives.