### PR TITLE
[core] Fix crash at Placement::getSymbolPlacement()

### DIFF
--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -1235,7 +1235,7 @@ float Placement::zoomAdjustment(const float zoom) const {
 const JointPlacement* Placement::getSymbolPlacement(const SymbolInstance& symbol) const {
     assert(symbol.crossTileID != 0);
     auto found = placements.find(symbol.crossTileID);
-    return (found == placements.end()) ? &found->second : nullptr;
+    return (found != placements.end()) ? &found->second : nullptr;
 }
 
 Duration Placement::getUpdatePeriod(const float zoom) const {


### PR DESCRIPTION
A mistype from https://github.com/mapbox/mapbox-gl-native/commit/05657e9573cdb01242a4e8365817be3f8bb62618