### PR TITLE
Fix wrong method call in  map_snapshotter.cpp

### DIFF
--- a/platform/android/src/snapshotter/map_snapshotter.cpp
+++ b/platform/android/src/snapshotter/map_snapshotter.cpp
@@ -57,7 +57,7 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
     if (styleJSON) {
         snapshotter->setStyleJSON(jni::Make<std::string>(_env, styleJSON));
     } else {
-        snapshotter->setStyleJSON(jni::Make<std::string>(_env, styleURL));
+        snapshotter->setStyleURL(jni::Make<std::string>(_env, styleURL));
     }
 }
 


### PR DESCRIPTION
In snapshotter, it will call `snapshotter->setStyleJSON` for both style json mode and url mode.
This pr fix this issue.