### PR TITLE
Add Map::Impl::get to retrieve the Impl from Map

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -31,6 +31,7 @@ class Style;
 
 class Map : private util::noncopyable {
 public:
+    class Impl;
     explicit Map(RendererFrontend&,
                  MapObserver&,
                  const MapOptions&,
@@ -127,11 +128,11 @@ public:
     void dumpDebugLogs() const;
 
 protected:
-    class Impl;
     const std::unique_ptr<Impl> impl;
 
     // For testing only.
     Map(std::unique_ptr<Impl>);
+    friend class Impl;
 };
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mbgl/annotation/annotation.hpp>
-#include <mbgl/annotation/symbol_annotation_impl.hpp>
 #include <mbgl/style/image.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
@@ -18,8 +17,6 @@ namespace mbgl {
 class LatLngBounds;
 class AnnotationTile;
 class AnnotationTileData;
-class SymbolAnnotationImpl;
-class ShapeAnnotationImpl;
 
 namespace style {
 class Style;
@@ -75,19 +72,8 @@ private:
     
     AnnotationID nextID = 0;
 
-    using SymbolAnnotationTree = boost::geometry::index::rtree<std::shared_ptr<const SymbolAnnotationImpl>, boost::geometry::index::rstar<16, 4>>;
-    // Unlike std::unordered_map, std::map is guaranteed to sort by AnnotationID, ensuring that older annotations are below newer annotations.
-    // <https://github.com/mapbox/mapbox-gl-native/issues/5691>
-    using SymbolAnnotationMap = std::map<AnnotationID, std::shared_ptr<SymbolAnnotationImpl>>;
-    using ShapeAnnotationMap = std::map<AnnotationID, std::unique_ptr<ShapeAnnotationImpl>>;
-    using ImageMap = std::unordered_map<std::string, style::Image>;
-
-    SymbolAnnotationTree symbolTree;
-    SymbolAnnotationMap symbolAnnotations;
-    ShapeAnnotationMap shapeAnnotations;
-    ImageMap images;
-
-    std::unordered_set<AnnotationTile*> tiles;
+    class Impl;
+    const std::unique_ptr<Impl> impl;
     mapbox::base::WeakPtrFactory<AnnotationManager> weakFactory{this};
 };
 

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -30,7 +30,15 @@ Map::Impl::~Impl() {
     // Explicitly reset the RendererFrontend first to ensure it releases
     // All shared resources (AnnotationManager)
     rendererFrontend.reset();
-};
+}
+
+Map::Impl *Map::Impl::get(Map& map) {
+    return map.impl.get();
+}
+
+const Map::Impl *Map::Impl::get(const Map& map) {
+    return map.impl.get();
+}
 
 #pragma mark - Map::Impl StyleObserver
 

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -31,6 +31,9 @@ public:
     Impl(RendererFrontend&, MapObserver&, std::shared_ptr<FileSource>, const MapOptions&);
     ~Impl() final;
 
+    static Map::Impl *get(Map&);
+    static const Map::Impl *get(const Map&);
+
     // StyleObserver
     void onSourceChanged(style::Source&) final;
     void onUpdate() final;


### PR DESCRIPTION
This allow to access the map private implementation if necessary.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality

