### PR TITLE
Add additional transformState getters

### DIFF
--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -81,7 +81,7 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
     }
 
     const double cameraToCenterDistance = getCameraToCenterDistance();
-    auto offset = getCenterOffset();
+    const ScreenCoordinate offset = getCenterOffset();
 
     // Find the Z distance from the viewport center point
     // [width/2 + offset.x, height/2 + offset.y] to the top edge; to point
@@ -498,11 +498,15 @@ double TransformState::scaleZoom(double s) const {
 }
 
 ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) const {
+    vec4 p;
+    return latLngToScreenCoordinate(latLng, p);
+}
+
+ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng, vec4& p) const {
     if (size.isEmpty()) {
         return {};
     }
 
-    vec4 p;
     Point<double> pt = Projection::project(latLng, scale) / util::tileSize;
     vec4 c = {{pt.x, pt.y, 0, 1}};
     matrix::transformMat4(p, c, getCoordMatrix());

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -196,6 +196,7 @@ public:
 
     // Conversion
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&) const;
+    ScreenCoordinate latLngToScreenCoordinate(const LatLng&, vec4&) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Unwrapped) const;
     // Implements mapbox-gl-js pointCoordinate() : MercatorCoordinate.
     TileCoordinate screenCoordinateToTileCoordinate(const ScreenCoordinate&, uint8_t atZoom) const;

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -130,6 +130,16 @@ TEST(Transform, PerspectiveProjection) {
     point = transform.getState().latLngToScreenCoordinate({37.692872969426375, -76.75823239205641});
     ASSERT_NEAR(point.x, 1000.0, 1e-5);
     ASSERT_NEAR(point.y, 0.0, 1e-4);
+
+    mbgl::vec4 p;
+    point = transform.getState().latLngToScreenCoordinate({37.692872969426375, -76.75823239205641}, p);
+    ASSERT_NEAR(point.x, 1000.0, 1e-5);
+    ASSERT_NEAR(point.y, 0.0, 1e-4);
+    ASSERT_GT(p[3], 0.0);
+
+    transform.jumpTo(CameraOptions().withCenter(LatLng{38.0, -77.0}).withZoom(18.0).withPitch(51.56620156));
+    point = transform.getState().latLngToScreenCoordinate({7.692872969426375, -76.75823239205641}, p);
+    ASSERT_LT(p[3], 0.0);
 }
 
 TEST(Transform, UnwrappedLatLng) {


### PR DESCRIPTION
This change adds a latLngToScreenCoordinate overload, to retrieve
the projected vec4 in additional to the ScreenCoordinate object,
that is useful to detect whether the projected latLng is in front
or behind the camera.
The change also adds an additional, optional argument to getProjMatrix,
to retrieve a projection matrix centered around 0,0, instead of around
the current map center. This is necessary to minimize numerical error
in floating point math when projecting float coordinates with a float
matrix4 over a large domain.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
