### PR TITLE
Cleanup source conversion code

### DIFF
--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -196,16 +196,16 @@ optional<std::unique_ptr<Source>> Converter<std::unique_ptr<Source>>::operator()
         error.message = "source type must be a string";
         return nullopt;
     }
-    const std::string tname = *type;
-    if (*type == "raster") {
+    const std::string& tname = type.value();
+    if (tname == "raster") {
         return convertRasterSource(id, value, error);
-    } else if (*type == "raster-dem") {
+    } else if (tname == "raster-dem") {
         return convertRasterDEMSource(id, value, error);
-    } else if (*type == "vector") {
+    } else if (tname == "vector") {
         return convertVectorSource(id, value, error);
-    } else if (*type == "geojson") {
+    } else if (tname == "geojson") {
         return convertGeoJSONSource(id, value, error);
-    } else if (*type == "image") {
+    } else if (tname == "image") {
         return convertImageSource(id, value, error);
     } else {
         error.message = "invalid source type";


### PR DESCRIPTION
While reviewing the code in `src/mbgl/style/conversion/source.cpp ` I noticed an used variable. 

Perhaps gl-native should be being built with `-Wunused-variable`?

In the meantime here is a fix for the variable that was unused, which may help efficiency slightly by reducing the # of times the optional is accessed and by avoiding taking a copy of the string.

