### PR TITLE
Add NSURLSession delegation to http_file_source.mm

### DIFF
--- a/platform/darwin/include/mbgl/interface/native_apple_interface.h
+++ b/platform/darwin/include/mbgl/interface/native_apple_interface.h
@@ -2,15 +2,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class MGLNativeNetworkManager;
+
 @protocol MGLNativeNetworkDelegate <NSObject>
 
 @optional
 
 - (NSString *)skuToken;
 
+- (NSURLSession *)sessionForNetworkManager:(MGLNativeNetworkManager *)networkManager;
+
 @required
 
-- (NSURLSession *)session;
+- (NSURLSessionConfiguration *)sessionConfiguration;
 
 - (void)startDownloadEvent:(NSString *)event type:(NSString *)type;
 
@@ -34,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSString *skuToken;
 
-@property (nonatomic, readonly) NSURLSession *session;
+@property (nonatomic, readonly) NSURLSessionConfiguration *sessionConfiguration;
 
 - (void)startDownloadEvent:(NSString *)event type:(NSString *)type;
 

--- a/platform/darwin/include/mbgl/interface/native_apple_interface.h
+++ b/platform/darwin/include/mbgl/interface/native_apple_interface.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @required
 
-- (NSURLSessionConfiguration *)sessionConfiguration;
+- (NSURLSession *)session;
 
 - (void)startDownloadEvent:(NSString *)event type:(NSString *)type;
 
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSString *skuToken;
 
-@property (nonatomic, readonly) NSURLSessionConfiguration *sessionConfiguration;
+@property (nonatomic, readonly) NSURLSession *session;
 
 - (void)startDownloadEvent:(NSString *)event type:(NSString *)type;
 

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -84,14 +84,10 @@ class HTTPFileSource::Impl {
 public:
     Impl() {
         @autoreleasepool {
-            NSURLSessionConfiguration *sessionConfig = MGLNativeNetworkManager.sharedManager.sessionConfiguration;
-            session = [NSURLSession sessionWithConfiguration:sessionConfig];
-
             userAgent = getUserAgent();
         }
     }
 
-    NSURLSession* session = nil;
     NSString* userAgent = nil;
     NSInteger accountType = 0;
 
@@ -249,8 +245,10 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
         if (isTile) {
             [MGLNativeNetworkManager.sharedManager startDownloadEvent:url.relativePath type:@"tile"];
         }
-        
-        request->task = [impl->session
+
+        NSURLSession *session = [MGLNativeNetworkManager.sharedManager.session copy];
+
+        request->task = [session
             dataTaskWithRequest:req
               completionHandler:^(NSData* data, NSURLResponse* res, NSError* error) {
                 if (error && [error code] == NSURLErrorCancelled) {

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -250,7 +250,7 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
             [MGLNativeNetworkManager.sharedManager startDownloadEvent:url.relativePath type:@"tile"];
         }
 
-        NSURLSession *session;
+        __block NSURLSession *session;
 
         // Use the delegate's session if there is one, otherwise use the one that
         // was created when this class was constructed.
@@ -268,6 +268,8 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
         request->task = [session
             dataTaskWithRequest:req
               completionHandler:^(NSData* data, NSURLResponse* res, NSError* error) {
+                session = nil;
+            
                 if (error && [error code] == NSURLErrorCancelled) {
                     [MGLNativeNetworkManager.sharedManager cancelDownloadEventForResponse:res];
                     return;


### PR DESCRIPTION
This PR adds a `sessionForNetworkManager:` optional method to `MGLNativeNetworkManager`; this enables a mechanism for the platform SDK (and the app) to provide an `NSURLSession`.

Tests are being added to the iOS SDK.

Note that `native_apple_interface.h` needs better documentation - currently `MGLNativeNetworkManager` and `MGLNativeNetworkDelegate` should be considered undocumented.

cc @mapbox/maps-ios

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] ~write tests for all new functionality~
 - [ ] ~document any changes to public APIs~ TBD
 - [x] tagged `@mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk` if this PR adds or updates a public API