### PR TITLE
[core] Add Renderer::clearData() instead of keepRenderData map options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,9 @@
 
 ### ✨ New features
 
-- [tile mode][static mode] Clear render data for the new still image request ([#16318](https://github.com/mapbox/mapbox-gl-native/pull/16318))
+- [core] Add Renderer::clearData() ([#16323](https://github.com/mapbox/mapbox-gl-native/pull/16323))
 
-  The new `keepRenderData` map options flag is added to control whether render data shall be kept between `renderStill()` calls.
-
-### 🐞 Bug fixes
-
-- [tile mode][static mode] Clear render data for the new still image request ([#16318](https://github.com/mapbox/mapbox-gl-native/pull/16318))
-
-  If the `keepRenderData` map options flag is unset all render data is cleared between `renderStill()` calls, thus stale tiles from the previous `renderStill()` call are never shown.
-
-### 🏁 Performance improvements
-
-- [tile mode][static mode] Clear render data for the new still image request ([#16318](https://github.com/mapbox/mapbox-gl-native/pull/16318))
-
-  If the `keepRenderData` map options flag is unset all render data is cleared between `renderStill()` calls, thus saving memory being used.
+  The newly added `Renderer::clearData()` method allows to clear render data and thus save memory and make sure outdated tiles are not shown.
 
 ## maps-v1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [core] Add Renderer::clearData() ([#16323](https://github.com/mapbox/mapbox-gl-native/pull/16323))
 
-  The newly added `Renderer::clearData()` method allows to clear render data and thus save memory and make sure outdated tiles are not shown.
+  The newly added `Renderer::clearData()` method allows to clear render data and thus save memory and make sure outdated tiles are not shown. It clears data more agressively than `Renderer::reduceMemoryUse()` does, as it clears not only the cache but all orchestration data, including the data used by the currently rendered frame.
 
 ## maps-v1.4.1
 

--- a/include/mbgl/map/map_options.hpp
+++ b/include/mbgl/map/map_options.hpp
@@ -89,28 +89,6 @@ public:
     bool crossSourceCollisions() const;
 
     /**
-     * @brief Specify whether render data for layers, sources and images should be kept between renderStill() calls.
-     *
-     * This flag is ignored in Continuous mode. In Static mode and Tile mode, if this flag is set to false, all the data
-     * are created from scratch for every renderStill() call, which guaranties that no extra memory is used, however it
-     * might cause higher CPU load and network traffic.
-     *
-     * By default, it is set to true.
-     *
-     * @param keepRenderData true to enable, false to disable
-     * @return MapOptions for chaining options together.
-     */
-    MapOptions& withKeepRenderData(bool keepRenderData);
-
-    /**
-     * @brief Gets the previously set (or default) keepRenderData value.
-     *
-     * @return true if render data is kept between renderStill() calls,
-     * false otherwise.
-     */
-    bool keepRenderData() const;
-
-    /**
      * @brief Sets the orientation of the Map. By default, it is set to
      * Upwards.
      *

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -63,6 +63,7 @@ public:
 
     // Memory
     void reduceMemoryUse();
+    void clearData();
 
 private:
     class Impl;

--- a/metrics/android-render-test-runner/render-tests/map-mode/tile-avoid-edges/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/map-mode/tile-avoid-edges/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            12,
-            340753
+            8,
+            246523
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/android-render-test-runner/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            183111
+            6,
+            268053
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/android-render-test-runner/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            1500180
+            8,
+            1755006
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/android-render-test-runner/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            13,
-            2413450
+            16,
+            2668276
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/android-render-test-runner/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
+++ b/metrics/android-render-test-runner/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            15,
-            2585276
+            22,
+            3183754
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/ios-render-test-runner/render-tests/map-mode/tile-avoid-edges/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/map-mode/tile-avoid-edges/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            12,
-            340753
+            8,
+            246523
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/ios-render-test-runner/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            183111
+            6,
+            268053
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/ios-render-test-runner/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            1500180
+            8,
+            1755006
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/ios-render-test-runner/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            13,
-            2413450
+            16,
+            2668276
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/ios-render-test-runner/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
+++ b/metrics/ios-render-test-runner/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            15,
-            2585276
+            22,
+            3183754
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-clang8-release/render-tests/map-mode/tile-avoid-edges/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/map-mode/tile-avoid-edges/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            12,
-            340753
+            8,
+            246523
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-clang8-release/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            183111
+            6,
+            268053
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-clang8-release/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            1500180
+            8,
+            1755006
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-clang8-release/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            13,
-            2413450
+            16,
+            2668276
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-clang8-release/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
+++ b/metrics/linux-clang8-release/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            15,
-            2585276
+            22,
+            3183754
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-gcc8-release/render-tests/map-mode/tile-avoid-edges/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/map-mode/tile-avoid-edges/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            12,
-            340753
+            8,
+            246523
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-gcc8-release/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/symbol-placement/line-center-buffer-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            183111
+            6,
+            268053
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-gcc8-release/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/symbol-placement/line-center-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            5,
-            1500180
+            8,
+            1755006
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-gcc8-release/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/text-variable-anchor/all-anchors-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            13,
-            2413450
+            16,
+            2668276
         ],
         [
             "probeNetwork - default - start",

--- a/metrics/linux-gcc8-release/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
+++ b/metrics/linux-gcc8-release/render-tests/text-variable-anchor/left-top-right-bottom-offset-tile-map-mode/metrics.json
@@ -2,8 +2,8 @@
     "network": [
         [
             "probeNetwork - default - end",
-            15,
-            2585276
+            22,
+            3183754
         ],
         [
             "probeNetwork - default - start",

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -641,6 +641,7 @@ TestOperations getAfterOperations(const Manifest& manifest) {
 }
 
 void resetContext(const TestMetadata& metadata, TestContext& ctx) {
+    ctx.getFrontend().getRenderer()->clearData();
     ctx.getFrontend().setSize(metadata.size);
     auto& map = ctx.getMap();
     map.setSize(metadata.size);
@@ -683,8 +684,7 @@ TestRunner::Impl::Impl(const TestMetadata& metadata, const mbgl::ResourceOptions
               .withMapMode(metadata.mapMode)
               .withSize(metadata.size)
               .withPixelRatio(metadata.pixelRatio)
-              .withCrossSourceCollisions(metadata.crossSourceCollisions)
-              .withKeepRenderData(metadata.mapMode != MapMode::Tile),
+              .withCrossSourceCollisions(metadata.crossSourceCollisions),
           resourceOptions) {}
 
 TestRunner::Impl::~Impl() {}

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -17,7 +17,6 @@ Map::Impl::Impl(RendererFrontend& frontend_,
       mode(mapOptions.mapMode()),
       pixelRatio(mapOptions.pixelRatio()),
       crossSourceCollisions(mapOptions.crossSourceCollisions()),
-      keepRenderData(mapOptions.keepRenderData()),
       fileSource(std::move(fileSource_)),
       style(std::make_unique<style::Style>(fileSource, pixelRatio)),
       annotationManager(*style) {
@@ -65,9 +64,8 @@ void Map::Impl::onUpdate() {
                                annotationManager.makeWeakPtr(),
                                fileSource,
                                prefetchZoomDelta,
-                               stillImageRequest.get(),
-                               crossSourceCollisions,
-                               keepRenderData};
+                               bool(stillImageRequest),
+                               crossSourceCollisions};
 
     rendererFrontend.update(std::make_shared<UpdateParameters>(std::move(params)));
 }

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -59,7 +59,6 @@ public:
     const MapMode mode;
     const float pixelRatio;
     const bool crossSourceCollisions;
-    const bool keepRenderData;
 
     MapDebugOptions debugOptions { MapDebugOptions::NoDebug };
 

--- a/src/mbgl/map/map_options.cpp
+++ b/src/mbgl/map/map_options.cpp
@@ -9,7 +9,6 @@ public:
     ViewportMode viewportMode = ViewportMode::Default;
     NorthOrientation orientation = NorthOrientation::Upwards;
     bool crossSourceCollisions = true;
-    bool keepRenderData = true;
     Size size = { 64, 64 };
     float pixelRatio = 1.0;
 };
@@ -53,15 +52,6 @@ MapOptions& MapOptions::withCrossSourceCollisions(bool enableCollisions) {
 
 bool MapOptions::crossSourceCollisions() const {
     return impl_->crossSourceCollisions;
-}
-
-MapOptions& MapOptions::withKeepRenderData(bool keepRenderData_) {
-    impl_->keepRenderData = keepRenderData_;
-    return *this;
-}
-
-bool MapOptions::keepRenderData() const {
-    return impl_->keepRenderData;
 }
 
 MapOptions& MapOptions::withNorthOrientation(NorthOrientation orientation) {

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -141,10 +141,6 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     if (!isMapModeContinuous) {
         // Reset zoom history state.
         zoomHistory.first = true;
-        if (!updateParameters->keepRenderData && stillImageRequest != updateParameters->stillImageRequest) {
-            clearData();
-            stillImageRequest = updateParameters->stillImageRequest;
-        }
     }
 
     if (LayerManager::annotationsEnabled) {

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -709,6 +709,7 @@ void RenderOrchestrator::clearData() {
     if (!patternAtlas->isEmpty()) patternAtlas = std::make_unique<PatternAtlas>();
 
     imageManager->clear();
+    glyphManager->evict(fontStacks(*layerImpls));
 }
 
 void RenderOrchestrator::onGlyphsError(const FontStack& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) {

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -75,11 +75,11 @@ public:
 
     void reduceMemoryUse();
     void dumpDebugLogs();
+    void clearData();
 
 private:
     bool isLoaded() const;
     bool hasTransitions(TimePoint) const;
-    void clearData();
 
     RenderSource* getRenderSource(const std::string& id) const;
 
@@ -127,7 +127,6 @@ private:
 
     const bool backgroundLayerAsColor;
     bool contextLost = false;
-    const void* stillImageRequest = nullptr;
 
     // Vectors with reserved capacity of layerImpls->size() to avoid reallocation
     // on each frame.

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -131,4 +131,8 @@ void Renderer::reduceMemoryUse() {
     impl->orchestrator.reduceMemoryUse();
 }
 
+void Renderer::clearData() {
+    impl->orchestrator.clearData();
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -41,12 +41,9 @@ public:
     const uint8_t prefetchZoomDelta;
     
     // For still image requests, render requested
-    const void* stillImageRequest;
+    const bool stillImageRequest;
 
     const bool crossSourceCollisions;
-
-    // If set, the render data from the previous render calls is kept.
-    const bool keepRenderData;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
`Renderer::clearData()` is a better API than the removed `MapOptions::keepRenderData()`:
- gives more flexibility to the client
- similar to the existing `Renderer::reduceMemoryUse()`
- the `MapOptions::keepRenderData()` API implementation could not handle the race condition, which
happened if the new still image request had come before all tiles from the previous requests were loaded.

Co-authored-by: Dane Springmeyer <dane@mapbox.com>

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/215