### PR TITLE
[core] Ability to set generic layer properties using setProperty method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 - [android] Add jni binding for styleable snapshotter ([#16286](https://github.com/mapbox/mapbox-gl-native/pull/16286))
 
+- [core] Ability to set generic layer properties using setProperty method ([#16324](https://github.com/mapbox/mapbox-gl-native/pull/16324))
+  This change enables the following new keys for the `mbgl::Layer::setProperty()` API:
+  - "filter" invokes `setFilter()`
+  - "minzoom" invokes `setMinZoom()`
+  - "maxzoom" invokes `setMaxZoom()`
+  - "source-layer" invokes `setSourceLayer()`
+
+  The newly-added API is used in the style-conversion code, which made this code much simpler.
+
 ### 🐞 Bug fixes
 
 - [core] Use `TileCoordinates` instead of `LngLat` for `within` expression calculation ([#16319](https://github.com/mapbox/mapbox-gl-native/pull/16319))

--- a/include/mbgl/gl/custom_layer.hpp
+++ b/include/mbgl/gl/custom_layer.hpp
@@ -66,21 +66,17 @@ public:
     CustomLayer(const std::string& id,
                 std::unique_ptr<CustomLayerHost> host);
 
+    CustomLayer(const CustomLayer&) = delete;
     ~CustomLayer() final;
-
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-    StyleProperty getProperty(const std::string&) const final;
-    // Private implementation
-
     class Impl;
     const Impl& impl() const;
-
     Mutable<Impl> mutableImpl() const;
+
+private:
+    optional<conversion::Error> setPropertyInternal(const std::string& name,
+                                                    const conversion::Convertible& value) final;
+    StyleProperty getProperty(const std::string&) const final;
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
-
-    CustomLayer(const CustomLayer&) = delete;
-
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/layermanager/layer_factory.hpp
+++ b/include/mbgl/layermanager/layer_factory.hpp
@@ -37,7 +37,6 @@ public:
 
 protected:
     optional<std::string> getSource(const style::conversion::Convertible& value) const noexcept;
-    bool initSourceLayerAndFilter(style::Layer*, const style::conversion::Convertible& value) const noexcept;
 };
 
 } // namespace mbgl

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -110,8 +110,7 @@ public:
     void setMaxZoom(float);
 
     // Dynamic properties
-    virtual optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) = 0;
-    optional<conversion::Error> setVisibility(const conversion::Convertible& value);
+    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value);
 
     virtual StyleProperty getProperty(const std::string&) const = 0;
     virtual Value serialize() const;
@@ -142,9 +141,13 @@ public:
 protected:
     virtual Mutable<Impl> mutableBaseImpl() const = 0;
     void serializeProperty(Value&, const StyleProperty&, const char* propertyName, bool isPaint) const;
-
+    virtual optional<conversion::Error> setPropertyInternal(const std::string& name,
+                                                            const conversion::Convertible& value) = 0;
     LayerObserver* observer;
     mapbox::base::WeakPtrFactory<Layer> weakFactory {this};
+
+private:
+    optional<conversion::Error> setVisibility(const conversion::Convertible& value);
 };
 
 } // namespace style

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -148,6 +148,8 @@ protected:
 
 private:
     optional<conversion::Error> setVisibility(const conversion::Convertible& value);
+    optional<conversion::Error> setMinZoom(const conversion::Convertible& value);
+    optional<conversion::Error> setMaxZoom(const conversion::Convertible& value);
 };
 
 } // namespace style

--- a/include/mbgl/style/layers/background_layer.hpp
+++ b/include/mbgl/style/layers/background_layer.hpp
@@ -20,12 +20,6 @@ public:
     BackgroundLayer(const std::string& layerID);
     ~BackgroundLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Paint properties
 
     static PropertyValue<Color> getDefaultBackgroundColor();
@@ -56,6 +50,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -20,12 +20,6 @@ public:
     CircleLayer(const std::string& layerID, const std::string& sourceID);
     ~CircleLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Paint properties
 
     static PropertyValue<float> getDefaultCircleBlur();
@@ -104,6 +98,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -20,12 +20,6 @@ public:
     FillExtrusionLayer(const std::string& layerID, const std::string& sourceID);
     ~FillExtrusionLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Paint properties
 
     static PropertyValue<float> getDefaultFillExtrusionBase();
@@ -86,6 +80,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/fill_layer.hpp
+++ b/include/mbgl/style/layers/fill_layer.hpp
@@ -20,12 +20,6 @@ public:
     FillLayer(const std::string& layerID, const std::string& sourceID);
     ~FillLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Layout properties
 
     static PropertyValue<float> getDefaultFillSortKey();
@@ -86,6 +80,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/heatmap_layer.hpp
+++ b/include/mbgl/style/layers/heatmap_layer.hpp
@@ -21,12 +21,6 @@ public:
     HeatmapLayer(const std::string& layerID, const std::string& sourceID);
     ~HeatmapLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Paint properties
 
     static ColorRampPropertyValue getDefaultHeatmapColor();
@@ -69,6 +63,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/hillshade_layer.hpp
+++ b/include/mbgl/style/layers/hillshade_layer.hpp
@@ -20,12 +20,6 @@ public:
     HillshadeLayer(const std::string& layerID, const std::string& sourceID);
     ~HillshadeLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Paint properties
 
     static PropertyValue<Color> getDefaultHillshadeAccentColor();
@@ -74,6 +68,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/layer.hpp.ejs
+++ b/include/mbgl/style/layers/layer.hpp.ejs
@@ -36,12 +36,6 @@ public:
 <% } -%>
     ~<%- camelize(type) %>Layer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
 <% if (layoutProperties.length) { -%>
     // Layout properties
 
@@ -72,6 +66,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/line_layer.hpp
+++ b/include/mbgl/style/layers/line_layer.hpp
@@ -23,12 +23,6 @@ public:
     LineLayer(const std::string& layerID, const std::string& sourceID);
     ~LineLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Layout properties
 
     static PropertyValue<LineCapType> getDefaultLineCap();
@@ -129,6 +123,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/raster_layer.hpp
+++ b/include/mbgl/style/layers/raster_layer.hpp
@@ -20,12 +20,6 @@ public:
     RasterLayer(const std::string& layerID, const std::string& sourceID);
     ~RasterLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Paint properties
 
     static PropertyValue<float> getDefaultRasterBrightnessMax();
@@ -86,6 +80,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/include/mbgl/style/layers/symbol_layer.hpp
+++ b/include/mbgl/style/layers/symbol_layer.hpp
@@ -22,12 +22,6 @@ public:
     SymbolLayer(const std::string& layerID, const std::string& sourceID);
     ~SymbolLayer() final;
 
-    // Dynamic properties
-    optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value) final;
-
-    StyleProperty getProperty(const std::string& name) const final;
-    Value serialize() const final;
-
     // Layout properties
 
     static PropertyValue<bool> getDefaultIconAllowOverlap();
@@ -290,6 +284,12 @@ public:
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
 
 protected:
+    // Dynamic properties
+    optional<conversion::Error> setPropertyInternal(const std::string& name, const conversion::Convertible& value) final;
+
+    StyleProperty getProperty(const std::string& name) const final;
+    Value serialize() const final;
+
     Mutable<Layer::Impl> mutableBaseImpl() const final;
 };
 

--- a/src/mbgl/gl/custom_layer.cpp
+++ b/src/mbgl/gl/custom_layer.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<Layer> CustomLayer::cloneRef(const std::string&) const {
 
 using namespace conversion;
 
-optional<Error> CustomLayer::setProperty(const std::string&, const Convertible&) {
+optional<Error> CustomLayer::setPropertyInternal(const std::string&, const Convertible&) {
     return Error { "layer doesn't support this property" };
 }
 

--- a/src/mbgl/layermanager/circle_layer_factory.cpp
+++ b/src/mbgl/layermanager/circle_layer_factory.cpp
@@ -17,11 +17,7 @@ std::unique_ptr<style::Layer> CircleLayerFactory::createLayer(const std::string&
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::CircleLayer(id, *source));
-    if (!initSourceLayerAndFilter(layer.get(), value)) {
-        return nullptr;
-    }
-    return layer;
+    return std::unique_ptr<style::Layer>(new style::CircleLayer(id, *source));
 }
 
 std::unique_ptr<Bucket> CircleLayerFactory::createBucket(const BucketParameters& parameters, const std::vector<Immutable<style::LayerProperties>>& layers) noexcept {

--- a/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
@@ -17,11 +17,7 @@ std::unique_ptr<style::Layer> FillExtrusionLayerFactory::createLayer(const std::
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::FillExtrusionLayer(id, *source));
-    if (!initSourceLayerAndFilter(layer.get(), value)) {
-        return nullptr;
-    }
-    return layer;
+    return std::unique_ptr<style::Layer>(new style::FillExtrusionLayer(id, *source));
 }
 
 std::unique_ptr<Layout> FillExtrusionLayerFactory::createLayout(const LayoutParameters& parameters,

--- a/src/mbgl/layermanager/fill_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_layer_factory.cpp
@@ -17,11 +17,7 @@ std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& i
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::FillLayer(id, *source));
-    if (!initSourceLayerAndFilter(layer.get(), value)) {
-        return nullptr;
-    }
-    return layer;
+    return std::unique_ptr<style::Layer>(new style::FillLayer(id, *source));
 }
 
 std::unique_ptr<Layout>

--- a/src/mbgl/layermanager/heatmap_layer_factory.cpp
+++ b/src/mbgl/layermanager/heatmap_layer_factory.cpp
@@ -17,11 +17,7 @@ std::unique_ptr<style::Layer> HeatmapLayerFactory::createLayer(const std::string
         return nullptr;
     }
 
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::HeatmapLayer(id, *source));
-    if (!initSourceLayerAndFilter(layer.get(), value)) {
-        return nullptr;
-    }
-    return layer;
+    return std::unique_ptr<style::Layer>(new style::HeatmapLayer(id, *source));
 }
 
 std::unique_ptr<Bucket> HeatmapLayerFactory::createBucket(const BucketParameters& parameters, const std::vector<Immutable<style::LayerProperties>>& layers) noexcept {

--- a/src/mbgl/layermanager/layer_factory.cpp
+++ b/src/mbgl/layermanager/layer_factory.cpp
@@ -46,17 +46,6 @@ bool LayerFactory::initSourceLayerAndFilter(style::Layer* layer, const style::co
         }
         layer->setSourceLayer(*sourceLayer);
     }
-
-    auto filterValue = objectMember(value, "filter");
-    if (filterValue) {
-        style::conversion::Error error;
-        optional<style::Filter> filter = style::conversion::convert<style::Filter>(*filterValue, error);
-        if (!filter) {
-            return false;
-        }
-        layer->setFilter(*filter);
-    }
-
     return true;
 }
 

--- a/src/mbgl/layermanager/layer_factory.cpp
+++ b/src/mbgl/layermanager/layer_factory.cpp
@@ -37,16 +37,4 @@ std::unique_ptr<Layout> LayerFactory::createLayout(const LayoutParameters&,
     return nullptr;
 }
 
-bool LayerFactory::initSourceLayerAndFilter(style::Layer* layer, const style::conversion::Convertible& value) const noexcept {
-    auto sourceLayerValue = objectMember(value, "source-layer");
-    if (sourceLayerValue) {
-        optional<std::string> sourceLayer = toString(*sourceLayerValue);
-        if (!sourceLayer) {
-            return false;
-        }
-        layer->setSourceLayer(*sourceLayer);
-    }
-    return true;
-}
-
 } // namespace mbgl

--- a/src/mbgl/layermanager/line_layer_factory.cpp
+++ b/src/mbgl/layermanager/line_layer_factory.cpp
@@ -16,12 +16,7 @@ std::unique_ptr<style::Layer> LineLayerFactory::createLayer(const std::string& i
     if (!source) {
         return nullptr;
     }
-
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::LineLayer(id, *source));
-    if (!initSourceLayerAndFilter(layer.get(), value)) {
-        return nullptr;
-    }
-    return layer;
+    return std::unique_ptr<style::Layer>(new style::LineLayer(id, *source));
 }
 
 std::unique_ptr<Layout> LineLayerFactory::createLayout(const LayoutParameters& parameters,

--- a/src/mbgl/layermanager/symbol_layer_factory.cpp
+++ b/src/mbgl/layermanager/symbol_layer_factory.cpp
@@ -16,12 +16,7 @@ std::unique_ptr<style::Layer> SymbolLayerFactory::createLayer(const std::string&
     if (!source) {
         return nullptr;
     }
-
-    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::SymbolLayer(id, *source));
-    if (!initSourceLayerAndFilter(layer.get(), value)) {
-        return nullptr;
-    }
-    return layer;
+    return std::unique_ptr<style::Layer>(new style::SymbolLayer(id, *source));
 }
 
 std::unique_ptr<Layout> SymbolLayerFactory::createLayout(const LayoutParameters& parameters,

--- a/src/mbgl/style/conversion/layer.cpp
+++ b/src/mbgl/style/conversion/layer.cpp
@@ -68,6 +68,9 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
     if (!setObjectMember(layer, value, "minzoom", error)) return nullopt;
     if (!setObjectMember(layer, value, "maxzoom", error)) return nullopt;
     if (!setObjectMember(layer, value, "filter", error)) return nullopt;
+    if (layer->getTypeInfo()->source == LayerTypeInfo::Source::Required) {
+        if (!setObjectMember(layer, value, "source-layer", error)) return nullopt;
+    }
 
     auto layoutValue = objectMember(value, "layout");
     if (layoutValue) {

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -144,10 +144,27 @@ void Layer::setObserver(LayerObserver* observer_) {
 }
 
 optional<conversion::Error> Layer::setProperty(const std::string& name, const conversion::Convertible& value) {
-    optional<conversion::Error> error = setPropertyInternal(name, value);
+    using namespace conversion;
+    optional<Error> error = setPropertyInternal(name, value);
     if (!error) return error; // Successfully set by the derived class implementation.
     if (name == "visibility") return setVisibility(value);
-    return error; // Must be Error{"layer doesn't support this property"}.
+    if (name == "minzoom") {
+        if (auto zoom = convert<float>(value, *error)) {
+            setMinZoom(*zoom);
+            return nullopt;
+        }
+    } else if (name == "maxzoom") {
+        if (auto zoom = convert<float>(value, *error)) {
+            setMaxZoom(*zoom);
+            return nullopt;
+        }
+    } else if (name == "filter") {
+        if (auto filter = convert<Filter>(value, *error)) {
+            setFilter(*filter);
+            return nullopt;
+        }
+    }
+    return error;
 }
 
 optional<conversion::Error> Layer::setVisibility(const conversion::Convertible& value) {

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/tile/tile.hpp>
 
 #include <mbgl/renderer/render_layer.hpp>
+#include <mbgl/util/logging.hpp>
 
 namespace mbgl {
 namespace style {
@@ -161,6 +162,18 @@ optional<conversion::Error> Layer::setProperty(const std::string& name, const co
     } else if (name == "filter") {
         if (auto filter = convert<Filter>(value, *error)) {
             setFilter(*filter);
+            return nullopt;
+        }
+    } else if (name == "source-layer") {
+        if (auto sourceLayer = convert<std::string>(value, *error)) {
+            if (getTypeInfo()->source != LayerTypeInfo::Source::Required) {
+                Log::Warning(mbgl::Event::General,
+                             "source-layer property cannot be applied to"
+                             "the layer %s",
+                             baseImpl->id.c_str());
+                return nullopt;
+            }
+            setSourceLayer(*sourceLayer);
             return nullopt;
         }
     }

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -143,6 +143,13 @@ void Layer::setObserver(LayerObserver* observer_) {
     observer = observer_ ? observer_ : &nullObserver;
 }
 
+optional<conversion::Error> Layer::setProperty(const std::string& name, const conversion::Convertible& value) {
+    optional<conversion::Error> error = setPropertyInternal(name, value);
+    if (!error) return error; // Successfully set by the derived class implementation.
+    if (name == "visibility") return setVisibility(value);
+    return error; // Must be Error{"layer doesn't support this property"}.
+}
+
 optional<conversion::Error> Layer::setVisibility(const conversion::Convertible& value) {
     using namespace conversion;
 

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -211,12 +211,9 @@ Value BackgroundLayer::serialize() const {
     return result;
 }
 
-optional<Error> BackgroundLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> BackgroundLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -491,12 +491,9 @@ Value CircleLayer::serialize() const {
     return result;
 }
 
-optional<Error> CircleLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> CircleLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -386,12 +386,9 @@ Value FillExtrusionLayer::serialize() const {
     return result;
 }
 
-optional<Error> FillExtrusionLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> FillExtrusionLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -371,12 +371,9 @@ Value FillLayer::serialize() const {
     return result;
 }
 
-optional<Error> FillLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> FillLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -283,12 +283,9 @@ Value HeatmapLayer::serialize() const {
     return result;
 }
 
-optional<Error> HeatmapLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> HeatmapLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -316,12 +316,9 @@ Value HillshadeLayer::serialize() const {
     return result;
 }
 
-optional<Error> HillshadeLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> HillshadeLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -271,12 +271,9 @@ Value <%- camelize(type) %>Layer::serialize() const {
     return result;
 }
 
-optional<Error> <%- camelize(type) %>Layer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> <%- camelize(type) %>Layer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -588,12 +588,9 @@ Value LineLayer::serialize() const {
     return result;
 }
 
-optional<Error> LineLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> LineLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -386,12 +386,9 @@ Value RasterLayer::serialize() const {
     return result;
 }
 
-optional<Error> RasterLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> RasterLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1376,12 +1376,9 @@ Value SymbolLayer::serialize() const {
     return result;
 }
 
-optional<Error> SymbolLayer::setProperty(const std::string& name, const Convertible& value) {
+optional<Error> SymbolLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) {
-        if (name == "visibility") return setVisibility(value);
-        return Error{"layer doesn't support this property"};
-    }
+    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
 
     auto property = static_cast<Property>(it->second);
 


### PR DESCRIPTION
This change enables the following new keys for the `mbgl::Layer::setProperty()` API
* "filter" invokes `setFilter()`
* "minzoom" invokes `setMinZoom()`
* "maxzoom" invokes `setMaxZoom()`
* "source-layer" invokes `setSourceLayer()`

The newly-added API is used in the style-conversion code, which made this code much simpler.

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/220