### PR TITLE
[core] Fix all clang-tidy performance-* errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 Checks: '-*,bugprone-*,clang-analyzer-*,google-*,modernize-*,performance-*,-clang-analyzer-osx.*,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references'
-WarningsAsErrors: 'bugprone-use-after-move,performance-move-const-arg'
+WarningsAsErrors: 'bugprone-use-after-move,performance-*'
 HeaderFilterRegex: '.*'
 FormatStyle: file

--- a/include/mbgl/actor/mailbox.hpp
+++ b/include/mbgl/actor/mailbox.hpp
@@ -36,7 +36,7 @@ public:
     void push(std::unique_ptr<Message>);
     void receive();
 
-    static void maybeReceive(std::weak_ptr<Mailbox>);
+    static void maybeReceive(const std::weak_ptr<Mailbox>&);
     static std::function<void()> makeClosure(std::weak_ptr<Mailbox>);
 
 private:

--- a/include/mbgl/i18n/collator.hpp
+++ b/include/mbgl/i18n/collator.hpp
@@ -10,7 +10,7 @@ namespace platform {
 
 class Collator {
 public:
-    explicit Collator(bool caseSensitive, bool diacriticSensitive, optional<std::string> locale = nullopt);
+    explicit Collator(bool caseSensitive, bool diacriticSensitive, const optional<std::string>& locale = nullopt);
     int compare(const std::string& lhs, const std::string& rhs) const;
     std::string resolvedLocale() const;
     bool operator==(const Collator& other) const;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -60,17 +60,26 @@ public:
     bool isPanning() const;
 
     // Camera
-    CameraOptions getCameraOptions(optional<EdgeInsets> = {}) const;
+    CameraOptions getCameraOptions(const optional<EdgeInsets>& = {}) const;
     void jumpTo(const CameraOptions&);
     void easeTo(const CameraOptions&, const AnimationOptions&);
     void flyTo(const CameraOptions&, const AnimationOptions&);
     void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
-    void scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation = {});
+    void scaleBy(double scale, const optional<ScreenCoordinate>& anchor, const AnimationOptions& animation = {});
     void pitchBy(double pitch, const AnimationOptions& animation = {});
     void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
-    CameraOptions cameraForLatLngBounds(const LatLngBounds&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
-    CameraOptions cameraForLatLngs(const std::vector<LatLng>&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
-    CameraOptions cameraForGeometry(const Geometry<double>&, const EdgeInsets&, optional<double> bearing = {}, optional<double> pitch = {}) const;
+    CameraOptions cameraForLatLngBounds(const LatLngBounds&,
+                                        const EdgeInsets&,
+                                        const optional<double>& bearing = {},
+                                        const optional<double>& pitch = {}) const;
+    CameraOptions cameraForLatLngs(const std::vector<LatLng>&,
+                                   const EdgeInsets&,
+                                   const optional<double>& bearing = {},
+                                   const optional<double>& pitch = {}) const;
+    CameraOptions cameraForGeometry(const Geometry<double>&,
+                                    const EdgeInsets&,
+                                    const optional<double>& bearing = {},
+                                    const optional<double>& pitch = {}) const;
     LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
     LatLngBounds latLngBoundsForCameraUnwrapped(const CameraOptions&) const;
 

--- a/include/mbgl/platform/settings.hpp
+++ b/include/mbgl/platform/settings.hpp
@@ -26,7 +26,7 @@ public:
 
     // Sets multiple setting values by merging current Settings object
     // with provided `values` object.
-    void set(mapbox::base::ValueObject values) noexcept;
+    void set(const mapbox::base::ValueObject& values) noexcept;
 
     // Returns setting value for a specified key or NullValue if element
     // for specified key is missing.

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -23,8 +23,7 @@ class RendererBackend;
 
 class Renderer {
 public:
-    Renderer(gfx::RendererBackend&, float pixelRatio_,
-             const optional<std::string> localFontFamily = {});
+    Renderer(gfx::RendererBackend&, float pixelRatio_, const optional<std::string>& localFontFamily = {});
     ~Renderer();
 
     void markContextLost();

--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -216,7 +216,7 @@ public:
      * executed on the database thread; it is the responsibility of the SDK bindings
      * to re-execute a user-provided callback on the main thread.
      */
-    virtual void deleteOfflineRegion(OfflineRegion, std::function<void(std::exception_ptr)>);
+    virtual void deleteOfflineRegion(OfflineRegion&, std::function<void(std::exception_ptr)>);
 
     /*
      * Invalidate all the tiles from an offline region forcing Mapbox GL to revalidate

--- a/include/mbgl/style/expression/collator.hpp
+++ b/include/mbgl/style/expression/collator.hpp
@@ -11,7 +11,7 @@ namespace expression {
 
 class Collator {
 public:
-    Collator(bool caseSensitive, bool diacriticSensitive, optional<std::string> locale = {});
+    Collator(bool caseSensitive, bool diacriticSensitive, const optional<std::string>& locale = {});
 
     bool operator==(const Collator& other) const;
 

--- a/include/mbgl/style/expression/comparison.hpp
+++ b/include/mbgl/style/expression/comparison.hpp
@@ -15,7 +15,7 @@ ParseResult parseComparison(const mbgl::style::conversion::Convertible&, Parsing
 
 class BasicComparison : public Expression {
 public:
-    using CompareFunctionType = bool (*) (Value, Value);
+    using CompareFunctionType = bool (*)(const Value&, const Value&);
 
     BasicComparison(
         std::string op,
@@ -38,7 +38,7 @@ private:
 
 class CollatorComparison : public Expression {
 public:
-    using CompareFunctionType = bool (*) (std::string, std::string, Collator);
+    using CompareFunctionType = bool (*)(const std::string&, const std::string&, const Collator&);
 
     CollatorComparison(
         std::string op,

--- a/include/mbgl/style/expression/compound_expression.hpp
+++ b/include/mbgl/style/expression/compound_expression.hpp
@@ -46,7 +46,7 @@ protected:
     std::vector<std::unique_ptr<Expression>> args;
 };
 
-ParseResult parseCompoundExpression(const std::string name,
+ParseResult parseCompoundExpression(const std::string& name,
                                     const mbgl::style::conversion::Convertible& value,
                                     ParsingContext& ctx);
 

--- a/include/mbgl/style/expression/dsl.hpp
+++ b/include/mbgl/style/expression/dsl.hpp
@@ -29,13 +29,13 @@ std::unique_ptr<Expression> createExpression(const mbgl::style::conversion::Conv
 std::unique_ptr<Expression> error(std::string);
 
 std::unique_ptr<Expression> literal(const char* value);
-std::unique_ptr<Expression> literal(Value value);
+std::unique_ptr<Expression> literal(const Value& value);
 std::unique_ptr<Expression> literal(std::initializer_list<double> value);
 std::unique_ptr<Expression> literal(std::initializer_list<const char*> value);
 
-std::unique_ptr<Expression>
-assertion(type::Type, std::unique_ptr<Expression>, 
-          std::unique_ptr<Expression> def = nullptr);
+std::unique_ptr<Expression> assertion(const type::Type&,
+                                      std::unique_ptr<Expression>,
+                                      std::unique_ptr<Expression> def = nullptr);
 std::unique_ptr<Expression> number(std::unique_ptr<Expression>,
                                    std::unique_ptr<Expression> def = nullptr);
 std::unique_ptr<Expression> string(std::unique_ptr<Expression>,

--- a/include/mbgl/style/expression/parsing_context.hpp
+++ b/include/mbgl/style/expression/parsing_context.hpp
@@ -93,7 +93,7 @@ public:
         Parse the given style-spec JSON value as an expression.
     */
     ParseResult parseExpression(const mbgl::style::conversion::Convertible& value,
-                                optional<TypeAnnotationOption> = {});
+                                const optional<TypeAnnotationOption>& = {});
 
     /*
         Parse the given style-spec JSON value as an expression intended to be used
@@ -108,8 +108,8 @@ public:
     ParseResult parse(const mbgl::style::conversion::Convertible&,
                       std::size_t,
                       optional<type::Type> = {},
-                      optional<TypeAnnotationOption> = {});
-    
+                      const optional<TypeAnnotationOption>& = {});
+
     /*
         Parse a child expression.  For use by individual Expression::parse() methods.
     */
@@ -168,9 +168,8 @@ private:
         type (either Literal, or the one named in value[0]) and dispatching to the
         appropriate ParseXxxx::parse(const V&, ParsingContext) method.
     */
-    ParseResult parse(const mbgl::style::conversion::Convertible& value,
-                      optional<TypeAnnotationOption> = {});
-    
+    ParseResult parse(const mbgl::style::conversion::Convertible& value, const optional<TypeAnnotationOption>& = {});
+
     std::string key;
     optional<type::Type> expected;
     std::shared_ptr<detail::Scope> scope;

--- a/include/mbgl/style/image.hpp
+++ b/include/mbgl/style/image.hpp
@@ -34,7 +34,7 @@ public:
           bool sdf,
           ImageStretches stretchX = {},
           ImageStretches stretchY = {},
-          optional<ImageContent> content = nullopt);
+          const optional<ImageContent>& content = nullopt);
     Image(std::string id,
           PremultipliedImage&& image,
           float pixelRatio,

--- a/include/mbgl/style/sources/custom_geometry_source.hpp
+++ b/include/mbgl/style/sources/custom_geometry_source.hpp
@@ -37,7 +37,7 @@ public:
         TileOptions tileOptions;
     };
 public:
-    CustomGeometrySource(std::string id, CustomGeometrySource::Options options);
+    CustomGeometrySource(std::string id, const CustomGeometrySource::Options& options);
     ~CustomGeometrySource() final;
     void loadDescription(FileSource&) final;
     void setTileData(const CanonicalTileID&, const GeoJSON&);

--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -42,7 +42,7 @@ public:
     using TileFeatures = mapbox::feature::feature_collection<int16_t>;
     using Features = mapbox::feature::feature_collection<double>;
     static std::shared_ptr<GeoJSONData> create(const GeoJSON&,
-                                               Immutable<GeoJSONOptions> = GeoJSONOptions::defaultOptions(),
+                                               const Immutable<GeoJSONOptions>& = GeoJSONOptions::defaultOptions(),
                                                std::shared_ptr<Scheduler> scheduler = nullptr);
 
     virtual ~GeoJSONData() = default;

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -65,7 +65,7 @@ inline std::string toString(long double t, bool decimal = false) {
     return toString(static_cast<double>(t), decimal);
 }
 
-std::string toString(std::exception_ptr);
+std::string toString(const std::exception_ptr &);
 
 template <class T>
 std::string toString(T) = delete;

--- a/platform/android/src/i18n/collator.cpp
+++ b/platform/android/src/i18n/collator.cpp
@@ -173,10 +173,8 @@ private:
     jni::Global<jni::Object<android::Locale>> locale;
 };
 
-
-Collator::Collator(bool caseSensitive, bool diacriticSensitive, optional<std::string> locale_)
-    : impl(std::make_shared<Impl>(caseSensitive, diacriticSensitive, std::move(locale_)))
-{}
+Collator::Collator(bool caseSensitive, bool diacriticSensitive, const optional<std::string>& locale_)
+    : impl(std::make_shared<Impl>(caseSensitive, diacriticSensitive, locale_)) {}
 
 bool Collator::operator==(const Collator& other) const {
     return *impl == *(other.impl);

--- a/platform/android/src/offline/offline_region.cpp
+++ b/platform/android/src/offline/offline_region.cpp
@@ -111,7 +111,7 @@ void OfflineRegion::getOfflineRegionStatus(jni::JNIEnv& env_, const jni::Object<
 void OfflineRegion::deleteOfflineRegion(jni::JNIEnv& env_, const jni::Object<OfflineRegionDeleteCallback>& callback_) {
     auto globalCallback = jni::NewGlobal<jni::EnvAttachingDeleter>(env_, callback_);
 
-    fileSource->deleteOfflineRegion(std::move(*region),
+    fileSource->deleteOfflineRegion(*region,
                                     [
                                         // Ensure the object is not gc'd in the meanwhile
                                         callback = std::make_shared<decltype(globalCallback)>(

--- a/platform/android/src/test/collator_test_stub.cpp
+++ b/platform/android/src/test/collator_test_stub.cpp
@@ -16,7 +16,7 @@ public:
     std::string resolvedLocale() const { return ""; }
 };
 
-Collator::Collator(bool, bool, optional<std::string> locale_) : impl(std::make_shared<Impl>(std::move(locale_))) {}
+Collator::Collator(bool, bool, const optional<std::string>& locale_) : impl(std::make_shared<Impl>(locale_)) {}
 
 int Collator::compare(const std::string& lhs, const std::string& rhs) const {
     return impl->compare(lhs, rhs);

--- a/platform/android/src/text/local_glyph_rasterizer.cpp
+++ b/platform/android/src/text/local_glyph_rasterizer.cpp
@@ -89,9 +89,8 @@ private:
     android::LocalGlyphRasterizer androidLocalGlyphRasterizer;
 };
 
-LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string> fontFamily)
-    : impl(std::make_unique<Impl>(fontFamily))
-{}
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string>& fontFamily)
+    : impl(std::make_unique<Impl>(fontFamily)) {}
 
 LocalGlyphRasterizer::~LocalGlyphRasterizer()
 {}

--- a/platform/darwin/src/collator.mm
+++ b/platform/darwin/src/collator.mm
@@ -9,7 +9,7 @@ namespace platform {
 
 class Collator::Impl {
 public:
-    Impl(bool caseSensitive, bool diacriticSensitive, optional<std::string> locale_)
+    Impl(bool caseSensitive, bool diacriticSensitive, const optional<std::string>& locale_)
         : options((caseSensitive ? 0 : NSCaseInsensitiveSearch) |
                   (diacriticSensitive ? 0 : NSDiacriticInsensitiveSearch))
         , locale(locale_ ?
@@ -47,8 +47,8 @@ private:
     NSLocale* locale;
 };
 
-Collator::Collator(bool caseSensitive, bool diacriticSensitive, optional<std::string> locale_)
-    : impl(std::make_shared<Impl>(caseSensitive, diacriticSensitive, std::move(locale_)))
+Collator::Collator(bool caseSensitive, bool diacriticSensitive, const optional<std::string>& locale_)
+    : impl(std::make_shared<Impl>(caseSensitive, diacriticSensitive, locale_))
 {}
 
 bool Collator::operator==(const Collator& other) const {

--- a/platform/darwin/src/local_glyph_rasterizer.mm
+++ b/platform/darwin/src/local_glyph_rasterizer.mm
@@ -88,7 +88,7 @@ private:
     CTFontRef fontHandle;
 };
 
-LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string> fontFamily)
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string>& fontFamily)
     : impl(std::make_unique<Impl>(fontFamily))
 {}
 

--- a/platform/default/include/mbgl/gfx/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_frontend.hpp
@@ -26,12 +26,12 @@ public:
     HeadlessFrontend(float pixelRatio_,
                      gfx::HeadlessBackend::SwapBehaviour swapBehviour = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
-                     const optional<std::string> localFontFamily = {});
+                     const optional<std::string>& localFontFamily = {});
     HeadlessFrontend(Size,
                      float pixelRatio_,
                      gfx::HeadlessBackend::SwapBehaviour swapBehviour = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
-                     const optional<std::string> localFontFamily = {});
+                     const optional<std::string>& localFontFamily = {});
     ~HeadlessFrontend() override;
 
     void reset() override;

--- a/platform/default/include/mbgl/storage/local_file_request.hpp
+++ b/platform/default/include/mbgl/storage/local_file_request.hpp
@@ -8,6 +8,6 @@ template <typename>
 class ActorRef;
 class FileSourceRequest;
 
-void requestLocalFile(const std::string&, ActorRef<FileSourceRequest>);
+void requestLocalFile(const std::string&, const ActorRef<FileSourceRequest>&);
 
 } // namespace mbgl

--- a/platform/default/include/mbgl/storage/sqlite3.hpp
+++ b/platform/default/include/mbgl/storage/sqlite3.hpp
@@ -79,9 +79,9 @@ public:
     static mapbox::util::variant<Database, Exception> tryOpen(const std::string &filename, int flags = 0);
     static Database open(const std::string &filename, int flags = 0);
 
-    Database(Database &&);
+    Database(Database&&) noexcept;
     ~Database();
-    Database &operator=(Database &&);
+    Database& operator=(Database&&) noexcept;
 
     void setBusyTimeout(std::chrono::milliseconds);
     void exec(const std::string &sql);

--- a/platform/default/src/mbgl/gfx/headless_frontend.cpp
+++ b/platform/default/src/mbgl/gfx/headless_frontend.cpp
@@ -14,14 +14,14 @@ namespace mbgl {
 HeadlessFrontend::HeadlessFrontend(float pixelRatio_,
                                    gfx::HeadlessBackend::SwapBehaviour swapBehavior,
                                    const gfx::ContextMode contextMode,
-                                   const optional<std::string> localFontFamily)
+                                   const optional<std::string>& localFontFamily)
     : HeadlessFrontend({256, 256}, pixelRatio_, swapBehavior, contextMode, localFontFamily) {}
 
 HeadlessFrontend::HeadlessFrontend(Size size_,
                                    float pixelRatio_,
                                    gfx::HeadlessBackend::SwapBehaviour swapBehavior,
                                    const gfx::ContextMode contextMode,
-                                   const optional<std::string> localFontFamily)
+                                   const optional<std::string>& localFontFamily)
     : size(size_),
       pixelRatio(pixelRatio_),
       frameTime(0),
@@ -144,7 +144,7 @@ HeadlessFrontend::RenderResult HeadlessFrontend::render(Map& map) {
     HeadlessFrontend::RenderResult result;
     std::exception_ptr error;
 
-    map.renderStill([&](std::exception_ptr e) {
+    map.renderStill([&](const std::exception_ptr& e) {
         if (e) {
             error = e;
         } else {

--- a/platform/default/src/mbgl/i18n/collator.cpp
+++ b/platform/default/src/mbgl/i18n/collator.cpp
@@ -50,10 +50,8 @@ namespace platform {
 
 class Collator::Impl {
 public:
-    Impl(bool caseSensitive_, bool diacriticSensitive_, optional<std::string>)
-        : caseSensitive(caseSensitive_)
-        , diacriticSensitive(diacriticSensitive_)
-    {}
+    Impl(bool caseSensitive_, bool diacriticSensitive_, const optional<std::string>&)
+        : caseSensitive(caseSensitive_), diacriticSensitive(diacriticSensitive_) {}
 
     bool operator==(const Impl& other) const {
         return caseSensitive == other.caseSensitive && diacriticSensitive == other.diacriticSensitive;
@@ -94,8 +92,8 @@ std::string Collator::resolvedLocale() const {
     return impl->resolvedLocale();
 }
 
-Collator::Collator(bool caseSensitive, bool diacriticSensitive, optional<std::string> locale)
-    : impl(std::make_shared<Impl>(caseSensitive, diacriticSensitive, std::move(locale))) {}
+Collator::Collator(bool caseSensitive, bool diacriticSensitive, const optional<std::string>& locale)
+    : impl(std::make_shared<Impl>(caseSensitive, diacriticSensitive, locale)) {}
 
 } // namespace platform
 } // namespace mbgl

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -14,6 +14,7 @@
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/thread.hpp>
+#include <utility>
 
 namespace mbgl {
 
@@ -49,12 +50,12 @@ private:
 
 class SnapshotterRenderer final : public RendererObserver {
 public:
-    SnapshotterRenderer(Size size, float pixelRatio, optional<std::string> localFontFamily)
+    SnapshotterRenderer(Size size, float pixelRatio, const optional<std::string>& localFontFamily)
         : frontend(size,
                    pixelRatio,
                    gfx::HeadlessBackend::SwapBehaviour::NoFlush,
                    gfx::ContextMode::Unique,
-                   std::move(localFontFamily)) {}
+                   localFontFamily) {}
 
     void reset() {
         hasPendingStillImageRequest = false;
@@ -178,11 +179,11 @@ public:
                                              Attributions attributions,
                                              PointForFn pfn,
                                              LatLngForFn latLonFn) {
-                cb(ptr, std::move(image), std::move(attributions), std::move(pfn), std::move(latLonFn));
+                cb(std::move(ptr), std::move(image), std::move(attributions), std::move(pfn), std::move(latLonFn));
                 renderStillCallback.reset();
             });
 
-        map.renderStill([this, actorRef = renderStillCallback->self()](std::exception_ptr error) {
+        map.renderStill([this, actorRef = renderStillCallback->self()](const std::exception_ptr& error) {
             // Create lambda that captures the current transform state
             // and can be used to translate for geographic to screen
             // coordinates

--- a/platform/default/src/mbgl/storage/asset_file_source.cpp
+++ b/platform/default/src/mbgl/storage/asset_file_source.cpp
@@ -19,11 +19,9 @@ namespace mbgl {
 
 class AssetFileSource::Impl {
 public:
-    Impl(ActorRef<Impl>, std::string root_)
-        : root(std::move(root_)) {
-    }
+    Impl(const ActorRef<Impl>&, std::string root_) : root(std::move(root_)) {}
 
-    void request(const std::string& url, ActorRef<FileSourceRequest> req) {
+    void request(const std::string& url, const ActorRef<FileSourceRequest>& req) {
         if (!acceptsURL(url)) {
             Response response;
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::Other,
@@ -35,7 +33,7 @@ public:
         // Cut off the protocol and prefix with path.
         const auto path =
             root + "/" + mbgl::util::percentDecode(url.substr(std::char_traits<char>::length(util::ASSET_PROTOCOL)));
-        requestLocalFile(path, std::move(req));
+        requestLocalFile(path, req);
     }
 
 private:

--- a/platform/default/src/mbgl/storage/local_file_request.cpp
+++ b/platform/default/src/mbgl/storage/local_file_request.cpp
@@ -11,7 +11,7 @@
 
 namespace mbgl {
 
-void requestLocalFile(const std::string& path, ActorRef<FileSourceRequest> req) {
+void requestLocalFile(const std::string& path, const ActorRef<FileSourceRequest>& req) {
     Response response;
     struct stat buf;
     int result = stat(path.c_str(), &buf);

--- a/platform/default/src/mbgl/storage/local_file_source.cpp
+++ b/platform/default/src/mbgl/storage/local_file_source.cpp
@@ -19,9 +19,9 @@ namespace mbgl {
 
 class LocalFileSource::Impl {
 public:
-    Impl(ActorRef<Impl>) {}
+    Impl(const ActorRef<Impl>&) {}
 
-    void request(const std::string& url, ActorRef<FileSourceRequest> req) {
+    void request(const std::string& url, const ActorRef<FileSourceRequest>& req) {
         if (!acceptsURL(url)) {
             Response response;
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::Other,
@@ -32,7 +32,7 @@ public:
 
         // Cut off the protocol and prefix with path.
         const auto path = mbgl::util::percentDecode(url.substr(std::char_traits<char>::length(util::FILE_PROTOCOL)));
-        requestLocalFile(path, std::move(req));
+        requestLocalFile(path, req);
     }
 };
 

--- a/platform/default/src/mbgl/storage/main_resource_loader.cpp
+++ b/platform/default/src/mbgl/storage/main_resource_loader.cpp
@@ -25,7 +25,7 @@ public:
           localFileSource(std::move(localFileSource_)),
           onlineFileSource(std::move(onlineFileSource_)) {}
 
-    void request(AsyncRequest* req, Resource resource, ActorRef<FileSourceRequest> ref) {
+    void request(AsyncRequest* req, const Resource& resource, const ActorRef<FileSourceRequest>& ref) {
         auto callback = [ref](const Response& res) { ref.invoke(&FileSourceRequest::setResponse, res); };
 
         auto requestFromNetwork = [=](const Resource& res,
@@ -38,7 +38,7 @@ public:
             std::shared_ptr<AsyncRequest> parentKeepAlive = std::move(parent);
 
             MBGL_TIMING_START(watch);
-            return onlineFileSource->request(res, [=, ptr = parentKeepAlive](Response response) {
+            return onlineFileSource->request(res, [=, ptr = parentKeepAlive](const Response& response) {
                 if (databaseFileSource) {
                     databaseFileSource->forward(res, response);
                 }
@@ -72,7 +72,7 @@ public:
                 tasks[req] = databaseFileSource->request(resource, callback);
             } else {
                 // Cache request with fallback to network with cache control
-                tasks[req] = databaseFileSource->request(resource, [=](Response response) {
+                tasks[req] = databaseFileSource->request(resource, [=](const Response& response) {
                     Resource res = resource;
 
                     // Resource is in the cache

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -236,7 +236,7 @@ void OfflineDownload::activateDownload() {
     styleResource.setPriority(Resource::Priority::Low);
     styleResource.setUsage(Resource::Usage::Offline);
 
-    ensureResource(std::move(styleResource), [&](Response styleResponse) {
+    ensureResource(std::move(styleResource), [&](const Response& styleResponse) {
         status.requiredResourceCountIsPrecise = true;
 
         style::Parser parser;
@@ -258,7 +258,7 @@ void OfflineDownload::activateDownload() {
                     sourceResource.setPriority(Resource::Priority::Low);
                     sourceResource.setUsage(Resource::Usage::Offline);
 
-                    ensureResource(std::move(sourceResource), [=](Response sourceResponse) {
+                    ensureResource(std::move(sourceResource), [=](const Response& sourceResponse) {
                         style::conversion::Error error;
                         optional<Tileset> tileset = style::conversion::convertJSON<Tileset>(*sourceResponse.data, error);
                         if (tileset) {
@@ -275,45 +275,45 @@ void OfflineDownload::activateDownload() {
             };
 
             switch (type) {
-            case SourceType::Vector: {
-                const auto& vectorSource = *source->as<VectorSource>();
-                handleTiledSource(vectorSource.getURLOrTileset(), util::tileSize);
-                break;
-            }
-
-            case SourceType::Raster: {
-                const auto& rasterSource = *source->as<RasterSource>();
-                handleTiledSource(rasterSource.getURLOrTileset(), rasterSource.getTileSize());
-                break;
-            }
-
-            case SourceType::RasterDEM: {
-                const auto& rasterDEMSource = *source->as<RasterDEMSource>();
-                handleTiledSource(rasterDEMSource.getURLOrTileset(), rasterDEMSource.getTileSize());
-                break;
-            }
-
-            case SourceType::GeoJSON: {
-                const auto& geojsonSource = *source->as<GeoJSONSource>();
-                if (geojsonSource.getURL()) {
-                    queueResource(Resource::source(*geojsonSource.getURL()));
+                case SourceType::Vector: {
+                    const auto& vectorSource = *source->as<VectorSource>();
+                    handleTiledSource(vectorSource.getURLOrTileset(), util::tileSize);
+                    break;
                 }
-                break;
-            }
 
-            case SourceType::Image: {
-                const auto& imageSource = *source->as<ImageSource>();
-                auto imageUrl = imageSource.getURL();
-                if (imageUrl && !imageUrl->empty()) {
-                    queueResource(Resource::image(*imageUrl));
+                case SourceType::Raster: {
+                    const auto& rasterSource = *source->as<RasterSource>();
+                    handleTiledSource(rasterSource.getURLOrTileset(), rasterSource.getTileSize());
+                    break;
                 }
-                break;
-            }
 
-            case SourceType::Video:
-            case SourceType::Annotations:
-            case SourceType::CustomVector:
-                break;
+                case SourceType::RasterDEM: {
+                    const auto& rasterDEMSource = *source->as<RasterDEMSource>();
+                    handleTiledSource(rasterDEMSource.getURLOrTileset(), rasterDEMSource.getTileSize());
+                    break;
+                }
+
+                case SourceType::GeoJSON: {
+                    const auto& geojsonSource = *source->as<GeoJSONSource>();
+                    if (geojsonSource.getURL()) {
+                        queueResource(Resource::source(*geojsonSource.getURL()));
+                    }
+                    break;
+                }
+
+                case SourceType::Image: {
+                    const auto& imageSource = *source->as<ImageSource>();
+                    auto imageUrl = imageSource.getURL();
+                    if (imageUrl && !imageUrl->empty()) {
+                        queueResource(Resource::image(*imageUrl));
+                    }
+                    break;
+                }
+
+                case SourceType::Video:
+                case SourceType::Annotations:
+                case SourceType::CustomVector:
+                    break;
             }
         }
 
@@ -481,7 +481,7 @@ void OfflineDownload::ensureResource(Resource&& resource,
         }
 
         auto fileRequestsIt = requests.insert(requests.begin(), nullptr);
-        *fileRequestsIt = onlineFileSource.request(resource, [=](Response onlineResponse) {
+        *fileRequestsIt = onlineFileSource.request(resource, [=](const Response& onlineResponse) {
             if (onlineResponse.error) {
                 observer->responseError(*onlineResponse.error);
                 if (onlineResponse.error->reason == Response::Error::Reason::NotFound) {

--- a/platform/default/src/mbgl/storage/sqlite3.cpp
+++ b/platform/default/src/mbgl/storage/sqlite3.cpp
@@ -144,10 +144,9 @@ Database::Database(std::unique_ptr<DatabaseImpl> impl_)
     : impl(std::move(impl_))
 {}
 
-Database::Database(Database &&other)
-    : impl(std::move(other.impl)) {}
+Database::Database(Database&& other) noexcept : impl(std::move(other.impl)) {}
 
-Database &Database::operator=(Database &&other) {
+Database& Database::operator=(Database&& other) noexcept {
     std::swap(impl, other.impl);
     return *this;
 }

--- a/platform/default/src/mbgl/text/bidi.cpp
+++ b/platform/default/src/mbgl/text/bidi.cpp
@@ -5,6 +5,7 @@
 #include <unicode/ushape.h>
 
 #include <memory>
+#include <utility>
 
 namespace mbgl {
 
@@ -98,7 +99,7 @@ std::vector<std::u16string> BiDi::processText(const std::u16string& input,
         throw std::runtime_error(std::string("BiDi::processText: ") + u_errorName(errorCode));
     }
 
-    return applyLineBreaking(lineBreakPoints);
+    return applyLineBreaking(std::move(lineBreakPoints));
 }
     
 std::vector<StyledText> BiDi::processStyledText(const StyledText& input, std::set<std::size_t> lineBreakPoints) {

--- a/platform/default/src/mbgl/text/local_glyph_rasterizer.cpp
+++ b/platform/default/src/mbgl/text/local_glyph_rasterizer.cpp
@@ -5,8 +5,7 @@ namespace mbgl {
 class LocalGlyphRasterizer::Impl {
 };
 
-LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string>)
-{}
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string>&) {}
 
 LocalGlyphRasterizer::~LocalGlyphRasterizer()
 {}

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <utility>
 
 class SnapshotObserver final : public mbgl::MapSnapshotterObserver {
 public:
@@ -640,11 +641,11 @@ void GLFWView::makeSnapshot(bool withOverlay) {
 
     auto snapshot = [&] {
         snapshotter->setCameraOptions(map->getCameraOptions());
-        snapshotter->snapshot([](std::exception_ptr ptr,
+        snapshotter->snapshot([](const std::exception_ptr &ptr,
                                  mbgl::PremultipliedImage image,
-                                 mbgl::MapSnapshotter::Attributions,
-                                 mbgl::MapSnapshotter::PointForFn,
-                                 mbgl::MapSnapshotter::LatLngForFn) {
+                                 const mbgl::MapSnapshotter::Attributions &,
+                                 const mbgl::MapSnapshotter::PointForFn &,
+                                 const mbgl::MapSnapshotter::LatLngForFn &) {
             if (!ptr) {
                 mbgl::Log::Info(mbgl::Event::General,
                                 "Made snapshot './snapshot.png' with size w:%dpx h:%dpx",
@@ -865,7 +866,7 @@ void GLFWView::report(float duration) {
 }
 
 void GLFWView::setChangeStyleCallback(std::function<void()> callback) {
-    changeStyleCallback = callback;
+    changeStyleCallback = std::move(callback);
 }
 
 void GLFWView::setShouldClose() {

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, char *argv[]) {
     auto databaseFileSource = std::static_pointer_cast<mbgl::DatabaseFileSource>(std::shared_ptr<mbgl::FileSource>(
         mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resourceOptions)));
     view->setResetCacheCallback([databaseFileSource]() {
-        databaseFileSource->resetDatabase([](std::exception_ptr ex) {
+        databaseFileSource->resetDatabase([](const std::exception_ptr& ex) {
             if (ex) {
                 mbgl::Log::Error(mbgl::Event::Database, "Failed to reset cache:: %s", mbgl::util::toString(ex).c_str());
             }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -443,7 +443,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         assert(!nodeMap->image.data);
         nodeMap->req = std::make_unique<RenderRequest>(Nan::To<v8::Function>(info[1]).ToLocalChecked());
 
-        nodeMap->startRender(std::move(options));
+        nodeMap->startRender(options);
     } catch (const mbgl::style::conversion::Error& err) {
         return Nan::ThrowTypeError(err.message.c_str());
     } catch (const mbgl::util::StyleParseException& ex) {
@@ -455,7 +455,7 @@ void NodeMap::Render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     info.GetReturnValue().SetUndefined();
 }
 
-void NodeMap::startRender(NodeMap::RenderOptions options) {
+void NodeMap::startRender(const NodeMap::RenderOptions& options) {
     frontend->setSize(options.size);
     map->setSize(options.size);
 
@@ -472,7 +472,7 @@ void NodeMap::startRender(NodeMap::RenderOptions options) {
 
     map->setProjectionMode(projectionOptions);
 
-    map->renderStill(camera, options.debugOptions, [this](const std::exception_ptr eptr) {
+    map->renderStill(camera, options.debugOptions, [this](const std::exception_ptr& eptr) {
         if (eptr) {
             error = eptr;
             uv_async_send(async);

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -70,7 +70,7 @@ public:
 
     static v8::Local<v8::Value> ParseError(const char* msg);
 
-    void startRender(RenderOptions options);
+    void startRender(const RenderOptions& options);
     void renderFinished();
 
     void release();

--- a/platform/qt/src/local_glyph_rasterizer.cpp
+++ b/platform/qt/src/local_glyph_rasterizer.cpp
@@ -12,7 +12,7 @@ namespace mbgl {
 
 class LocalGlyphRasterizer::Impl {
 public:
-    Impl(const optional<std::string> fontFamily_);
+    Impl(const optional<std::string>& fontFamily_);
 
     bool isConfigured() const;
 
@@ -21,8 +21,7 @@ public:
     optional<QFontMetrics> metrics;
 };
 
-LocalGlyphRasterizer::Impl::Impl(const optional<std::string> fontFamily_)
-    : fontFamily(fontFamily_) {
+LocalGlyphRasterizer::Impl::Impl(const optional<std::string>& fontFamily_) : fontFamily(fontFamily_) {
     if (isConfigured()) {
         font.setFamily(QString::fromStdString(*fontFamily));
         font.setPixelSize(util::ONE_EM);
@@ -34,9 +33,8 @@ bool LocalGlyphRasterizer::Impl::isConfigured() const {
     return fontFamily.operator bool();
 }
 
-LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string> fontFamily)
-    : impl(std::make_unique<Impl>(fontFamily)) {
-}
+LocalGlyphRasterizer::LocalGlyphRasterizer(const optional<std::string>& fontFamily)
+    : impl(std::make_unique<Impl>(fontFamily)) {}
 
 LocalGlyphRasterizer::~LocalGlyphRasterizer() {
 }

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -91,7 +91,7 @@ void Mailbox::receive() {
 }
 
 // static
-void Mailbox::maybeReceive(std::weak_ptr<Mailbox> mailbox) {
+void Mailbox::maybeReceive(const std::weak_ptr<Mailbox>& mailbox) {
     if (auto locked = mailbox.lock()) {
         locked->receive();
     }
@@ -99,7 +99,7 @@ void Mailbox::maybeReceive(std::weak_ptr<Mailbox> mailbox) {
 
 // static
 std::function<void()> Mailbox::makeClosure(std::weak_ptr<Mailbox> mailbox) {
-    return [mailbox]() { maybeReceive(mailbox); };
+    return [mailbox = std::move(mailbox)]() { maybeReceive(mailbox); };
 }
 
 } // namespace mbgl

--- a/src/mbgl/layout/clip_lines.cpp
+++ b/src/mbgl/layout/clip_lines.cpp
@@ -23,33 +23,41 @@ GeometryCollection clipLines(const GeometryCollection &lines,
             if (p0.x < x1 && p1.x < x1) {
                 continue;
             } else if (p0.x < x1) {
-                p0 = { x1, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x)))) };
+                p0 = {x1,
+                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x))))};
             } else if (p1.x < x1) {
-                p1 = { x1, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x)))) };
+                p1 = {x1,
+                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x))))};
             }
 
             if (p0.y < y1 && p1.y < y1) {
                 continue;
             } else if (p0.y < y1) {
-                p0 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))), y1 };
+                p0 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))),
+                      y1};
             } else if (p1.y < y1) {
-                p1 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))), y1 };
+                p1 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))),
+                      y1};
             }
 
             if (p0.x >= x2 && p1.x >= x2) {
                 continue;
             } else if (p0.x >= x2) {
-                p0 = { x2, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x)))) };
+                p0 = {x2,
+                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x))))};
             } else if (p1.x >= x2) {
-                p1 = { x2, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x)))) };
+                p1 = {x2,
+                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x))))};
             }
 
             if (p0.y >= y2 && p1.y >= y2) {
                 continue;
             } else if (p0.y >= y2) {
-                p0 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))), y2 };
+                p0 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))),
+                      y2};
             } else if (p1.y >= y2) {
-                p1 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))), y2 };
+                p1 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))),
+                      y2};
             }
 
             if (clippedLines.empty() || (!clippedLines.back().empty() && !(p0 == clippedLines.back().back()))) {

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -571,7 +571,7 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
             verticallyShapedIcon->fitIconToText(
                 shapedTextOrientations.vertical, iconTextFit, layout->get<IconTextFitPadding>(), iconOffset, fontScale);
         }
-        const auto shapedText = getDefaultHorizontalShaping(shapedTextOrientations);
+        const auto& shapedText = getDefaultHorizontalShaping(shapedTextOrientations);
         if (shapedText) {
             shapedIcon->fitIconToText(
                 shapedText, iconTextFit, layout->get<IconTextFitPadding>(), iconOffset, fontScale);

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -961,7 +961,7 @@ size_t SymbolLayout::addSymbol(SymbolBucket::Buffer& buffer,
 
     if (buffer.segments.empty() ||
         buffer.segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max() ||
-        fabs(buffer.segments.back().sortKey - sortKey) > std::numeric_limits<float>::epsilon()) {
+        std::fabs(buffer.segments.back().sortKey - sortKey) > std::numeric_limits<float>::epsilon()) {
         buffer.segments.emplace_back(buffer.vertices.elements(), buffer.triangles.elements(), 0ul, 0ul, sortKey);
     }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -128,7 +128,7 @@ bool Map::isPanning() const {
 
 #pragma mark -
 
-CameraOptions Map::getCameraOptions(optional<EdgeInsets> padding) const {
+CameraOptions Map::getCameraOptions(const optional<EdgeInsets>& padding) const {
     return impl->transform.getCameraOptions(padding);
 }
 
@@ -158,7 +158,7 @@ void Map::pitchBy(double pitch, const AnimationOptions& animation) {
     easeTo(CameraOptions().withPitch((impl->transform.getPitch() * util::RAD2DEG) - pitch), animation);
 }
 
-void Map::scaleBy(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
+void Map::scaleBy(double scale, const optional<ScreenCoordinate>& anchor, const AnimationOptions& animation) {
     const double zoom = impl->transform.getZoom() + impl->transform.getState().scaleZoom(scale);
     easeTo(CameraOptions().withZoom(zoom).withAnchor(anchor), animation);
 }
@@ -169,13 +169,20 @@ void Map::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second
     impl->onUpdate();
 }
 
-CameraOptions Map::cameraForLatLngBounds(const LatLngBounds& bounds, const EdgeInsets& padding, optional<double> bearing, optional<double> pitch) const {
-    return cameraForLatLngs({
-        bounds.northwest(),
-        bounds.southwest(),
-        bounds.southeast(),
-        bounds.northeast(),
-    }, padding, bearing, pitch);
+CameraOptions Map::cameraForLatLngBounds(const LatLngBounds& bounds,
+                                         const EdgeInsets& padding,
+                                         const optional<double>& bearing,
+                                         const optional<double>& pitch) const {
+    return cameraForLatLngs(
+        {
+            bounds.northwest(),
+            bounds.southwest(),
+            bounds.southeast(),
+            bounds.northeast(),
+        },
+        padding,
+        bearing,
+        pitch);
 }
 
 CameraOptions cameraForLatLngs(const std::vector<LatLng>& latLngs, const Transform& transform, const EdgeInsets& padding) {
@@ -223,8 +230,10 @@ CameraOptions cameraForLatLngs(const std::vector<LatLng>& latLngs, const Transfo
         .withZoom(zoom);
 }
 
-CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, const EdgeInsets& padding, optional<double> bearing, optional<double> pitch) const {
-
+CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs,
+                                    const EdgeInsets& padding,
+                                    const optional<double>& bearing,
+                                    const optional<double>& pitch) const {
     if (!bearing && !pitch) {
         return mbgl::cameraForLatLngs(latLngs, impl->transform, padding);
     }
@@ -240,8 +249,10 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, const Ed
         .withPitch(transform.getPitch() * util::RAD2DEG);
 }
 
-CameraOptions Map::cameraForGeometry(const Geometry<double>& geometry, const EdgeInsets& padding, optional<double> bearing, optional<double> pitch) const {
-
+CameraOptions Map::cameraForGeometry(const Geometry<double>& geometry,
+                                     const EdgeInsets& padding,
+                                     const optional<double>& bearing,
+                                     const optional<double>& pitch) const {
     std::vector<LatLng> latLngs;
     forEachPoint(geometry, [&](const Point<double>& pt) {
         latLngs.emplace_back(pt.y, pt.x);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -11,8 +11,9 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
 
-#include <cstdio>
 #include <cmath>
+#include <cstdio>
+#include <utility>
 
 namespace mbgl {
 
@@ -66,7 +67,7 @@ void Transform::resize(const Size size) {
 
 #pragma mark - Camera
 
-CameraOptions Transform::getCameraOptions(optional<EdgeInsets> padding) const {
+CameraOptions Transform::getCameraOptions(const optional<EdgeInsets>& padding) const {
     return state.getCameraOptions(padding);
 }
 
@@ -491,7 +492,7 @@ ProjectionMode Transform::getProjectionMode() const {
 
 void Transform::startTransition(const CameraOptions& camera,
                                 const AnimationOptions& animation,
-                                std::function<void(double)> frame,
+                                const std::function<void(double)>& frame,
                                 const Duration& duration) {
     if (transitionFinishFn) {
         transitionFinishFn();

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -29,7 +29,7 @@ public:
 
     // Camera
     /** Returns the current camera options. */
-    CameraOptions getCameraOptions(optional<EdgeInsets>) const;
+    CameraOptions getCameraOptions(const optional<EdgeInsets>&) const;
 
     /** Instantaneously, synchronously applies the given camera options. */
     void jumpTo(const CameraOptions&);
@@ -117,7 +117,10 @@ private:
     MapObserver& observer;
     TransformState state;
 
-    void startTransition(const CameraOptions&, const AnimationOptions&, std::function<void(double)>, const Duration&);
+    void startTransition(const CameraOptions&,
+                         const AnimationOptions&,
+                         const std::function<void(double)>&,
+                         const Duration&);
 
     // We don't want to show horizon: limit max pitch based on edge insets.
     double getMaxPitchForEdgeInsets(const EdgeInsets &insets) const;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -255,7 +255,7 @@ void TransformState::setViewportMode(ViewportMode val) {
 
 #pragma mark - Camera options
 
-CameraOptions TransformState::getCameraOptions(optional<EdgeInsets> padding) const {
+CameraOptions TransformState::getCameraOptions(const optional<EdgeInsets>& padding) const {
     return CameraOptions()
         .withCenter(getLatLng())
         .withPadding(padding ? padding : edgeInsets)

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -130,7 +130,7 @@ public:
     ViewportMode getViewportMode() const;
     void setViewportMode(ViewportMode val);
 
-    CameraOptions getCameraOptions(optional<EdgeInsets>) const;
+    CameraOptions getCameraOptions(const optional<EdgeInsets>&) const;
 
     // EdgeInsects
     EdgeInsets getEdgeInsets() const { return edgeInsets; }

--- a/src/mbgl/platform/settings.cpp
+++ b/src/mbgl/platform/settings.cpp
@@ -33,7 +33,7 @@ void Settings::set(const std::string& key, mapbox::base::Value value) noexcept {
     impl->settings[key] = std::move(value);
 }
 
-void Settings::set(mapbox::base::ValueObject values) noexcept {
+void Settings::set(const mapbox::base::ValueObject& values) noexcept {
     std::lock_guard<std::mutex> lock(impl->mutex);
     for (const auto& pair : values) {
         impl->settings[pair.first] = pair.second;

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -27,11 +27,10 @@ using namespace style;
 
 struct GeometryTooLongException : std::exception {};
 
-FillBucket::FillBucket(const FillBucket::PossiblyEvaluatedLayoutProperties,
+FillBucket::FillBucket(const FillBucket::PossiblyEvaluatedLayoutProperties&,
                        const std::map<std::string, Immutable<style::LayerProperties>>& layerPaintProperties,
                        const float zoom,
                        const uint32_t) {
-
     for (const auto& pair : layerPaintProperties) {
         paintPropertyBinders.emplace(
             std::piecewise_construct,

--- a/src/mbgl/renderer/buckets/fill_bucket.hpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.hpp
@@ -20,7 +20,7 @@ public:
     ~FillBucket() override;
     using PossiblyEvaluatedLayoutProperties = style::FillLayoutProperties::PossiblyEvaluated;
 
-    FillBucket(const PossiblyEvaluatedLayoutProperties layout,
+    FillBucket(const PossiblyEvaluatedLayoutProperties& layout,
                const std::map<std::string, Immutable<style::LayerProperties>>& layerPaintProperties,
                const float zoom,
                const uint32_t overscaling);

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -10,7 +10,7 @@ namespace mbgl {
 
 using namespace style;
 
-LineBucket::LineBucket(const LineBucket::PossiblyEvaluatedLayoutProperties layout_,
+LineBucket::LineBucket(const LineBucket::PossiblyEvaluatedLayoutProperties& layout_,
                        const std::map<std::string, Immutable<LayerProperties>>& layerPaintProperties,
                        const float zoom_,
                        const uint32_t overscaling_)

--- a/src/mbgl/renderer/buckets/line_bucket.hpp
+++ b/src/mbgl/renderer/buckets/line_bucket.hpp
@@ -19,7 +19,7 @@ class LineBucket final : public Bucket {
 public:
     using PossiblyEvaluatedLayoutProperties = style::LineLayoutProperties::PossiblyEvaluated;
 
-    LineBucket(const PossiblyEvaluatedLayoutProperties layout,
+    LineBucket(const PossiblyEvaluatedLayoutProperties& layout,
                const std::map<std::string, Immutable<style::LayerProperties>>& layerPaintProperties,
                const float zoom,
                const uint32_t overscaling);

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -21,7 +21,7 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
                            float zoom,
                            bool iconsNeedLinear_,
                            bool sortFeaturesByY_,
-                           const std::string bucketName_,
+                           const std::string& bucketName_,
                            const std::vector<SymbolInstance>&& symbolInstances_,
                            const std::vector<SortKeyRange>&& sortKeyRanges_,
                            float tilePixelRatio_,

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -281,8 +281,8 @@ SymbolInstanceReferences SymbolBucket::getSortedSymbols(const float angle) const
     const float cos = std::cos(angle);
 
     std::sort(result.begin(), result.end(), [sin, cos](const SymbolInstance& a, const SymbolInstance& b) {
-        const auto aRotated = ::lround(sin * a.anchor.point.x + cos * a.anchor.point.y);
-        const auto bRotated = ::lround(sin * b.anchor.point.x + cos * b.anchor.point.y);
+        const auto aRotated = std::lround(sin * a.anchor.point.x + cos * a.anchor.point.y);
+        const auto bRotated = std::lround(sin * b.anchor.point.x + cos * b.anchor.point.y);
         if (aRotated != bRotated) {
             return aRotated < bRotated;
         }

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -72,7 +72,7 @@ public:
                  float zoom,
                  bool iconsNeedLinear,
                  bool sortFeaturesByY,
-                 const std::string bucketLeaderID,
+                 const std::string& bucketLeaderID,
                  const std::vector<SymbolInstance>&&,
                  const std::vector<SortKeyRange>&&,
                  const float tilePixelRatio,

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -501,7 +501,7 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
     const Placement& placement = *placementController.getPlacement();
     auto renderedSymbols = placement.getCollisionIndex().queryRenderedSymbols(geometry);
     std::vector<std::reference_wrapper<const RetainedQueryData>> bucketQueryData;
-    for (auto entry : renderedSymbols) {
+    for (const auto& entry : renderedSymbols) {
         bucketQueryData.emplace_back(placement.getQueryData(entry.first));
     }
     // Although symbol query is global, symbol results are only sortable within a bucket

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -103,9 +103,9 @@ public:
 
 }  // namespace
 
-RenderOrchestrator::RenderOrchestrator(bool backgroundLayerAsColor_, optional<std::string> localFontFamily_)
+RenderOrchestrator::RenderOrchestrator(bool backgroundLayerAsColor_, const optional<std::string>& localFontFamily_)
     : observer(&nullObserver()),
-      glyphManager(std::make_unique<GlyphManager>(std::make_unique<LocalGlyphRasterizer>(std::move(localFontFamily_)))),
+      glyphManager(std::make_unique<GlyphManager>(std::make_unique<LocalGlyphRasterizer>(localFontFamily_))),
       imageManager(std::make_unique<ImageManager>()),
       lineAtlas(std::make_unique<LineAtlas>()),
       patternAtlas(std::make_unique<PatternAtlas>()),

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -501,6 +501,7 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
     const Placement& placement = *placementController.getPlacement();
     auto renderedSymbols = placement.getCollisionIndex().queryRenderedSymbols(geometry);
     std::vector<std::reference_wrapper<const RetainedQueryData>> bucketQueryData;
+    bucketQueryData.reserve(renderedSymbols.size());
     for (const auto& entry : renderedSymbols) {
         bucketQueryData.emplace_back(placement.getQueryData(entry.first));
     }

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -41,9 +41,7 @@ class RenderOrchestrator final : public GlyphManagerObserver,
                                  public ImageManagerObserver,
                                  public RenderSourceObserver {
 public:
-    RenderOrchestrator(
-        bool backgroundLayerAsColor_,
-        optional<std::string> localFontFamily_);
+    RenderOrchestrator(bool backgroundLayerAsColor_, const optional<std::string>& localFontFamily_);
     ~RenderOrchestrator() override;
 
     void markContextLost() {

--- a/src/mbgl/renderer/render_source.cpp
+++ b/src/mbgl/renderer/render_source.cpp
@@ -18,7 +18,7 @@ namespace mbgl {
 
 using namespace style;
 
-std::unique_ptr<RenderSource> RenderSource::create(Immutable<Source::Impl> impl) {
+std::unique_ptr<RenderSource> RenderSource::create(const Immutable<Source::Impl>& impl) {
     switch (impl->type) {
     case SourceType::Vector:
         return std::make_unique<RenderVectorSource>(staticImmutableCast<VectorSource::Impl>(impl));

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -47,7 +47,7 @@ using RenderTiles = std::shared_ptr<const std::vector<std::reference_wrapper<con
 
 class RenderSource : protected TileObserver {
 public:
-    static std::unique_ptr<RenderSource> create(Immutable<style::Source::Impl>);
+    static std::unique_ptr<RenderSource> create(const Immutable<style::Source::Impl>&);
     virtual ~RenderSource();
 
     bool isEnabled() const;

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -8,7 +8,7 @@
 
 namespace mbgl {
 
-Renderer::Renderer(gfx::RendererBackend& backend, float pixelRatio_, const optional<std::string> localFontFamily_)
+Renderer::Renderer(gfx::RendererBackend& backend, float pixelRatio_, const optional<std::string>& localFontFamily_)
     : impl(std::make_unique<Impl>(backend, pixelRatio_, localFontFamily_)) {}
 
 Renderer::~Renderer() {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -24,15 +24,11 @@ static RendererObserver& nullObserver() {
     return observer;
 }
 
-Renderer::Impl::Impl(gfx::RendererBackend& backend_,
-                     float pixelRatio_,
-                     optional<std::string> localFontFamily_)
-    : orchestrator(!backend_.contextIsShared(), std::move(localFontFamily_))
-    , backend(backend_)
-    , observer(&nullObserver())
-    , pixelRatio(pixelRatio_) {
-
-}
+Renderer::Impl::Impl(gfx::RendererBackend& backend_, float pixelRatio_, const optional<std::string>& localFontFamily_)
+    : orchestrator(!backend_.contextIsShared(), localFontFamily_),
+      backend(backend_),
+      observer(&nullObserver()),
+      pixelRatio(pixelRatio_) {}
 
 Renderer::Impl::~Impl() {
     assert(gfx::BackendScope::exists());

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -17,9 +17,7 @@ class RendererBackend;
 
 class Renderer::Impl {
 public:
-    Impl(gfx::RendererBackend&,
-         float pixelRatio_,
-         optional<std::string> localFontFamily_);
+    Impl(gfx::RendererBackend&, float pixelRatio_, const optional<std::string>& localFontFamily_);
     ~Impl();
 
 private:

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -25,12 +25,14 @@ using FeatureExtensionGetterPtr = FeatureExtensionValue (*)(std::shared_ptr<styl
                                                             std::uint32_t,
                                                             const optional<std::map<std::string, Value>>&);
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 FeatureExtensionValue getChildren(std::shared_ptr<style::GeoJSONData> clusterData,
                                   std::uint32_t clusterID,
                                   const optional<std::map<std::string, Value>>&) {
     return clusterData->getChildren(clusterID);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 FeatureExtensionValue getLeaves(std::shared_ptr<style::GeoJSONData> clusterData,
                                 std::uint32_t clusterID,
                                 const optional<std::map<std::string, Value>>& args) {
@@ -51,6 +53,7 @@ FeatureExtensionValue getLeaves(std::shared_ptr<style::GeoJSONData> clusterData,
     return clusterData->getLeaves(clusterID);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 FeatureExtensionValue getClusterExpansionZoom(std::shared_ptr<style::GeoJSONData> clusterData,
                                               std::uint32_t clusterID,
                                               const optional<std::map<std::string, Value>>&) {

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -264,7 +264,7 @@ void TilePyramid::handleWrapJump(float lng) {
 
     const float lngDifference = lng - prevLng;
     const float worldDifference = lngDifference / 360;
-    const int wrapDelta = ::round(worldDifference);
+    const int wrapDelta = std::round(worldDifference);
     prevLng = lng;
 
     if (wrapDelta) {

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<style::Image> createStyleImage(const std::string& id,
                                                const bool sdf,
                                                style::ImageStretches&& stretchX,
                                                style::ImageStretches&& stretchY,
-                                               optional<style::ImageContent> content) {
+                                               const optional<style::ImageContent>& content) {
     // Disallow invalid parameter configurations.
     if (width <= 0 || height <= 0 || width > 1024 || height > 1024 || ratio <= 0 || ratio > 10 ||
         srcX >= image.size.width || srcY >= image.size.height || srcX + width > image.size.width ||
@@ -49,7 +49,7 @@ std::unique_ptr<style::Image> createStyleImage(const std::string& id,
 
     try {
         return std::make_unique<style::Image>(
-            id, std::move(dstImage), ratio, sdf, std::move(stretchX), std::move(stretchY), std::move(content));
+            id, std::move(dstImage), ratio, sdf, std::move(stretchX), std::move(stretchY), content);
     } catch (const util::StyleImageException& ex) {
         Log::Error(Event::Sprite, "Can't create image with invalid metadata: %s", ex.what());
         return nullptr;
@@ -181,17 +181,8 @@ std::vector<Immutable<style::Image::Impl>> parseSprite(const std::string& encode
             style::ImageStretches stretchY = getStretches(value, "stretchY", name.c_str());
             optional<style::ImageContent> content = getContent(value, "content", name.c_str());
 
-            auto image = createStyleImage(name,
-                                          raster,
-                                          x,
-                                          y,
-                                          width,
-                                          height,
-                                          pixelRatio,
-                                          sdf,
-                                          std::move(stretchX),
-                                          std::move(stretchY),
-                                          std::move(content));
+            auto image = createStyleImage(
+                name, raster, x, y, width, height, pixelRatio, sdf, std::move(stretchX), std::move(stretchY), content);
             if (image) {
                 images.push_back(std::move(image->baseImpl));
             }

--- a/src/mbgl/sprite/sprite_parser.hpp
+++ b/src/mbgl/sprite/sprite_parser.hpp
@@ -17,7 +17,7 @@ std::unique_ptr<style::Image> createStyleImage(const std::string& id,
                                                bool sdf,
                                                style::ImageStretches&& stretchX = {},
                                                style::ImageStretches&& stretchY = {},
-                                               optional<style::ImageContent> content = nullopt);
+                                               const optional<style::ImageContent>& content = nullopt);
 
 // Parses an image and an associated JSON file and returns the sprite objects.
 std::vector<Immutable<style::Image::Impl>> parseSprite(const std::string& image, const std::string& json);

--- a/src/mbgl/style/conversion/filter.cpp
+++ b/src/mbgl/style/conversion/filter.cpp
@@ -1,11 +1,12 @@
 #include <mbgl/style/conversion/filter.hpp>
 #include <mbgl/style/conversion_impl.hpp>
-#include <mbgl/style/expression/literal.hpp>
-#include <mbgl/style/expression/expression.hpp>
-#include <mbgl/style/expression/type.hpp>
-#include <mbgl/style/expression/compound_expression.hpp>
 #include <mbgl/style/expression/boolean_operator.hpp>
+#include <mbgl/style/expression/compound_expression.hpp>
+#include <mbgl/style/expression/expression.hpp>
+#include <mbgl/style/expression/literal.hpp>
+#include <mbgl/style/expression/type.hpp>
 #include <mbgl/util/geometry.hpp>
+#include <utility>
 
 namespace mbgl {
 namespace style {
@@ -78,7 +79,9 @@ bool isExpression(const Convertible& filter) {
     }
 }
 
-ParseResult createExpression(std::string op, optional<std::vector<std::unique_ptr<Expression>>> args, Error& error) {
+ParseResult createExpression(const std::string& op,
+                             optional<std::vector<std::unique_ptr<Expression>>> args,
+                             Error& error) {
     if (!args) return {};
     assert(std::all_of(args->begin(), args->end(), [](const std::unique_ptr<Expression> &e) {
         return bool(e.get());
@@ -100,7 +103,7 @@ ParseResult createExpression(std::string op, optional<std::vector<std::unique_pt
     }
 }
 
-ParseResult createExpression(std::string op, ParseResult arg, Error& error) {
+ParseResult createExpression(const std::string& op, ParseResult arg, Error& error) {
     if (!arg) {
         return {};
     }
@@ -134,7 +137,9 @@ optional<std::vector<std::unique_ptr<Expression>>> convertLiteralArray(const Con
     return {std::move(output)};
 }
 
-ParseResult convertLegacyComparisonFilter(const Convertible& values, Error& error, optional<std::string> opOverride = {}) {
+ParseResult convertLegacyComparisonFilter(const Convertible& values,
+                                          Error& error,
+                                          const optional<std::string>& opOverride = {}) {
     optional<std::string> op = opOverride ? opOverride : toString(arrayMember(values, 0));
     optional<std::string> property = toString(arrayMember(values, 1));
 

--- a/src/mbgl/style/conversion/function.cpp
+++ b/src/mbgl/style/conversion/function.cpp
@@ -12,6 +12,7 @@
 #include <mbgl/util/string.hpp>
 
 #include <cassert>
+#include <utility>
 
 namespace mbgl {
 namespace style {
@@ -320,7 +321,7 @@ static optional<std::unique_ptr<Expression>> convertLiteral(type::Type type, con
         });
 }
 
-static optional<std::map<double, std::unique_ptr<Expression>>> convertStops(type::Type type,
+static optional<std::map<double, std::unique_ptr<Expression>>> convertStops(const type::Type& type,
                                                                             const Convertible& value,
                                                                             Error& error,
                                                                             bool convertTokens) {
@@ -382,7 +383,7 @@ static void omitFirstStop(std::map<double, std::unique_ptr<Expression>>& stops) 
 }
 
 template <class T>
-optional<std::map<T, std::unique_ptr<Expression>>> convertBranches(type::Type type,
+optional<std::map<T, std::unique_ptr<Expression>>> convertBranches(const type::Type& type,
                                                                    const Convertible& value,
                                                                    Error& error) {
     auto stopsValue = objectMember(value, "stops");
@@ -447,13 +448,15 @@ static optional<double> convertBase(const Convertible& value, Error& error) {
     return *base;
 }
 
-static std::unique_ptr<Expression> step(type::Type type, std::unique_ptr<Expression> input, std::map<double, std::unique_ptr<Expression>> stops) {
+static std::unique_ptr<Expression> step(const type::Type& type,
+                                        std::unique_ptr<Expression> input,
+                                        std::map<double, std::unique_ptr<Expression>> stops) {
     return std::make_unique<Step>(type, std::move(input), std::move(stops));
 }
 
 static std::unique_ptr<Expression> interpolate(type::Type type, Interpolator interpolator, std::unique_ptr<Expression> input, std::map<double, std::unique_ptr<Expression>> stops) {
     ParsingContext ctx;
-    auto result = createInterpolate(type, std::move(interpolator), std::move(input), std::move(stops), ctx);
+    auto result = createInterpolate(std::move(type), std::move(interpolator), std::move(input), std::move(stops), ctx);
     if (!result) {
         assert(false);
         return {};
@@ -462,7 +465,7 @@ static std::unique_ptr<Expression> interpolate(type::Type type, Interpolator int
 }
 
 template <class T>
-std::unique_ptr<Expression> categorical(type::Type type,
+std::unique_ptr<Expression> categorical(const type::Type& type,
                                         const std::string& property,
                                         std::map<T, std::unique_ptr<Expression>> branches,
                                         std::unique_ptr<Expression> def) {
@@ -477,7 +480,7 @@ std::unique_ptr<Expression> categorical(type::Type type,
 }
 
 template <>
-std::unique_ptr<Expression> categorical<bool>(type::Type type,
+std::unique_ptr<Expression> categorical<bool>(const type::Type& type,
                                               const std::string& property,
                                               std::map<bool, std::unique_ptr<Expression>> branches,
                                               std::unique_ptr<Expression> def) {
@@ -499,7 +502,7 @@ std::unique_ptr<Expression> categorical<bool>(type::Type type,
                                   def ? std::move(def) : error("replaced with default"));
 }
 
-static std::unique_ptr<Expression> numberOrDefault(type::Type type,
+static std::unique_ptr<Expression> numberOrDefault(const type::Type& type,
                                                    std::unique_ptr<Expression> get,
                                                    std::unique_ptr<Expression> expr,
                                                    std::unique_ptr<Expression> def) {
@@ -513,12 +516,13 @@ static std::unique_ptr<Expression> numberOrDefault(type::Type type,
     return std::make_unique<Case>(type, std::move(branches), std::move(def));
 }
 
-static optional<std::unique_ptr<Expression>> convertIntervalFunction(type::Type type,
-                                                                     const Convertible& value,
-                                                                     Error& error,
-                                                                     std::function<std::unique_ptr<Expression> (bool)> makeInput,
-                                                                     std::unique_ptr<Expression> def,
-                                                                     bool convertTokens = false) {
+static optional<std::unique_ptr<Expression>> convertIntervalFunction(
+    const type::Type& type,
+    const Convertible& value,
+    Error& error,
+    const std::function<std::unique_ptr<Expression>(bool)>& makeInput,
+    std::unique_ptr<Expression> def,
+    bool convertTokens = false) {
     auto stops = convertStops(type, value, error, convertTokens);
     if (!stops) {
         return nullopt;
@@ -531,12 +535,13 @@ static optional<std::unique_ptr<Expression>> convertIntervalFunction(type::Type 
                            std::move(def));
 }
 
-static optional<std::unique_ptr<Expression>> convertExponentialFunction(type::Type type,
-                                                                        const Convertible& value,
-                                                                        Error& error,
-                                                                        std::function<std::unique_ptr<Expression> (bool)> makeInput,
-                                                                        std::unique_ptr<Expression> def,
-                                                                        bool convertTokens = false) {
+static optional<std::unique_ptr<Expression>> convertExponentialFunction(
+    const type::Type& type,
+    const Convertible& value,
+    Error& error,
+    const std::function<std::unique_ptr<Expression>(bool)>& makeInput,
+    std::unique_ptr<Expression> def,
+    bool convertTokens = false) {
     auto stops = convertStops(type, value, error, convertTokens);
     if (!stops) {
         return nullopt;
@@ -552,7 +557,7 @@ static optional<std::unique_ptr<Expression>> convertExponentialFunction(type::Ty
                            std::move(def));
 }
 
-static optional<std::unique_ptr<Expression>> convertCategoricalFunction(type::Type type,
+static optional<std::unique_ptr<Expression>> convertCategoricalFunction(const type::Type& type,
                                                                         const Convertible& value,
                                                                         Error& err,
                                                                         const std::string& property,
@@ -849,9 +854,13 @@ optional<std::unique_ptr<Expression>> convertFunctionToExpression(type::Type typ
         if (toBool(*sourceValue)) {
             switch (functionType) {
             case FunctionType::Categorical:
-                return composite<bool>(type, value, err, [&] (type::Type type_, double, std::map<bool, std::unique_ptr<Expression>> stops) {
-                    return categorical<bool>(type_, *property, std::move(stops), defaultExpr());
-                });
+                return composite<bool>(
+                    type,
+                    value,
+                    err,
+                    [&](const type::Type& type_, double, std::map<bool, std::unique_ptr<Expression>> stops) {
+                        return categorical<bool>(type_, *property, std::move(stops), defaultExpr());
+                    });
             default:
                 err.message = "unsupported function type";
                 return nullopt;
@@ -861,24 +870,35 @@ optional<std::unique_ptr<Expression>> convertFunctionToExpression(type::Type typ
         if (toNumber(*sourceValue)) {
             switch (functionType) {
             case FunctionType::Interval:
-                return composite<double>(type, value, err, [&] (type::Type type_, double, std::map<double, std::unique_ptr<Expression>> stops) {
-                    omitFirstStop(stops);
-                    return numberOrDefault(type,
-                                           getProperty(false),
-                                           step(type_, getProperty(true), std::move(stops)),
-                                           defaultExpr());
-                });
+                return composite<double>(
+                    type,
+                    value,
+                    err,
+                    [&](const type::Type& type_, double, std::map<double, std::unique_ptr<Expression>> stops) {
+                        omitFirstStop(stops);
+                        return numberOrDefault(
+                            type, getProperty(false), step(type_, getProperty(true), std::move(stops)), defaultExpr());
+                    });
             case FunctionType::Exponential:
-                return composite<double>(type, value, err, [&] (type::Type type_, double base, std::map<double, std::unique_ptr<Expression>> stops) {
-                    return numberOrDefault(type,
-                                           getProperty(false),
-                                           interpolate(type_, exponential(base), getProperty(true), std::move(stops)),
-                                           defaultExpr());
-                });
+                return composite<double>(
+                    type,
+                    value,
+                    err,
+                    [&](type::Type type_, double base, std::map<double, std::unique_ptr<Expression>> stops) {
+                        return numberOrDefault(
+                            type,
+                            getProperty(false),
+                            interpolate(std::move(type_), exponential(base), getProperty(true), std::move(stops)),
+                            defaultExpr());
+                    });
             case FunctionType::Categorical:
-                return composite<int64_t>(type, value, err, [&] (type::Type type_, double, std::map<int64_t, std::unique_ptr<Expression>> stops) {
-                    return categorical<int64_t>(type_, *property, std::move(stops), defaultExpr());
-                });
+                return composite<int64_t>(
+                    type,
+                    value,
+                    err,
+                    [&](const type::Type& type_, double, std::map<int64_t, std::unique_ptr<Expression>> stops) {
+                        return categorical<int64_t>(type_, *property, std::move(stops), defaultExpr());
+                    });
             default:
                 err.message = "unsupported function type";
                 return nullopt;
@@ -888,9 +908,13 @@ optional<std::unique_ptr<Expression>> convertFunctionToExpression(type::Type typ
         if (toString(*sourceValue)) {
             switch (functionType) {
             case FunctionType::Categorical:
-                return composite<std::string>(type, value, err, [&] (type::Type type_, double, std::map<std::string, std::unique_ptr<Expression>> stops) {
-                    return categorical<std::string>(type_, *property, std::move(stops), defaultExpr());
-                });
+                return composite<std::string>(
+                    type,
+                    value,
+                    err,
+                    [&](const type::Type& type_, double, std::map<std::string, std::unique_ptr<Expression>> stops) {
+                        return categorical<std::string>(type_, *property, std::move(stops), defaultExpr());
+                    });
             default:
                 err.message = "unsupported function type";
                 return nullopt;

--- a/src/mbgl/style/custom_tile_loader.cpp
+++ b/src/mbgl/style/custom_tile_loader.cpp
@@ -10,7 +10,7 @@ CustomTileLoader::CustomTileLoader(const TileFunction& fetchTileFn, const TileFu
     cancelTileFunction = cancelTileFn;
 }
 
-void CustomTileLoader::fetchTile(const OverscaledTileID& tileID, ActorRef<CustomGeometryTile> tileRef) {
+void CustomTileLoader::fetchTile(const OverscaledTileID& tileID, const ActorRef<CustomGeometryTile>& tileRef) {
     std::lock_guard<std::mutex> guard(dataMutex);
     auto cachedTileData = dataCache.find(tileID.canonical);
     if (cachedTileData != dataCache.end()) {

--- a/src/mbgl/style/custom_tile_loader.hpp
+++ b/src/mbgl/style/custom_tile_loader.hpp
@@ -21,7 +21,7 @@ public:
 
     CustomTileLoader(const TileFunction& fetchTileFn, const TileFunction& cancelTileFn);
 
-    void fetchTile(const OverscaledTileID& tileID, ActorRef<CustomGeometryTile> tileRef);
+    void fetchTile(const OverscaledTileID& tileID, const ActorRef<CustomGeometryTile>& tileRef);
     void cancelTile(const OverscaledTileID& tileID);
 
     void removeTile(const OverscaledTileID& tileID);

--- a/src/mbgl/style/expression/assertion.cpp
+++ b/src/mbgl/style/expression/assertion.cpp
@@ -1,6 +1,7 @@
+#include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/expression/assertion.hpp>
 #include <mbgl/style/expression/check_subtype.hpp>
-#include <mbgl/style/conversion_impl.hpp>
+#include <utility>
 
 namespace mbgl {
 namespace style {
@@ -8,10 +9,8 @@ namespace expression {
 
 using namespace mbgl::style::conversion;
 
-Assertion::Assertion(type::Type type_, std::vector<std::unique_ptr<Expression>> inputs_) :
-    Expression(Kind::Assertion, type_),
-    inputs(std::move(inputs_))
-{
+Assertion::Assertion(type::Type type_, std::vector<std::unique_ptr<Expression>> inputs_)
+    : Expression(Kind::Assertion, std::move(type_)), inputs(std::move(inputs_)) {
     assert(!inputs.empty());
 }
 

--- a/src/mbgl/style/expression/collator.cpp
+++ b/src/mbgl/style/expression/collator.cpp
@@ -4,8 +4,8 @@ namespace mbgl {
 namespace style {
 namespace expression {
 
-Collator::Collator(bool caseSensitive, bool diacriticSensitive, optional<std::string> locale)
-    : collator(platform::Collator(caseSensitive, diacriticSensitive, std::move(locale))) {}
+Collator::Collator(bool caseSensitive, bool diacriticSensitive, const optional<std::string>& locale)
+    : collator(platform::Collator(caseSensitive, diacriticSensitive, locale)) {}
 
 bool Collator::operator==(const Collator& other) const {
     return collator == other.collator;

--- a/src/mbgl/style/expression/comparison.cpp
+++ b/src/mbgl/style/expression/comparison.cpp
@@ -22,30 +22,34 @@ static bool isComparableType(const std::string& op, const type::Type& type) {
     }
 }
 
-bool eq(Value a, Value b) { return a == b; }
-bool neq(Value a, Value b) { return a != b; }
-bool lt(Value lhs, Value rhs) {
+bool eq(const Value& a, const Value& b) {
+    return a == b;
+}
+bool neq(const Value& a, const Value& b) {
+    return a != b;
+}
+bool lt(const Value& lhs, const Value& rhs) {
     return lhs.match(
         [&](const std::string& a) { return a < rhs.get<std::string>(); },
         [&](double a) { return a < rhs.get<double>(); },
         [&](const auto&) { assert(false); return false; }
     );
 }
-bool gt(Value lhs, Value rhs) {
+bool gt(const Value& lhs, const Value& rhs) {
     return lhs.match(
         [&](const std::string& a) { return a > rhs.get<std::string>(); },
         [&](double a) { return a > rhs.get<double>(); },
         [&](const auto&) { assert(false); return false; }
     );
 }
-bool lteq(Value lhs, Value rhs) {
+bool lteq(const Value& lhs, const Value& rhs) {
     return lhs.match(
         [&](const std::string& a) { return a <= rhs.get<std::string>(); },
         [&](double a) { return a <= rhs.get<double>(); },
         [&](const auto&) { assert(false); return false; }
     );
 }
-bool gteq(Value lhs, Value rhs) {
+bool gteq(const Value& lhs, const Value& rhs) {
     return lhs.match(
         [&](const std::string& a) { return a >= rhs.get<std::string>(); },
         [&](double a) { return a >= rhs.get<double>(); },
@@ -53,12 +57,24 @@ bool gteq(Value lhs, Value rhs) {
     );
 }
 
-bool eqCollate(std::string a, std::string b, Collator c) { return c.compare(a, b) == 0; }
-bool neqCollate(std::string a, std::string b, Collator c) { return !eqCollate(a, b, c); }
-bool ltCollate(std::string a, std::string b, Collator c) { return c.compare(a, b) < 0; }
-bool gtCollate(std::string a, std::string b, Collator c) { return c.compare(a, b) > 0; }
-bool lteqCollate(std::string a, std::string b, Collator c) { return c.compare(a, b) <= 0; }
-bool gteqCollate(std::string a, std::string b, Collator c) { return c.compare(a, b) >= 0; }
+bool eqCollate(const std::string& a, const std::string& b, const Collator& c) {
+    return c.compare(a, b) == 0;
+}
+bool neqCollate(const std::string& a, const std::string& b, const Collator& c) {
+    return !eqCollate(a, b, c);
+}
+bool ltCollate(const std::string& a, const std::string& b, const Collator& c) {
+    return c.compare(a, b) < 0;
+}
+bool gtCollate(const std::string& a, const std::string& b, const Collator& c) {
+    return c.compare(a, b) > 0;
+}
+bool lteqCollate(const std::string& a, const std::string& b, const Collator& c) {
+    return c.compare(a, b) <= 0;
+}
+bool gteqCollate(const std::string& a, const std::string& b, const Collator& c) {
+    return c.compare(a, b) >= 0;
+}
 
 static BasicComparison::CompareFunctionType getBasicCompareFunction(const std::string& op) {
     if (op == "==") return eq;

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -84,13 +84,11 @@ struct Signature;
 // Simple evaluate function (const T0&, const T1&, ...) -> Result<U>
 template <class R, class... Params>
 struct Signature<R (Params...)> : SignatureBase {
-    Signature(R (*evaluate_)(Params...), std::string name_) :
-        SignatureBase(
-            valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
-            std::vector<type::Type> {valueTypeToExpressionType<std::decay_t<Params>>()...},
-            std::move(name_)
-        ),
-        evaluate(evaluate_)    {}
+    Signature(R (*evaluate_)(Params...), const std::string& name_)
+        : SignatureBase(valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
+                        std::vector<type::Type>{valueTypeToExpressionType<std::decay_t<Params>>()...},
+                        name_),
+          evaluate(evaluate_) {}
 
     EvaluationResult apply(const EvaluationContext& evaluationParameters, const Args& args) const override {
         return applyImpl(evaluationParameters, args, std::index_sequence_for<Params...>{});
@@ -116,14 +114,11 @@ private:
 // Varargs evaluate function (const Varargs<T>&) -> Result<U>
 template <class R, typename T>
 struct Signature<R (const Varargs<T>&)> : SignatureBase {
-    Signature(R (*evaluate_)(const Varargs<T>&), std::string name_) :
-        SignatureBase(
-            valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
-            VarargsType { valueTypeToExpressionType<T>() },
-            std::move(name_)
-        ),
-        evaluate(evaluate_)
-    {}
+    Signature(R (*evaluate_)(const Varargs<T>&), const std::string& name_)
+        : SignatureBase(valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
+                        VarargsType{valueTypeToExpressionType<T>()},
+                        name_),
+          evaluate(evaluate_) {}
 
     EvaluationResult apply(const EvaluationContext& evaluationParameters, const Args& args) const override {
         Varargs<T> evaluated;
@@ -145,14 +140,11 @@ struct Signature<R (const Varargs<T>&)> : SignatureBase {
 // (const EvaluationParams&, const T0&, const T1&, ...) -> Result<U>
 template <class R, class... Params>
 struct Signature<R (const EvaluationContext&, Params...)> : SignatureBase {
-    Signature(R (*evaluate_)(const EvaluationContext&, Params...), std::string name_) :
-        SignatureBase(
-            valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
-            std::vector<type::Type> {valueTypeToExpressionType<std::decay_t<Params>>()...},
-            std::move(name_)
-        ),
-        evaluate(evaluate_)
-    {}
+    Signature(R (*evaluate_)(const EvaluationContext&, Params...), const std::string& name_)
+        : SignatureBase(valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
+                        std::vector<type::Type>{valueTypeToExpressionType<std::decay_t<Params>>()...},
+                        name_),
+          evaluate(evaluate_) {}
 
     EvaluationResult apply(const EvaluationContext& evaluationParameters, const Args& args) const override {
         return applyImpl(evaluationParameters, args, std::index_sequence_for<Params...>{});
@@ -179,14 +171,11 @@ private:
 // (const EvaluationContext&, const Varargs<T>&) -> Result<U>
 template <class R, typename T>
 struct Signature<R (const EvaluationContext&, const Varargs<T>&)> : SignatureBase {
-    Signature(R (*evaluate_)(const EvaluationContext&, const Varargs<T>&), std::string name_) :
-    SignatureBase(
-                  valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
-                  VarargsType { valueTypeToExpressionType<T>() },
-                  std::move(name_)
-                  ),
-    evaluate(evaluate_)
-    {}
+    Signature(R (*evaluate_)(const EvaluationContext&, const Varargs<T>&), const std::string& name_)
+        : SignatureBase(valueTypeToExpressionType<std::decay_t<typename R::Value>>(),
+                        VarargsType{valueTypeToExpressionType<T>()},
+                        name_),
+          evaluate(evaluate_) {}
 
     EvaluationResult apply(const EvaluationContext& evaluationParameters, const Args& args) const override {
         Varargs<T> evaluated;
@@ -223,7 +212,7 @@ static std::unique_ptr<detail::SignatureBase> makeSignature(std::string name, Fn
 
 } // namespace detail
 
-Value featureIdAsExpressionValue(EvaluationContext params) {
+Value featureIdAsExpressionValue(const EvaluationContext& params) {
     assert(params.feature);
     auto id = params.feature->getID();
     if (id.is<NullValue>()) return Null;
@@ -232,7 +221,7 @@ Value featureIdAsExpressionValue(EvaluationContext params) {
     });
 };
 
-optional<Value> featurePropertyAsExpressionValue(EvaluationContext params, const std::string& key) {
+optional<Value> featurePropertyAsExpressionValue(const EvaluationContext& params, const std::string& key) {
     assert(params.feature);
     auto property = params.feature->getValue(key);
     return property ? toExpressionValue(*property) : optional<Value>();
@@ -253,7 +242,7 @@ optional<std::string> featureTypeAsString(FeatureType type) {
     }
 };
 
-optional<double> featurePropertyAsDouble(EvaluationContext params, const std::string& key) {
+optional<double> featurePropertyAsDouble(const EvaluationContext& params, const std::string& key) {
     assert(params.feature);
     auto property = params.feature->getValue(key);
     if (!property) return {};
@@ -265,7 +254,7 @@ optional<double> featurePropertyAsDouble(EvaluationContext params, const std::st
     );
 };
 
-optional<std::string> featurePropertyAsString(EvaluationContext params, const std::string& key) {
+optional<std::string> featurePropertyAsString(const EvaluationContext& params, const std::string& key) {
     assert(params.feature);
     auto property = params.feature->getValue(key);
     if (!property) return {};
@@ -275,7 +264,7 @@ optional<std::string> featurePropertyAsString(EvaluationContext params, const st
     );
 };
 
-optional<double> featureIdAsDouble(EvaluationContext params) {
+optional<double> featureIdAsDouble(const EvaluationContext& params) {
     assert(params.feature);
     auto id = params.feature->getID();
     return id.match(
@@ -286,7 +275,7 @@ optional<double> featureIdAsDouble(EvaluationContext params) {
     );
 };
 
-optional<std::string> featureIdAsString(EvaluationContext params) {
+optional<std::string> featureIdAsString(const EvaluationContext& params) {
     assert(params.feature);
     auto id = params.feature->getID();
     return id.match(
@@ -723,10 +712,12 @@ const auto& filterLessThanNumberCompoundExpression() {
 }
 
 const auto& filterLessThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter-<", [](const EvaluationContext& params, const std::string& key, std::string lhs) -> Result<bool> {
-        auto rhs = featurePropertyAsString(params, key);
-        return rhs ? rhs < lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter-<",
+        [](const EvaluationContext& params, const std::string& key, const std::string& lhs) -> Result<bool> {
+            auto rhs = featurePropertyAsString(params, key);
+            return rhs ? rhs < lhs : false;
+        });
     return signature;
 }
 
@@ -739,10 +730,11 @@ const auto& filterIdLessThanNumberCompoundExpression() {
 }
 
 const auto& filterIdLessThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter-id-<", [](const EvaluationContext& params, std::string lhs) -> Result<bool> {
-        auto rhs = featureIdAsString(params);
-        return rhs ? rhs < lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter-id-<", [](const EvaluationContext& params, const std::string& lhs) -> Result<bool> {
+            auto rhs = featureIdAsString(params);
+            return rhs ? rhs < lhs : false;
+        });
     return signature;
 }
 
@@ -755,10 +747,12 @@ const auto& filterMoreThanNumberCompoundExpression() {
 }
 
 const auto& filterMoreThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter->", [](const EvaluationContext& params, const std::string& key, std::string lhs) -> Result<bool> {
-        auto rhs = featurePropertyAsString(params, key);
-        return rhs ? rhs > lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter->",
+        [](const EvaluationContext& params, const std::string& key, const std::string& lhs) -> Result<bool> {
+            auto rhs = featurePropertyAsString(params, key);
+            return rhs ? rhs > lhs : false;
+        });
     return signature;
 }
 
@@ -771,10 +765,11 @@ const auto& filterIdMoreThanNumberCompoundExpression() {
 }
 
 const auto& filterIdMoreThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter-id->", [](const EvaluationContext& params, std::string lhs) -> Result<bool> {
-        auto rhs = featureIdAsString(params);
-        return rhs ? rhs > lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter-id->", [](const EvaluationContext& params, const std::string& lhs) -> Result<bool> {
+            auto rhs = featureIdAsString(params);
+            return rhs ? rhs > lhs : false;
+        });
     return signature;
 }
 
@@ -787,10 +782,12 @@ const auto& filterLessOrEqualThanNumberCompoundExpression() {
 }
 
 const auto& filterLessOrEqualThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter-<=", [](const EvaluationContext& params, const std::string& key, std::string lhs) -> Result<bool> {
-        auto rhs = featurePropertyAsString(params, key);
-        return rhs ? rhs <= lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter-<=",
+        [](const EvaluationContext& params, const std::string& key, const std::string& lhs) -> Result<bool> {
+            auto rhs = featurePropertyAsString(params, key);
+            return rhs ? rhs <= lhs : false;
+        });
     return signature;
 }
 
@@ -803,10 +800,11 @@ const auto& filterIdLessOrEqualThanNumberCompoundExpression() {
 }
 
 const auto& filterIdLessOrEqualThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter-id-<=", [](const EvaluationContext& params, std::string lhs) -> Result<bool> {
-        auto rhs = featureIdAsString(params);
-        return rhs ? rhs <= lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter-id-<=", [](const EvaluationContext& params, const std::string& lhs) -> Result<bool> {
+            auto rhs = featureIdAsString(params);
+            return rhs ? rhs <= lhs : false;
+        });
     return signature;
 }
 
@@ -819,10 +817,12 @@ const auto& filterGreaterOrEqualThanNumberCompoundExpression() {
 }
 
 const auto& filterGreaterOrEqualThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter->=", [](const EvaluationContext& params, const std::string& key, std::string lhs) -> Result<bool> {
-        auto rhs = featurePropertyAsString(params, key);
-        return rhs ? rhs >= lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter->=",
+        [](const EvaluationContext& params, const std::string& key, const std::string& lhs) -> Result<bool> {
+            auto rhs = featurePropertyAsString(params, key);
+            return rhs ? rhs >= lhs : false;
+        });
     return signature;
 }
 
@@ -835,10 +835,11 @@ const auto& filterIdGreaterOrEqualThanNumberCompoundExpression() {
 }
 
 const auto& filterIdGreaterOrEqualThanStringCompoundExpression() {
-    static auto signature = detail::makeSignature("filter-id->=", [](const EvaluationContext& params, std::string lhs) -> Result<bool> {
-        auto rhs = featureIdAsString(params);
-        return rhs ? rhs >= lhs : false;
-    });
+    static auto signature = detail::makeSignature(
+        "filter-id->=", [](const EvaluationContext& params, const std::string& lhs) -> Result<bool> {
+            auto rhs = featureIdAsString(params);
+            return rhs ? rhs >= lhs : false;
+        });
     return signature;
 }
 
@@ -1065,7 +1066,7 @@ static ParseResult createCompoundExpression(const Definitions& definitions,
     return ParseResult();
 }
 
-ParseResult parseCompoundExpression(const std::string name, const Convertible& value, ParsingContext& ctx) {
+ParseResult parseCompoundExpression(const std::string& name, const Convertible& value, ParsingContext& ctx) {
     assert(isArray(value) && arrayLength(value) > 0);
 
     const auto definitions = compoundExpressionRegistry.equal_range(name.c_str());

--- a/src/mbgl/style/expression/dsl.cpp
+++ b/src/mbgl/style/expression/dsl.cpp
@@ -11,9 +11,10 @@
 #include <mbgl/style/expression/literal.hpp>
 #include <mbgl/style/expression/step.hpp>
 
+#include <rapidjson/document.h>
 #include <mapbox/geojsonvt.hpp>
 #include <mbgl/style/conversion/json.hpp>
-#include <rapidjson/document.h>
+#include <utility>
 
 namespace mbgl {
 namespace style {
@@ -54,7 +55,7 @@ std::unique_ptr<Expression> literal(const char* value) {
     return literal(std::string(value));
 }
 
-std::unique_ptr<Expression> literal(Value value) {
+std::unique_ptr<Expression> literal(const Value& value) {
     return std::make_unique<Literal>(value);
 }
 
@@ -74,7 +75,7 @@ std::unique_ptr<Expression> literal(std::initializer_list<const char *> value) {
     return literal(values);
 }
 
-std::unique_ptr<Expression> assertion(type::Type type,
+std::unique_ptr<Expression> assertion(const type::Type& type,
                                       std::unique_ptr<Expression> value,
                                       std::unique_ptr<Expression> def) {
     std::vector<std::unique_ptr<Expression>> v  = vec(std::move(value));
@@ -99,7 +100,7 @@ std::unique_ptr<Expression> boolean(std::unique_ptr<Expression> value,
     return assertion(type::Boolean, std::move(value), std::move(def));
 }
 
-std::unique_ptr<Expression> coercion(type::Type type,
+std::unique_ptr<Expression> coercion(const type::Type& type,
                                      std::unique_ptr<Expression> value,
                                      std::unique_ptr<Expression> def) {
     std::vector<std::unique_ptr<Expression>> v = vec(std::move(value));
@@ -193,7 +194,7 @@ std::unique_ptr<Expression> interpolate(Interpolator interpolator,
     std::map<double, std::unique_ptr<Expression>> stops;
     stops[input1] = std::move(output1);
     ParsingContext ctx;
-    ParseResult result = createInterpolate(type, interpolator, std::move(input), std::move(stops), ctx);
+    ParseResult result = createInterpolate(type, std::move(interpolator), std::move(input), std::move(stops), ctx);
     assert(result);
     return std::move(*result);
 }
@@ -207,7 +208,7 @@ std::unique_ptr<Expression> interpolate(Interpolator interpolator,
     stops[input1] = std::move(output1);
     stops[input2] = std::move(output2);
     ParsingContext ctx;
-    ParseResult result = createInterpolate(type, interpolator, std::move(input), std::move(stops), ctx);
+    ParseResult result = createInterpolate(type, std::move(interpolator), std::move(input), std::move(stops), ctx);
     assert(result);
     return std::move(*result);
 }
@@ -223,7 +224,7 @@ std::unique_ptr<Expression> interpolate(Interpolator interpolator,
     stops[input2] = std::move(output2);
     stops[input3] = std::move(output3);
     ParsingContext ctx;
-    ParseResult result = createInterpolate(type, interpolator, std::move(input), std::move(stops), ctx);
+    ParseResult result = createInterpolate(type, std::move(interpolator), std::move(input), std::move(stops), ctx);
     assert(result);
     return std::move(*result);
 }

--- a/src/mbgl/style/expression/expression.cpp
+++ b/src/mbgl/style/expression/expression.cpp
@@ -1,6 +1,7 @@
-#include <mbgl/style/expression/expression.hpp>
 #include <mbgl/style/expression/compound_expression.hpp>
+#include <mbgl/style/expression/expression.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
+#include <utility>
 
 namespace mbgl {
 namespace style {
@@ -43,7 +44,7 @@ EvaluationResult Expression::evaluate(optional<float> zoom,
                                       const Feature& feature,
                                       optional<double> colorRampParameter) const {
     GeoJSONFeature f(feature);
-    return this->evaluate(EvaluationContext(zoom, &f, colorRampParameter));
+    return this->evaluate(EvaluationContext(std::move(zoom), &f, std::move(colorRampParameter)));
 }
 
 EvaluationResult Expression::evaluate(optional<float> zoom,
@@ -51,7 +52,8 @@ EvaluationResult Expression::evaluate(optional<float> zoom,
                                       optional<double> colorRampParameter,
                                       const std::set<std::string>& availableImages) const {
     GeoJSONFeature f(feature);
-    return this->evaluate(EvaluationContext(zoom, &f, colorRampParameter).withAvailableImages(&availableImages));
+    return this->evaluate(
+        EvaluationContext(std::move(zoom), &f, std::move(colorRampParameter)).withAvailableImages(&availableImages));
 }
 
 EvaluationResult Expression::evaluate(optional<float> zoom,
@@ -60,14 +62,14 @@ EvaluationResult Expression::evaluate(optional<float> zoom,
                                       const std::set<std::string>& availableImages,
                                       const CanonicalTileID& canonical) const {
     GeoJSONFeature f(feature, canonical);
-    return this->evaluate(EvaluationContext(zoom, &f, colorRampParameter)
+    return this->evaluate(EvaluationContext(std::move(zoom), &f, std::move(colorRampParameter))
                               .withAvailableImages(&availableImages)
                               .withCanonicalTileID(&canonical));
 }
 
 EvaluationResult Expression::evaluate(optional<mbgl::Value> accumulated, const Feature& feature) const {
     GeoJSONFeature f(feature);
-    return this->evaluate(EvaluationContext(accumulated, &f));
+    return this->evaluate(EvaluationContext(std::move(accumulated), &f));
 }
 
 } // namespace expression

--- a/src/mbgl/style/expression/in.cpp
+++ b/src/mbgl/style/expression/in.cpp
@@ -9,20 +9,20 @@ namespace style {
 namespace expression {
 
 namespace {
-bool isComparableType(type::Type type) {
+bool isComparableType(const type::Type& type) {
     return type == type::Boolean || type == type::String || type == type::Number || type == type::Null ||
            type == type::Value;
 }
 
-bool isComparableRuntimeType(type::Type type) {
+bool isComparableRuntimeType(const type::Type& type) {
     return type == type::Boolean || type == type::String || type == type::Number || type == type::Null;
 }
 
-bool isSearchableType(type::Type type) {
+bool isSearchableType(const type::Type& type) {
     return type == type::String || type.is<type::Array>() || type == type::Null || type == type::Value;
 }
 
-bool isSearchableRuntimeType(type::Type type) {
+bool isSearchableRuntimeType(const type::Type& type) {
     return type == type::String || type.is<type::Array>() || type == type::Null;
 }
 } // namespace

--- a/src/mbgl/style/expression/interpolate.cpp
+++ b/src/mbgl/style/expression/interpolate.cpp
@@ -11,12 +11,12 @@ using namespace mbgl::style::conversion;
 template <typename T>
 class InterpolateImpl : public Interpolate {
 public:
-    InterpolateImpl(type::Type type_,
-          Interpolator interpolator_,
-          std::unique_ptr<Expression> input_,
-          std::map<double, std::unique_ptr<Expression>> stops_
-    ) : Interpolate(std::move(type_), std::move(interpolator_), std::move(input_), std::move(stops_))
-    {
+    InterpolateImpl(const type::Type& type_,
+                    const Interpolator& interpolator_,
+                    std::unique_ptr<Expression> input_,
+                    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+                    std::map<double, std::unique_ptr<Expression>> stops_)
+        : Interpolate(type_, interpolator_, std::move(input_), std::move(stops_)) {
         static_assert(util::Interpolatable<T>::value, "Interpolate expression requires an interpolatable value type.");
     }
 

--- a/src/mbgl/style/expression/let.cpp
+++ b/src/mbgl/style/expression/let.cpp
@@ -69,7 +69,7 @@ ParseResult Let::parse(const Convertible& value, ParsingContext& ctx) {
 mbgl::Value Let::serialize() const {
     std::vector<mbgl::Value> serialized;
     serialized.emplace_back(getOperator());
-    for (auto entry : bindings) {
+    for (const auto& entry : bindings) {
         serialized.emplace_back(entry.first);
         serialized.emplace_back(entry.second->serialize());
     }

--- a/src/mbgl/style/image.cpp
+++ b/src/mbgl/style/image.cpp
@@ -11,7 +11,7 @@ Image::Image(std::string id,
              bool sdf,
              ImageStretches stretchX,
              ImageStretches stretchY,
-             optional<ImageContent> content)
+             const optional<ImageContent>& content)
     : baseImpl(makeMutable<Impl>(
           std::move(id), std::move(image), pixelRatio, sdf, std::move(stretchX), std::move(stretchY), content)) {}
 

--- a/src/mbgl/style/light.cpp
+++ b/src/mbgl/style/light.cpp
@@ -12,6 +12,8 @@
 
 #include <mapbox/eternal.hpp>
 
+#include <utility>
+
 namespace mbgl {
 namespace style {
 
@@ -188,7 +190,7 @@ PropertyValue<LightAnchorType> Light::getAnchor() const {
 
 void Light::setAnchor(PropertyValue<LightAnchorType> property) {
     auto impl_ = mutableImpl();
-    impl_->properties.template get<LightAnchor>().value = property;
+    impl_->properties.template get<LightAnchor>().value = std::move(property);
     impl = std::move(impl_);
     observer->onLightChanged(*this);
 }
@@ -214,7 +216,7 @@ PropertyValue<Color> Light::getColor() const {
 
 void Light::setColor(PropertyValue<Color> property) {
     auto impl_ = mutableImpl();
-    impl_->properties.template get<LightColor>().value = property;
+    impl_->properties.template get<LightColor>().value = std::move(property);
     impl = std::move(impl_);
     observer->onLightChanged(*this);
 }
@@ -240,7 +242,7 @@ PropertyValue<float> Light::getIntensity() const {
 
 void Light::setIntensity(PropertyValue<float> property) {
     auto impl_ = mutableImpl();
-    impl_->properties.template get<LightIntensity>().value = property;
+    impl_->properties.template get<LightIntensity>().value = std::move(property);
     impl = std::move(impl_);
     observer->onLightChanged(*this);
 }
@@ -266,7 +268,7 @@ PropertyValue<Position> Light::getPosition() const {
 
 void Light::setPosition(PropertyValue<Position> property) {
     auto impl_ = mutableImpl();
-    impl_->properties.template get<LightPosition>().value = property;
+    impl_->properties.template get<LightPosition>().value = std::move(property);
     impl = std::move(impl_);
     observer->onLightChanged(*this);
 }

--- a/src/mbgl/style/light.cpp.ejs
+++ b/src/mbgl/style/light.cpp.ejs
@@ -15,6 +15,8 @@
 
 #include <mapbox/eternal.hpp>
 
+#include <utility>
+
 namespace mbgl {
 namespace style {
 
@@ -142,7 +144,7 @@ StyleProperty Light::getProperty(const std::string& name) const {
 
 void Light::set<%- camelize(property.name) %>(<%- propertyValueType(property) %> property) {
     auto impl_ = mutableImpl();
-    impl_->properties.template get<Light<%- camelize(property.name) %>>().value = property;
+    impl_->properties.template get<Light<%- camelize(property.name) %>>().value = std::move(property);
     impl = std::move(impl_);
     observer->onLightChanged(*this);
 }

--- a/src/mbgl/style/sources/custom_geometry_source.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source.cpp
@@ -14,7 +14,7 @@
 namespace mbgl {
 namespace style {
 
-CustomGeometrySource::CustomGeometrySource(std::string id, CustomGeometrySource::Options options)
+CustomGeometrySource::CustomGeometrySource(std::string id, const CustomGeometrySource::Options& options)
     : Source(makeMutable<CustomGeometrySource::Impl>(std::move(id), options)),
       loader(std::make_unique<Actor<CustomTileLoader>>(
           Scheduler::GetBackground(), options.fetchTileFunction, options.cancelTileFunction)) {}

--- a/src/mbgl/style/sources/custom_geometry_source_impl.cpp
+++ b/src/mbgl/style/sources/custom_geometry_source_impl.cpp
@@ -4,13 +4,13 @@
 namespace mbgl {
 namespace style {
 
-CustomGeometrySource::Impl::Impl(std::string id_, CustomGeometrySource::Options options)
+CustomGeometrySource::Impl::Impl(std::string id_, const CustomGeometrySource::Options& options)
     : Source::Impl(SourceType::CustomVector, std::move(id_)),
       tileOptions(makeMutable<CustomGeometrySource::TileOptions>(options.tileOptions)),
       zoomRange(options.zoomRange),
       loaderRef({}) {}
 
-CustomGeometrySource::Impl::Impl(const Impl& impl, ActorRef<CustomTileLoader> loaderRef_)
+CustomGeometrySource::Impl::Impl(const Impl& impl, const ActorRef<CustomTileLoader>& loaderRef_)
     : Source::Impl(impl), tileOptions(impl.tileOptions), zoomRange(impl.zoomRange), loaderRef(loaderRef_) {}
 
 bool CustomGeometrySource::Impl::operator!=(const Impl& other) const noexcept {

--- a/src/mbgl/style/sources/custom_geometry_source_impl.hpp
+++ b/src/mbgl/style/sources/custom_geometry_source_impl.hpp
@@ -10,8 +10,8 @@ namespace style {
 
 class CustomGeometrySource::Impl : public Source::Impl {
 public:
-    Impl(std::string id, CustomGeometrySource::Options options);
-    Impl(const Impl&, ActorRef<CustomTileLoader>);
+    Impl(std::string id, const CustomGeometrySource::Options& options);
+    Impl(const Impl&, const ActorRef<CustomTileLoader>&);
 
     optional<std::string> getAttribution() const final;
 

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -79,7 +79,7 @@ void GeoJSONSource::loadDescription(FileSource& fileSource) {
         return;
     }
 
-    req = fileSource.request(Resource::source(*url), [this](Response res) {
+    req = fileSource.request(Resource::source(*url), [this](const Response& res) {
         if (res.error) {
             observer->onSourceError(
                 *this, std::make_exception_ptr(std::runtime_error(res.error->message)));

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -80,7 +80,7 @@ T evaluateFeature(const mapbox::feature::feature<double>& f,
 
 // static
 std::shared_ptr<GeoJSONData> GeoJSONData::create(const GeoJSON& geoJSON,
-                                                 Immutable<GeoJSONOptions> options,
+                                                 const Immutable<GeoJSONOptions>& options,
                                                  std::shared_ptr<Scheduler> scheduler) {
     constexpr double scale = util::EXTENT / util::tileSize;
     if (options->cluster && geoJSON.is<Features>() && !geoJSON.get<Features>().empty()) {

--- a/src/mbgl/style/sources/image_source.cpp
+++ b/src/mbgl/style/sources/image_source.cpp
@@ -64,7 +64,7 @@ void ImageSource::loadDescription(FileSource& fileSource) {
     }
     const Resource imageResource { Resource::Image, *url, {} };
 
-    req = fileSource.request(imageResource, [this](Response res) {
+    req = fileSource.request(imageResource, [this](const Response& res) {
         if (res.error) {
             observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error(res.error->message)));
         } else if (res.notModified) {

--- a/src/mbgl/style/sources/raster_dem_source.cpp
+++ b/src/mbgl/style/sources/raster_dem_source.cpp
@@ -6,13 +6,13 @@
 #include <mbgl/style/sources/raster_source_impl.hpp>
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/util/mapbox.hpp>
+#include <utility>
 
 namespace mbgl {
 namespace style {
 
 RasterDEMSource::RasterDEMSource(std::string id, variant<std::string, Tileset> urlOrTileset_, uint16_t tileSize)
-    : RasterSource(std::move(id), urlOrTileset_, tileSize, SourceType::RasterDEM){
-}
+    : RasterSource(std::move(id), std::move(urlOrTileset_), tileSize, SourceType::RasterDEM) {}
 
 bool RasterDEMSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) const {
     return mbgl::underlying_type(Tile::Kind::RasterDEM) == mbgl::underlying_type(info->tileKind);

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -53,7 +53,7 @@ void RasterSource::loadDescription(FileSource& fileSource) {
     }
 
     const auto& url = urlOrTileset.get<std::string>();
-    req = fileSource.request(Resource::source(url), [this, url](Response res) {
+    req = fileSource.request(Resource::source(url), [this, url](const Response& res) {
         if (res.error) {
             observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error(res.error->message)));
         } else if (res.notModified) {

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -52,7 +52,7 @@ void VectorSource::loadDescription(FileSource& fileSource) {
     }
 
     const auto& url = urlOrTileset.get<std::string>();
-    req = fileSource.request(Resource::source(url), [this, url](Response res) {
+    req = fileSource.request(Resource::source(url), [this, url](const Response& res) {
         if (res.error) {
             observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error(res.error->message)));
         } else if (res.notModified) {

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -62,7 +62,7 @@ void Style::Impl::loadURL(const std::string& url_) {
     loaded = false;
     url = url_;
 
-    styleRequest = fileSource->request(Resource::style(url), [this](Response res) {
+    styleRequest = fileSource->request(Resource::style(url), [this](const Response& res) {
         // Don't allow a loaded, mutated style to be overwritten with a new version.
         if (mutated && loaded) {
             return;
@@ -190,7 +190,7 @@ Layer* Style::Impl::getLayer(const std::string& id) const {
     return layers.get(id);
 }
 
-Layer* Style::Impl::addLayer(std::unique_ptr<Layer> layer, optional<std::string> before) {
+Layer* Style::Impl::addLayer(std::unique_ptr<Layer> layer, const optional<std::string>& before) {
     // TODO: verify source
     if (Source* source = sources.get(layer->getSourceID())) {
         if (!source->supportsLayerType(layer->baseImpl->getTypeInfo())) {

--- a/src/mbgl/style/style_impl.hpp
+++ b/src/mbgl/style/style_impl.hpp
@@ -65,8 +65,7 @@ public:
     std::vector<const Layer*> getLayers() const;
     Layer* getLayer(const std::string& id) const;
 
-    Layer* addLayer(std::unique_ptr<Layer>,
-                    optional<std::string> beforeLayerID = {});
+    Layer* addLayer(std::unique_ptr<Layer>, const optional<std::string>& beforeLayerID = {});
     std::unique_ptr<Layer> removeLayer(const std::string& layerID);
 
     std::string getName() const;

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -126,7 +126,7 @@ std::pair<bool, bool> CollisionIndex::placeFeature(
     const bool pitchWithMap,
     const bool collisionDebug,
     const optional<CollisionBoundaries>& avoidEdges,
-    const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate,
+    const optional<std::function<bool(const IndexedSubfeature&)>>& collisionGroupPredicate,
     std::vector<ProjectedCollisionBox>& projectedBoxes) {
     assert(projectedBoxes.empty());
     if (!feature.alongLine) {
@@ -157,7 +157,7 @@ std::pair<bool, bool> CollisionIndex::placeLineFeature(
     const bool pitchWithMap,
     const bool collisionDebug,
     const optional<CollisionBoundaries>& avoidEdges,
-    const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate,
+    const optional<std::function<bool(const IndexedSubfeature&)>>& collisionGroupPredicate,
     std::vector<ProjectedCollisionBox>& projectedBoxes) {
     assert(feature.alongLine);
     assert(projectedBoxes.empty());

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -39,7 +39,7 @@ public:
         const bool pitchWithMap,
         const bool collisionDebug,
         const optional<CollisionBoundaries>& avoidEdges,
-        const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate,
+        const optional<std::function<bool(const IndexedSubfeature&)>>& collisionGroupPredicate,
         std::vector<ProjectedCollisionBox>& /*out*/);
 
     void insertFeature(const CollisionFeature& feature, const std::vector<ProjectedCollisionBox>&, bool ignorePlacement, uint32_t bucketInstanceId, uint16_t collisionGroupId);
@@ -68,7 +68,7 @@ private:
         const bool pitchWithMap,
         const bool collisionDebug,
         const optional<CollisionBoundaries>& avoidEdges,
-        const optional<std::function<bool(const IndexedSubfeature&)>> collisionGroupPredicate,
+        const optional<std::function<bool(const IndexedSubfeature&)>>& collisionGroupPredicate,
         std::vector<ProjectedCollisionBox>& /*out*/);
 
     float approximateTileDistance(const TileDistance& tileDistance, const float lastSegmentAngle, const float pixelsToTileUnits, const float cameraToAnchorDistance, const bool pitchWithMap);

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -185,7 +185,7 @@ bool CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& tileID,
 }
 
 void CrossTileSymbolLayerIndex::removeBucketCrossTileIDs(uint8_t zoom, const TileLayerIndex& removedBucket) {
-    for (auto key : removedBucket.indexedSymbolInstances) {
+    for (const auto& key : removedBucket.indexedSymbolInstances) {
         for (auto indexedSymbolInstance : key.second) {
             usedCrossTileIDs[zoom].erase(indexedSymbolInstance.crossTileID);
         }

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -76,8 +76,7 @@ CrossTileSymbolLayerIndex::CrossTileSymbolLayerIndex(uint32_t& maxCrossTileID_) 
  * so that they match the new wrapped version of the map.
  */
 void CrossTileSymbolLayerIndex::handleWrapJump(float newLng) {
-
-    const int wrapDelta = ::round((newLng - lng) / 360);
+    const int wrapDelta = std::round((newLng - lng) / 360);
     if (wrapDelta != 0) {
         std::map<uint8_t, std::map<OverscaledTileID,TileLayerIndex>> newIndexes;
         for (auto& zoomIndex : indexes) {

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -61,7 +61,7 @@ static Anchors resample(const GeometryCoordinates& line,
             if (x >= 0 && x < util::EXTENT && y >= 0 && y < util::EXTENT &&
                     markedDistance - halfLabelLength >= 0.0f &&
                     markedDistance + halfLabelLength <= lineLength) {
-                Anchor anchor(::round(x), ::round(y), angle, i);
+                Anchor anchor(std::round(x), std::round(y), angle, i);
 
                 if (!angleWindowSize || checkMaxAngle(line, anchor, labelLength, angleWindowSize, maxAngle)) {
                     anchors.push_back(anchor);
@@ -104,7 +104,7 @@ Anchors getAnchors(const GeometryCoordinates& line,
 
     const float angleWindowSize = getAngleWindowSize(textLeft, textRight, glyphSize, boxScale);
 
-    const float shapedLabelLength = fmax(textRight - textLeft, iconRight - iconLeft);
+    const float shapedLabelLength = std::fmax(textRight - textLeft, iconRight - iconLeft);
     const float labelLength = shapedLabelLength * boxScale;
 
     // Is the line continued from outside the tile boundary?
@@ -143,8 +143,8 @@ optional<Anchor> getCenterAnchor(const GeometryCoordinates& line,
     }
     
     const float angleWindowSize = getAngleWindowSize(textLeft, textRight, glyphSize, boxScale);
-    const float labelLength = fmax(textRight - textLeft, iconRight - iconLeft) * boxScale;
-    
+    const float labelLength = std::fmax(textRight - textLeft, iconRight - iconLeft) * boxScale;
+
     float prevDistance = 0;
     const float centerDistance = getLineLength(line) / 2;
 
@@ -161,7 +161,7 @@ optional<Anchor> getCenterAnchor(const GeometryCoordinates& line,
                   x = util::interpolate(float(a.x), float(b.x), t),
                   y = util::interpolate(float(a.y), float(b.y), t);
 
-            Anchor anchor(::round(x), ::round(y), util::angle_to(b, a), i);
+            Anchor anchor(std::round(x), std::round(y), util::angle_to(b, a), i);
 
             if (!angleWindowSize || checkMaxAngle(line, anchor, labelLength, angleWindowSize, maxAngle)) {
                 return anchor;

--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -70,9 +70,9 @@ void GlyphManager::requestRange(GlyphRequest& request, const FontStack& fontStac
         return;
     }
 
-    request.req = fileSource.request(Resource::glyphs(glyphURL, fontStack, range), [this, fontStack, range](Response res) {
-        processResponse(res, fontStack, range);
-    });
+    request.req =
+        fileSource.request(Resource::glyphs(glyphURL, fontStack, range),
+                           [this, fontStack, range](const Response& res) { processResponse(res, fontStack, range); });
 }
 
 void GlyphManager::processResponse(const Response& res, const FontStack& fontStack, const GlyphRange& range) {

--- a/src/mbgl/text/local_glyph_rasterizer.hpp
+++ b/src/mbgl/text/local_glyph_rasterizer.hpp
@@ -33,7 +33,7 @@ namespace mbgl {
 class LocalGlyphRasterizer {
 public:
     virtual ~LocalGlyphRasterizer();
-    LocalGlyphRasterizer(const optional<std::string> fontFamily = optional<std::string>());
+    LocalGlyphRasterizer(const optional<std::string>& fontFamily = optional<std::string>());
 
     // virtual so that test harness can override platform-specific behavior
     virtual bool canRasterizeGlyph(const FontStack&, GlyphID);

--- a/src/mbgl/text/tagged_string.cpp
+++ b/src/mbgl/text/tagged_string.cpp
@@ -12,7 +12,7 @@ namespace mbgl {
 
 void TaggedString::addTextSection(const std::u16string& sectionText,
                                   double scale,
-                                  FontStack fontStack,
+                                  const FontStack& fontStack,
                                   optional<Color> textColor) {
     styledText.first += sectionText;
     sections.emplace_back(scale, fontStack, std::move(textColor));

--- a/src/mbgl/text/tagged_string.hpp
+++ b/src/mbgl/text/tagged_string.hpp
@@ -82,7 +82,7 @@ struct TaggedString {
 
     void addTextSection(const std::u16string& text,
                         double scale,
-                        FontStack fontStack,
+                        const FontStack& fontStack,
                         optional<Color> textColor_ = nullopt);
 
     void addImageSection(const std::string& imageID);

--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -17,7 +17,7 @@ CustomGeometryTile::CustomGeometryTile(const OverscaledTileID& overscaledTileID,
                                        const TileParameters& parameters,
                                        Immutable<style::CustomGeometrySource::TileOptions> options_,
                                        ActorRef<style::CustomTileLoader> loader_)
-    : GeometryTile(overscaledTileID, sourceID_, parameters),
+    : GeometryTile(overscaledTileID, std::move(sourceID_), parameters),
       necessity(TileNecessity::Optional),
       options(std::move(options_)),
       loader(std::move(loader_)),

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -3,13 +3,14 @@
 #include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/tile/geojson_tile.hpp>
 #include <mbgl/tile/geojson_tile_data.hpp>
+#include <utility>
 namespace mbgl {
 
 GeoJSONTile::GeoJSONTile(const OverscaledTileID& overscaledTileID,
                          std::string sourceID_,
                          const TileParameters& parameters,
                          std::shared_ptr<style::GeoJSONData> data_)
-    : GeometryTile(overscaledTileID, sourceID_, parameters) {
+    : GeometryTile(overscaledTileID, std::move(sourceID_), parameters) {
     updateData(std::move(data_), false /*needsRelayout*/);
 }
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -22,6 +22,7 @@
 #include <mbgl/util/logging.hpp>
 
 #include <mbgl/gfx/upload_pass.hpp>
+#include <utility>
 
 namespace mbgl {
 
@@ -176,7 +177,7 @@ void GeometryTile::markObsolete() {
 
 void GeometryTile::setError(std::exception_ptr err) {
     loaded = true;
-    observer->onTileError(*this, err);
+    observer->onTileError(*this, std::move(err));
 }
 
 void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
@@ -257,7 +258,7 @@ void GeometryTile::onError(std::exception_ptr err, const uint64_t resultCorrelat
     if (resultCorrelationID == correlationID) {
         pending = false;
     }
-    observer->onTileError(*this, err);
+    observer->onTileError(*this, std::move(err));
 }
     
 void GeometryTile::onGlyphsAvailable(GlyphMap glyphs) {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -352,7 +352,7 @@ void GeometryTile::querySourceFeatures(
         return;
     }
 
-    for (auto sourceLayer : *options.sourceLayers) {
+    for (const auto& sourceLayer : *options.sourceLayers) {
         // Go throught all sourceLayers, if any
         // to gather all the features
         auto layer = getData()->getLayer(sourceLayer);

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -214,7 +214,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
         [&](const MultiLineString<double>& lineStrings) -> GeometryCollection {
             GeometryCollection result;
             result.reserve(lineStrings.size());
-            for (const auto line : lineStrings) {
+            for (const auto& line : lineStrings) {
                 LineString<int16_t> temp;
                 temp.reserve(line.size());
                 for (const auto p : line) {
@@ -227,7 +227,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
         [&](const Polygon<double> polygon) -> GeometryCollection {
             GeometryCollection result;
             result.reserve(polygon.size());
-            for (const auto ring : polygon) {
+            for (const auto& ring : polygon) {
                 LinearRing<int16_t> temp;
                 temp.reserve(ring.size());
                 for (const auto p : ring) {
@@ -240,8 +240,8 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
         [&](const MultiPolygon<double> polygons) -> GeometryCollection {
             GeometryCollection result;
             result.reserve(polygons.size());
-            for (const auto pg : polygons) {
-                for (const auto r : pg) {
+            for (const auto& pg : polygons) {
+                for (const auto& r : pg) {
                     LinearRing<int16_t> ring;
                     ring.reserve(r.size());
                     for (const auto p : r) {

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -224,7 +224,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
             }
             return result;
         },
-        [&](const Polygon<double> polygon) -> GeometryCollection {
+        [&](const Polygon<double>& polygon) -> GeometryCollection {
             GeometryCollection result;
             result.reserve(polygon.size());
             for (const auto& ring : polygon) {
@@ -237,7 +237,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
             }
             return result;
         },
-        [&](const MultiPolygon<double> polygons) -> GeometryCollection {
+        [&](const MultiPolygon<double>& polygons) -> GeometryCollection {
             GeometryCollection result;
             result.reserve(polygons.size());
             for (const auto& pg : polygons) {

--- a/src/mbgl/tile/raster_dem_tile.hpp
+++ b/src/mbgl/tile/raster_dem_tile.hpp
@@ -71,7 +71,7 @@ public:
 
     void setError(std::exception_ptr);
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);
-    void setData(std::shared_ptr<const std::string> data);
+    void setData(const std::shared_ptr<const std::string>& data);
 
     bool layerPropertiesUpdated(const Immutable<style::LayerProperties>& layerProperties) override;
 

--- a/src/mbgl/tile/raster_dem_tile_worker.cpp
+++ b/src/mbgl/tile/raster_dem_tile_worker.cpp
@@ -6,11 +6,12 @@
 
 namespace mbgl {
 
-RasterDEMTileWorker::RasterDEMTileWorker(ActorRef<RasterDEMTileWorker>, ActorRef<RasterDEMTile> parent_)
-    : parent(std::move(parent_)) {
-}
+RasterDEMTileWorker::RasterDEMTileWorker(const ActorRef<RasterDEMTileWorker>&, ActorRef<RasterDEMTile> parent_)
+    : parent(std::move(parent_)) {}
 
-void RasterDEMTileWorker::parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::DEMEncoding encoding) {
+void RasterDEMTileWorker::parse(const std::shared_ptr<const std::string>& data,
+                                uint64_t correlationID,
+                                Tileset::DEMEncoding encoding) {
     if (!data) {
         parent.invoke(&RasterDEMTile::onParsed, nullptr, correlationID); // No data; empty tile.
         return;

--- a/src/mbgl/tile/raster_dem_tile_worker.hpp
+++ b/src/mbgl/tile/raster_dem_tile_worker.hpp
@@ -12,9 +12,9 @@ class RasterDEMTile;
 
 class RasterDEMTileWorker {
 public:
-    RasterDEMTileWorker(ActorRef<RasterDEMTileWorker>, ActorRef<RasterDEMTile>);
+    RasterDEMTileWorker(const ActorRef<RasterDEMTileWorker>&, ActorRef<RasterDEMTile>);
 
-    void parse(std::shared_ptr<const std::string> data, uint64_t correlationID, Tileset::DEMEncoding encoding);
+    void parse(const std::shared_ptr<const std::string>& data, uint64_t correlationID, Tileset::DEMEncoding encoding);
 
 private:
     ActorRef<RasterDEMTile> parent;

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -1,15 +1,16 @@
 #include <mbgl/tile/raster_tile.hpp>
 
-#include <mbgl/tile/raster_tile_worker.hpp>
-#include <mbgl/tile/tile_observer.hpp>
-#include <mbgl/tile/tile_loader_impl.hpp>
-#include <mbgl/style/source.hpp>
-#include <mbgl/storage/resource.hpp>
-#include <mbgl/storage/response.hpp>
+#include <mbgl/actor/scheduler.hpp>
+#include <mbgl/renderer/buckets/raster_bucket.hpp>
 #include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/renderer/tile_render_data.hpp>
-#include <mbgl/renderer/buckets/raster_bucket.hpp>
-#include <mbgl/actor/scheduler.hpp>
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/response.hpp>
+#include <mbgl/style/source.hpp>
+#include <mbgl/tile/raster_tile_worker.hpp>
+#include <mbgl/tile/tile_loader_impl.hpp>
+#include <mbgl/tile/tile_observer.hpp>
+#include <utility>
 
 namespace mbgl {
 
@@ -31,15 +32,15 @@ std::unique_ptr<TileRenderData> RasterTile::createRenderData() {
 
 void RasterTile::setError(std::exception_ptr err) {
     loaded = true;
-    observer->onTileError(*this, err);
+    observer->onTileError(*this, std::move(err));
 }
 
 void RasterTile::setMetadata(optional<Timestamp> modified_, optional<Timestamp> expires_) {
-    modified = modified_;
-    expires = expires_;
+    modified = std::move(modified_);
+    expires = std::move(expires_);
 }
 
-void RasterTile::setData(std::shared_ptr<const std::string> data) {
+void RasterTile::setData(const std::shared_ptr<const std::string>& data) {
     pending = true;
     ++correlationID;
     worker.self().invoke(&RasterTileWorker::parse, data, correlationID);
@@ -60,7 +61,7 @@ void RasterTile::onError(std::exception_ptr err, const uint64_t resultCorrelatio
     if (resultCorrelationID == correlationID) {
         pending = false;
     }
-    observer->onTileError(*this, err);
+    observer->onTileError(*this, std::move(err));
 }
 
 bool RasterTile::layerPropertiesUpdated(const Immutable<style::LayerProperties>&) {

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -27,7 +27,7 @@ public:
 
     void setError(std::exception_ptr);
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);
-    void setData(std::shared_ptr<const std::string> data);
+    void setData(const std::shared_ptr<const std::string>& data);
 
     bool layerPropertiesUpdated(const Immutable<style::LayerProperties>& layerProperties) override;
 

--- a/src/mbgl/tile/raster_tile_worker.cpp
+++ b/src/mbgl/tile/raster_tile_worker.cpp
@@ -6,11 +6,10 @@
 
 namespace mbgl {
 
-RasterTileWorker::RasterTileWorker(ActorRef<RasterTileWorker>, ActorRef<RasterTile> parent_)
-    : parent(std::move(parent_)) {
-}
+RasterTileWorker::RasterTileWorker(const ActorRef<RasterTileWorker>&, ActorRef<RasterTile> parent_)
+    : parent(std::move(parent_)) {}
 
-void RasterTileWorker::parse(std::shared_ptr<const std::string> data, uint64_t correlationID) {
+void RasterTileWorker::parse(const std::shared_ptr<const std::string>& data, uint64_t correlationID) {
     if (!data) {
         parent.invoke(&RasterTile::onParsed, nullptr, correlationID); // No data; empty tile.
         return;

--- a/src/mbgl/tile/raster_tile_worker.hpp
+++ b/src/mbgl/tile/raster_tile_worker.hpp
@@ -11,9 +11,9 @@ class RasterTile;
 
 class RasterTileWorker {
 public:
-    RasterTileWorker(ActorRef<RasterTileWorker>, ActorRef<RasterTile>);
+    RasterTileWorker(const ActorRef<RasterTileWorker>&, ActorRef<RasterTile>);
 
-    void parse(std::shared_ptr<const std::string> data, uint64_t correlationID);
+    void parse(const std::shared_ptr<const std::string>& data, uint64_t correlationID);
 
 private:
     ActorRef<RasterTile> parent;

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -1,7 +1,8 @@
+#include <mbgl/renderer/tile_parameters.hpp>
+#include <mbgl/tile/tile_loader_impl.hpp>
 #include <mbgl/tile/vector_tile.hpp>
 #include <mbgl/tile/vector_tile_data.hpp>
-#include <mbgl/tile/tile_loader_impl.hpp>
-#include <mbgl/renderer/tile_parameters.hpp>
+#include <utility>
 
 namespace mbgl {
 
@@ -9,19 +10,18 @@ VectorTile::VectorTile(const OverscaledTileID& id_,
                        std::string sourceID_,
                        const TileParameters& parameters,
                        const Tileset& tileset)
-    : GeometryTile(id_, sourceID_, parameters), loader(*this, id_, parameters, tileset) {
-}
+    : GeometryTile(id_, std::move(sourceID_), parameters), loader(*this, id_, parameters, tileset) {}
 
 void VectorTile::setNecessity(TileNecessity necessity) {
     loader.setNecessity(necessity);
 }
 
 void VectorTile::setMetadata(optional<Timestamp> modified_, optional<Timestamp> expires_) {
-    modified = modified_;
-    expires = expires_;
+    modified = std::move(modified_);
+    expires = std::move(expires_);
 }
 
-void VectorTile::setData(std::shared_ptr<const std::string> data_) {
+void VectorTile::setData(const std::shared_ptr<const std::string>& data_) {
     GeometryTile::setData(data_ ? std::make_unique<VectorTileData>(data_) : nullptr);
 }
 

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -17,7 +17,7 @@ public:
 
     void setNecessity(TileNecessity) final;
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);
-    void setData(std::shared_ptr<const std::string> data);
+    void setData(const std::shared_ptr<const std::string>& data);
 
 private:
     TileLoader<VectorTile> loader;

--- a/src/mbgl/util/string.cpp
+++ b/src/mbgl/util/string.cpp
@@ -48,7 +48,7 @@ std::string toString(double t, bool decimal) {
     return data;
 }
 
-std::string toString(std::exception_ptr error) {
+std::string toString(const std::exception_ptr& error) {
     assert(error);
 
     if (!error) {

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -34,7 +34,7 @@ struct edge {
 };
 
 // scan-line conversion
-static void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine scanLine) {
+static void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine& scanLine) {
     double y0 = ::fmax(ymin, std::floor(e1.y0));
     double y1 = ::fmin(ymax, std::ceil(e1.y1));
 

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -122,6 +122,7 @@ std::vector<UnwrappedTileID> tileCover(const Point<double>& tl,
             }), t.end());
 
     std::vector<UnwrappedTileID> result;
+    result.reserve(t.size());
     for (const auto& id : t) {
         result.emplace_back(z, id.x, id.y);
     }


### PR DESCRIPTION
Also make the bot fail if they come back. In theory we should reduce the number of heap allocations.

Warnings fixed by this PR:

```
      2 [performance-inefficient-vector-operation]
      2 [performance-noexcept-move-constructor]
      8 [performance-for-range-copy]
     19 [performance-type-promotion-in-math-fn]
    212 [performance-unnecessary-value-param]
```

- [x] Measure improvements in heap allocation before merging this PR.
