### PR TITLE
Fix `within` expression issue with geometry crossing the 180th Meridian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,13 @@
 
   Fix the issue that `within` expression evaluates point features inconsistently across zoom levels if the point lies near the boundary of a GeoJSON object ([#16301](https://github.com/mapbox/mapbox-gl-native/issues/16301))
 
- - [core][tile mode] Reduce cut-off labels ([#16336](https://github.com/mapbox/mapbox-gl-native/pull/16336))
+- [core][tile mode] Reduce cut-off labels ([#16336](https://github.com/mapbox/mapbox-gl-native/pull/16336))
 
   Place tile intersecting labels first, across all the layers. Thus we reduce the amount of label cut-offs in Tile mode.
 
   Before, labels were arranged within one symbol layer (one bucket),which was not enough for several symbol layers being placed at the same time.
+
+- [core] Fix issue that `within` expression returns incorrect results for geometries crossing the anti-meridian ([#16330](https://github.com/mapbox/mapbox-gl-native/pull/16330))
 
 ## maps-v1.4.1
 

--- a/src/mbgl/style/expression/within.cpp
+++ b/src/mbgl/style/expression/within.cpp
@@ -68,13 +68,19 @@ MultiPolygon<int64_t> getTilePolygons(const Feature::geometry_type& polygonGeoSe
 }
 
 void updatePoint(Point<int64_t>& p, WithinBBox& bbox, const WithinBBox& polyBBox, const int64_t worldSize) {
-    if (p.x <= polyBBox[0] || p.x >= polyBBox[2]) {
-        int64_t shift = 0;
-        shift = (p.x - polyBBox[0] > worldSize / 2) ? -worldSize : (polyBBox[0] - p.x > worldSize / 2) ? worldSize : 0;
-        if (shift == 0) {
-            shift =
-                (p.x - polyBBox[2] > worldSize / 2) ? -worldSize : (polyBBox[2] - p.x > worldSize / 2) ? worldSize : 0;
-        }
+    if (p.x < polyBBox[0] || p.x > polyBBox[2]) {
+        const auto getShift = [](Point<int64_t>& point, const int64_t polygonSide, const int64_t size) -> int64_t {
+            if (point.x - polygonSide > size / 2) {
+                return -size;
+            }
+            if (polygonSide - point.x > size / 2) {
+                return size;
+            }
+            return 0;
+        };
+
+        int64_t shift = getShift(p, polyBBox[0], worldSize);
+        if (shift == 0) shift = getShift(p, polyBBox[2], worldSize);
         p.x += shift;
     }
     updateBBox(bbox, p);

--- a/src/mbgl/util/geometry_within.cpp
+++ b/src/mbgl/util/geometry_within.cpp
@@ -47,7 +47,11 @@ bool lineIntersectLine(const Point<int64_t>& a,
             y2 = p2.y - q1.y;
             x3 = q2.x - q1.x;
             y3 = q2.y - q1.y;
-            if ((x1 * y3 - x3 * y1) * (x2 * y3 - x3 * y2) < 0) return true;
+            auto ret1 = (x1 * y3 - x3 * y1);
+            auto ret2 = (x2 * y3 - x3 * y2);
+            if ((ret1 > 0 && ret2 < 0) || (ret1 < 0 && ret2 > 0)) {
+                return true;
+            }
             return false;
         };
 

--- a/test/style/property_expression.test.cpp
+++ b/test/style/property_expression.test.cpp
@@ -390,7 +390,7 @@ TEST(PropertyExpression, WithinExpression) {
     }
 }
 
-TEST(PropertyExpression, WithinExpressionAntiMeridain) {
+TEST(PropertyExpression, WithinExpressionAntiMeridian) {
     CanonicalTileID canonicalTileID(0, 0, 0);
 
     // evaluation test with line geometries


### PR DESCRIPTION
Fix: https://github.com/mapbox/mapbox-gl-native/issues/16326

Parallel fix in gl-js: https://github.com/mapbox/mapbox-gl-js/pull/9440

- [x] Add changelog