### PR TITLE
Bump mapbox-base to v1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,15 +960,13 @@ target_link_libraries(
         mbgl-vendor-vector-tile
         mbgl-vendor-wagyu
     PUBLIC
+        Mapbox::Base
         Mapbox::Base::Extras::expected-lite
         Mapbox::Base::Extras::rapidjson
         Mapbox::Base::geojson.hpp
         Mapbox::Base::geometry.hpp
         Mapbox::Base::optional
-        Mapbox::Base::typewrapper
-        Mapbox::Base::value
         Mapbox::Base::variant
-        Mapbox::Base::weak
 )
 
 set_target_properties(

--- a/LICENSE.mbgl-core.md
+++ b/LICENSE.mbgl-core.md
@@ -404,6 +404,38 @@ DEALINGS IN THE SOFTWARE.
 
 ---
 
+### [mapbox-base](https://github.com/mapbox/mapbox-base) by Mapbox
+
+```
+Copyright (c) MapBox
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+- Neither the name "MapBox" nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES
+LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
 ### [expected-lite](https://github.com/martinmoene/expected-lite) by Martin Moene
 
 ```
@@ -572,103 +604,7 @@ DEALINGS IN THE SOFTWARE.
 
 ---
 
-### [typewrapper](https://github.com/mapbox/mapbox-base) by Mapbox
-
-```
-Copyright (c) MapBox
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-- Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
-- Neither the name "MapBox" nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES
-LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```
-
----
-
-### [value](https://github.com/mapbox/mapbox-base) by Mapbox
-
-```
-Copyright (c) MapBox
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-- Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
-- Neither the name "MapBox" nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES
-LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```
-
----
-
 ### [variant](https://github.com/mapbox/variant) by Mapbox
-
-```
-Copyright (c) MapBox
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-- Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
-- Neither the name "MapBox" nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES
-LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```
-
----
-
-### [weak](https://github.com/mapbox/mapbox-base) by Mapbox
 
 ```
 Copyright (c) MapBox

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -6,8 +6,8 @@ add_executable(
 target_link_libraries(
     mbgl-cache
     PRIVATE
+        Mapbox::Base
         Mapbox::Base::Extras::args
-        Mapbox::Base::io
         mbgl-compiler-options
         mbgl-core
 )

--- a/bin/cache.cpp
+++ b/bin/cache.cpp
@@ -5,7 +5,7 @@
 #include <mbgl/util/run_loop.hpp>
 
 #include <args.hxx>
-#include <mapbox/io.hpp>
+#include <mapbox/io/io.hpp>
 
 #include <fstream>
 #include <iostream>

--- a/expression-test/CMakeLists.txt
+++ b/expression-test/CMakeLists.txt
@@ -25,9 +25,9 @@ target_include_directories(
 target_link_libraries(
     mbgl-expression-test
     PRIVATE
+        Mapbox::Base
         Mapbox::Base::Extras::args
         Mapbox::Base::Extras::filesystem
-        Mapbox::Base::io
         mbgl-core
 )
 

--- a/include/mbgl/actor/mailbox.hpp
+++ b/include/mbgl/actor/mailbox.hpp
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <queue>
 
-#include <mapbox/weak.hpp>
+#include <mapbox/std/weak.hpp>
 
 namespace mbgl {
 

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -2,7 +2,7 @@
 
 #include <mbgl/util/pass_types.hpp>
 
-#include <mapbox/weak.hpp>
+#include <mapbox/std/weak.hpp>
 
 #include <functional>
 #include <memory>

--- a/include/mbgl/platform/settings.hpp
+++ b/include/mbgl/platform/settings.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mapbox/value.hpp>
+#include <mapbox/compatibility/value.hpp>
 
 #include <memory>
 

--- a/include/mbgl/storage/file_source.hpp
+++ b/include/mbgl/storage/file_source.hpp
@@ -3,7 +3,7 @@
 #include <mbgl/storage/resource_transform.hpp>
 #include <mbgl/storage/response.hpp>
 
-#include <mapbox/value.hpp>
+#include <mapbox/compatibility/value.hpp>
 
 #include <functional>
 #include <memory>

--- a/include/mbgl/style/conversion_impl.hpp
+++ b/include/mbgl/style/conversion_impl.hpp
@@ -11,7 +11,7 @@
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/traits.hpp>
 
-#include <mapbox/value.hpp>
+#include <mapbox/compatibility/value.hpp>
 
 #include <array>
 #include <chrono>

--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -6,8 +6,8 @@
 #include <mbgl/util/immutable.hpp>
 #include <mbgl/util/optional.hpp>
 
-#include <mapbox/weak.hpp>
-#include <mapbox/type_wrapper.hpp>
+#include <mapbox/std/weak.hpp>
+#include <mapbox/util/type_wrapper.hpp>
 
 #include <cassert>
 #include <memory>

--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -5,8 +5,8 @@
 #include <mbgl/util/immutable.hpp>
 #include <mbgl/style/types.hpp>
 
-#include <mapbox/weak.hpp>
-#include <mapbox/type_wrapper.hpp>
+#include <mapbox/std/weak.hpp>
+#include <mapbox/util/type_wrapper.hpp>
 
 #include <memory>
 #include <string>

--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -3,7 +3,7 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/optional.hpp>
 
-#include <mapbox/value.hpp>
+#include <mapbox/compatibility/value.hpp>
 
 namespace mbgl {
 namespace style {

--- a/include/mbgl/util/feature.hpp
+++ b/include/mbgl/util/feature.hpp
@@ -3,7 +3,7 @@
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/string.hpp>
 
-#include <mapbox/value.hpp>
+#include <mapbox/compatibility/value.hpp>
 
 namespace mbgl {
 

--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -309,10 +309,8 @@ target_link_libraries(
     example-custom-layer
     PRIVATE
         GLESv2
+        Mapbox::Base
         Mapbox::Base::optional
-        Mapbox::Base::typewrapper
-        Mapbox::Base::value
-        Mapbox::Base::weak
         log
         mbgl-compiler-options
 )

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -11,7 +11,7 @@
 #include <unordered_set>
 #include <unordered_map>
 
-#include <mapbox/weak.hpp>
+#include <mapbox/std/weak.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/renderer/tile_parameters.hpp
+++ b/src/mbgl/renderer/tile_parameters.hpp
@@ -4,7 +4,7 @@
 
 #include <memory>
 
-#include <mapbox/weak.hpp>
+#include <mapbox/std/weak.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -11,7 +11,7 @@
 
 #include <vector>
 
-#include <mapbox/weak.hpp>
+#include <mapbox/std/weak.hpp>
 
 namespace mbgl {
 

--- a/vendor/mapbox-base.cmake
+++ b/vendor/mapbox-base.cmake
@@ -1,8 +1,7 @@
 # License helper for mapbox-base, should be upstreamed.
 
 if(NOT TARGET mapbox-base)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/mapbox-base/extras)
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/mapbox-base)
 endif()
 
 set_target_properties(
@@ -29,7 +28,7 @@ set_target_properties(
         INTERFACE_MAPBOX_NAME "supercluster.hpp"
         INTERFACE_MAPBOX_URL "https://github.com/mapbox/supercluster.hpp"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/supercluster.hpp/LICENSE
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/supercluster.hpp/LICENSE
 )
 
 set_target_properties(
@@ -38,7 +37,7 @@ set_target_properties(
         INTERFACE_MAPBOX_NAME "shelf-pack-cpp"
         INTERFACE_MAPBOX_URL "https://github.com/mapbox/shelf-pack-cpp"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/shelf-pack-cpp/LICENSE.md
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/shelf-pack-cpp/LICENSE.md
 )
 
 set_target_properties(
@@ -47,7 +46,7 @@ set_target_properties(
         INTERFACE_MAPBOX_NAME "geojson-vt-cpp"
         INTERFACE_MAPBOX_URL "https://github.com/mapbox/geojson-vt-cpp"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/geojson-vt-cpp/LICENSE
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/geojson-vt-cpp/LICENSE
 )
 
 set_target_properties(
@@ -65,7 +64,7 @@ set_target_properties(
         INTERFACE_MAPBOX_NAME "geojson.hpp"
         INTERFACE_MAPBOX_URL "https://github.com/mapbox/geojson-cpp"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/geojson.hpp/LICENSE
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/geojson.hpp/LICENSE
 )
 
 set_target_properties(
@@ -74,7 +73,7 @@ set_target_properties(
         INTERFACE_MAPBOX_NAME "geometry.hpp"
         INTERFACE_MAPBOX_URL "https://github.com/mapbox/geometry.hpp"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/geometry.hpp/LICENSE
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/geometry.hpp/LICENSE
 )
 
 set_target_properties(
@@ -83,25 +82,16 @@ set_target_properties(
         INTERFACE_MAPBOX_NAME "Optional"
         INTERFACE_MAPBOX_URL "https://github.com/akrzemi1/Optional"
         INTERFACE_MAPBOX_AUTHOR "Andrzej Krzemienski"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/optional/LICENSE
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/optional/LICENSE
 )
 
 set_target_properties(
-    mapbox-base-typewrapper
+    mapbox-base
     PROPERTIES
-        INTERFACE_MAPBOX_NAME "typewrapper"
+        INTERFACE_MAPBOX_NAME "mapbox-base"
         INTERFACE_MAPBOX_URL "https://github.com/mapbox/mapbox-base"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/typewrapper/LICENSE
-)
-
-set_target_properties(
-    mapbox-base-value
-    PROPERTIES
-        INTERFACE_MAPBOX_NAME "value"
-        INTERFACE_MAPBOX_URL "https://github.com/mapbox/mapbox-base"
-        INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/value/LICENSE
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/LICENSE
 )
 
 set_target_properties(
@@ -110,14 +100,5 @@ set_target_properties(
         INTERFACE_MAPBOX_NAME "variant"
         INTERFACE_MAPBOX_URL "https://github.com/mapbox/variant"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/variant/LICENSE
-)
-
-set_target_properties(
-    mapbox-base-weak
-    PROPERTIES
-        INTERFACE_MAPBOX_NAME "weak"
-        INTERFACE_MAPBOX_URL "https://github.com/mapbox/mapbox-base"
-        INTERFACE_MAPBOX_AUTHOR "Mapbox"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/mapbox/weak/LICENSE
+        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/variant/LICENSE
 )


### PR DESCRIPTION
Update mapbox-base to tag [v1.2.0](https://github.com/mapbox/mapbox-base/releases/tag/v1.2.0)

Fixes: https://github.com/mapbox/mapbox-gl-native-team/issues/233

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR