### PR TITLE
[core][tile mode] Reduce cut-off labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
 
   Fix the issue that `within` expression evaluates point features inconsistently across zoom levels if the point lies near the boundary of a GeoJSON object ([#16301](https://github.com/mapbox/mapbox-gl-native/issues/16301))
 
+ - [core][tile mode] Reduce cut-off labels ([#16336](https://github.com/mapbox/mapbox-gl-native/pull/16336))
+
+  Place tile intersecting labels first, across all the layers. Thus we reduce the amount of label cut-offs in Tile mode.
+
+  Before, labels were arranged within one symbol layer (one bucket),which was not enough for several symbol layers being placed at the same time.
+
 ## maps-v1.4.1
 
 ### 🐞 Bug fixes

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -146,4 +146,6 @@ private:
     bool hasRenderFailures = false;
 };
 
+using RenderLayerReferences = std::vector<std::reference_wrapper<RenderLayer>>;
+
 } // namespace mbgl

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -407,9 +407,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         renderTreeParameters->placementChanged = !placementController.placementIsRecent(
             updateParameters->timePoint, updateParameters->transformState.getZoom(), placementUpdatePeriodOverride);
         symbolBucketsChanged |= renderTreeParameters->placementChanged;
-
         if (renderTreeParameters->placementChanged) {
-            Mutable<Placement> placement = makeMutable<Placement>(updateParameters, placementController.getPlacement());
+            Mutable<Placement> placement = Placement::create(updateParameters, placementController.getPlacement());
             placement->placeLayers(layersNeedPlacement);
             placementController.setPlacement(std::move(placement));
             crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
@@ -425,7 +424,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     } else {
         renderTreeParameters->placementChanged = symbolBucketsChanged = !layersNeedPlacement.empty();
         if (renderTreeParameters->placementChanged) {
-            Mutable<Placement> placement = makeMutable<Placement>(updateParameters);
+            Mutable<Placement> placement = Placement::create(updateParameters);
             placement->placeLayers(layersNeedPlacement);
             placementController.setPlacement(std::move(placement));
         }

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -21,7 +21,6 @@ namespace mbgl {
 
 class RendererObserver;
 class RenderSource;
-class RenderLayer;
 class UpdateParameters;
 class RenderStaticData;
 class RenderedQueryOptions;
@@ -129,8 +128,8 @@ private:
     // Vectors with reserved capacity of layerImpls->size() to avoid reallocation
     // on each frame.
     std::vector<Immutable<style::LayerProperties>> filteredLayersForSource;
-    std::vector<std::reference_wrapper<RenderLayer>> orderedLayers;
-    std::vector<std::reference_wrapper<RenderLayer>> layersNeedPlacement;
+    RenderLayerReferences orderedLayers;
+    RenderLayerReferences layersNeedPlacement;
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -105,6 +105,13 @@ Placement::Placement(std::shared_ptr<const UpdateParameters> updateParameters_,
 
 Placement::Placement() : collisionIndex({}, MapMode::Static), collisionGroups(true) {}
 
+void Placement::placeLayers(const RenderLayerReferences& layers) {
+    for (auto it = layers.crbegin(); it != layers.crend(); ++it) {
+        placeLayer(*it);
+    }
+    commit();
+}
+
 void Placement::placeLayer(const RenderLayer& layer) {
     std::set<uint32_t> seenCrossTileIDs;
     for (const BucketPlacementData& data : layer.getPlacementData()) {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -117,7 +117,7 @@ public:
                                      optional<Immutable<Placement>> prevPlacement = nullopt);
 
     virtual ~Placement();
-    void placeLayers(const RenderLayerReferences&);
+    virtual void placeLayers(const RenderLayerReferences&);
     void updateLayerBuckets(const RenderLayer&, const TransformState&, bool updateOpacities) const;
     virtual float symbolFadeChange(TimePoint now) const;
     virtual bool hasTransitions(TimePoint now) const;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -139,7 +139,7 @@ public:
 protected:
     friend SymbolBucket;
     void placeSymbolBucket(const BucketPlacementData&, std::set<uint32_t>& seenCrossTileIDs);
-    void placeLayer(const RenderLayer&);
+    void placeLayer(const RenderLayer&, std::set<uint32_t>&);
     virtual void commit();
     // Implentation specific hooks, which get called during a symbol bucket placement.
     virtual optional<CollisionBoundaries> getAvoidEdges(const SymbolBucket&, const mat4& /*posMatrix*/) {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -108,9 +108,7 @@ class Placement {
 public:
     Placement(std::shared_ptr<const UpdateParameters>, optional<Immutable<Placement>> prevPlacement = nullopt);
     Placement();
-
-    void placeLayer(const RenderLayer&);
-    void commit();
+    void placeLayers(const RenderLayerReferences&);
     void updateLayerBuckets(const RenderLayer&, const TransformState&, bool updateOpacities) const;
     float symbolFadeChange(TimePoint now) const;
     bool hasTransitions(TimePoint now) const;
@@ -128,6 +126,8 @@ public:
 private:
     friend SymbolBucket;
     void placeSymbolBucket(const BucketPlacementData&, std::set<uint32_t>& seenCrossTileIDs);
+    void placeLayer(const RenderLayer&);
+    void commit();
     // Returns `true` if bucket vertices were updated; returns `false` otherwise.
     bool updateBucketDynamicVertices(SymbolBucket&, const TransformState&, const RenderTile& tile) const;
     void updateBucketOpacities(SymbolBucket&, const TransformState&, std::set<uint32_t>&) const;


### PR DESCRIPTION
Place tile intersecting labels first, across all the layers.  Thus, we reduce the amount of label cut-offs in Tile mode.

Before, labels were arranged within one symbol layer (one bucket), which was not enough for several symbol layers being placed at the same time.

Partial fix for https://github.com/mapbox/mapbox-gl-native-team/issues/223
