### PR TITLE
[core][tile mode] Introduce API to collect placed symbols data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
   The new property sets a limit for how much parent tile can be overscaled.
 
+- [core][tile mode] Introduce API to collect placed symbols data ([#16339](https://github.com/mapbox/mapbox-gl-native/pull/16339))
+
+  The following methods are added to the `Renderer` class in implemented in the Tile map mode:
+  - `collectPlacedSymbolData()`
+    enables or disables collecting of the placed symbols data
+
+  - `getPlacedSymbolsData()`
+    if collecting of the placed symbols data is enabled, returns the reference to the `PlacedSymbolData` vector holding the collected data.
+
 ### 🐞 Bug fixes
 
 - [core] Fix assert in gfx resources cleanup ([#16349](https://github.com/mapbox/mapbox-gl-native/pull/16349))

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -21,6 +21,21 @@ namespace gfx {
 class RendererBackend;
 } // namespace gfx
 
+struct PlacedSymbolData {
+    // Contents of the label
+    std::u16string key;
+    // If symbol contains text, text collision box in viewport coordinates
+    optional<mapbox::geometry::box<float>> textCollisionBox;
+    // If symbol contains icon, icon collision box in viewport coordinates
+    optional<mapbox::geometry::box<float>> iconCollisionBox;
+    // Symbol text was placed
+    bool textPlaced;
+    // Symbol icon was placed
+    bool iconPlaced;
+    // Symbol text or icon collision box intersects tile borders
+    bool intersectsTileBorder;
+};
+
 class Renderer {
 public:
     Renderer(gfx::RendererBackend&, float pixelRatio_, const optional<std::string>& localFontFamily = {});
@@ -54,11 +69,31 @@ public:
     void getFeatureState(FeatureState& state, const std::string& sourceID, const optional<std::string>& sourceLayerID,
                          const std::string& featureID) const;
 
-    void removeFeatureState(const std::string& sourceID, const optional<std::string>& sourceLayerID,
-                            const optional<std::string>& featureID, const optional<std::string>& stateKey);
+    void removeFeatureState(const std::string& sourceID,
+                            const optional<std::string>& sourceLayerID,
+                            const optional<std::string>& featureID,
+                            const optional<std::string>& stateKey);
 
     // Debug
     void dumpDebugLogs();
+
+    /**
+     * @brief In Tile map mode, enables or disables collecting of the placed symbols data,
+     * which can be obtained with `getPlacedSymbolsData()`.
+     *
+     * The placed symbols data collecting is disabled by default.
+     */
+    void collectPlacedSymbolData(bool enable);
+
+    /**
+     * @brief If collecting of the placed symbols data is enabled, returns the reference
+     * to the `PlacedSymbolData` vector holding the collected data.
+     *
+     * Note: the returned vector gets re-populated at every `render()` call.
+     *
+     * @return collected placed symbols data
+     */
+    const std::vector<PlacedSymbolData>& getPlacedSymbolsData() const;
 
     // Memory
     void reduceMemoryUse();

--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -34,6 +34,8 @@ struct PlacedSymbolData {
     bool iconPlaced;
     // Symbol text or icon collision box intersects tile borders
     bool intersectsTileBorder;
+    // Viewport padding ({viewportPadding, viewportPadding} is a coordinate of the tile's top-left corner)
+    float viewportPadding;
 };
 
 class Renderer {
@@ -66,7 +68,9 @@ public:
     void setFeatureState(const std::string& sourceID, const optional<std::string>& sourceLayerID,
                          const std::string& featureID, const FeatureState& state);
 
-    void getFeatureState(FeatureState& state, const std::string& sourceID, const optional<std::string>& sourceLayerID,
+    void getFeatureState(FeatureState& state,
+                         const std::string& sourceID,
+                         const optional<std::string>& sourceLayerID,
                          const std::string& featureID) const;
 
     void removeFeatureState(const std::string& sourceID,

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -378,6 +378,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         }
     }
     // Symbol placement.
+    assert((updateParameters->mode == MapMode::Tile) || !placedSymbolDataCollected);
     bool symbolBucketsChanged = false;
     bool symbolBucketsAdded = false;
     std::set<std::string> usedSymbolLayers;
@@ -425,6 +426,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         renderTreeParameters->placementChanged = symbolBucketsChanged = !layersNeedPlacement.empty();
         if (renderTreeParameters->placementChanged) {
             Mutable<Placement> placement = Placement::create(updateParameters);
+            placement->collectPlacedSymbolData(placedSymbolDataCollected);
             placement->placeLayers(layersNeedPlacement);
             placementController.setPlacement(std::move(placement));
         }
@@ -633,6 +635,14 @@ void RenderOrchestrator::dumpDebugLogs() {
     }
 
     imageManager->dumpDebugLogs();
+}
+
+void RenderOrchestrator::collectPlacedSymbolData(bool enable) {
+    placedSymbolDataCollected = enable;
+}
+
+const std::vector<PlacedSymbolData>& RenderOrchestrator::getPlacedSymbolsData() const {
+    return placementController.getPlacement()->getPlacedSymbolsData();
 }
 
 RenderLayer* RenderOrchestrator::getRenderLayer(const std::string& id) {

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -72,6 +72,8 @@ public:
 
     void reduceMemoryUse();
     void dumpDebugLogs();
+    void collectPlacedSymbolData(bool);
+    const std::vector<PlacedSymbolData>& getPlacedSymbolsData() const;
     void clearData();
 
 private:
@@ -124,6 +126,7 @@ private:
 
     const bool backgroundLayerAsColor;
     bool contextLost = false;
+    bool placedSymbolDataCollected = false;
 
     // Vectors with reserved capacity of layerImpls->size() to avoid reallocation
     // on each frame.

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -125,6 +125,14 @@ void Renderer::dumpDebugLogs() {
     impl->orchestrator.dumpDebugLogs();
 }
 
+void Renderer::collectPlacedSymbolData(bool enable) {
+    impl->orchestrator.collectPlacedSymbolData(enable);
+}
+
+const std::vector<PlacedSymbolData>& Renderer::getPlacedSymbolsData() const {
+    return impl->orchestrator.getPlacedSymbolsData();
+}
+
 void Renderer::reduceMemoryUse() {
     gfx::BackendScope guard { impl->backend };
     impl->reduceMemoryUse();

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -27,7 +27,7 @@ const float viewportPaddingDefault = 100;
 // Viewport padding must be much larger for static tiles to avoid clipped labels.
 const float viewportPaddingForStaticTiles = 1024;
 
-inline float getViewportPadding(const TransformState& transformState, MapMode mapMode) {
+inline float findViewportPadding(const TransformState& transformState, MapMode mapMode) {
     if (mapMode == MapMode::Tile) return viewportPaddingForStaticTiles;
     return (transformState.getPitch() != 0.0f) ? viewportPaddingDefault * 2 : viewportPaddingDefault;
 }
@@ -36,7 +36,7 @@ inline float getViewportPadding(const TransformState& transformState, MapMode ma
 
 CollisionIndex::CollisionIndex(const TransformState& transformState_, MapMode mapMode)
     : transformState(transformState_),
-      viewportPadding(getViewportPadding(transformState_, mapMode)),
+      viewportPadding(findViewportPadding(transformState_, mapMode)),
       collisionGrid(transformState.getSize().width + 2 * viewportPadding,
                     transformState.getSize().height + 2 * viewportPadding,
                     25),

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -50,6 +50,8 @@ public:
 
     const TransformState& getTransformState() const { return transformState; }
 
+    float getViewportPadding() const { return viewportPadding; }
+
 private:
     bool isOffscreen(const CollisionBoundaries&) const;
     bool isInsideGrid(const CollisionBoundaries&) const;

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -1386,7 +1386,8 @@ void TilePlacement::newSymbolPlaced(const SymbolInstance& symbol,
                                 iconCollisionBox,
                                 placement.text,
                                 placement.icon,
-                                !placement.skipFade && onlyLabelsIntersectingTileBorders};
+                                !placement.skipFade && onlyLabelsIntersectingTileBorders,
+                                collisionIndex.getViewportPadding()};
     placedSymbolsData.emplace_back(std::move(symbolData));
 }
 

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -1142,6 +1142,11 @@ bool Placement::hasTransitions(TimePoint now) const {
            transitionOptions.duration.value_or(util::DEFAULT_TRANSITION_DURATION);
 }
 
+const std::vector<PlacedSymbolData>& Placement::getPlacedSymbolsData() const {
+    const static std::vector<PlacedSymbolData> data;
+    return data;
+}
+
 const CollisionIndex& Placement::getCollisionIndex() const {
     return collisionIndex;
 }

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -144,6 +144,11 @@ protected:
     void placeSymbolBucket(const BucketPlacementData&, std::set<uint32_t>& seenCrossTileIDs);
     void placeLayer(const RenderLayer&, std::set<uint32_t>&);
     virtual void commit();
+    virtual void newSymbolPlaced(const SymbolInstance&,
+                                 const JointPlacement&,
+                                 style::SymbolPlacementType,
+                                 const std::vector<ProjectedCollisionBox>& /*textBoxes*/,
+                                 const std::vector<ProjectedCollisionBox>& /*iconBoxes*/) {}
     // Implentation specific hooks, which get called during a symbol bucket placement.
     virtual optional<CollisionBoundaries> getAvoidEdges(const SymbolBucket&, const mat4& /*posMatrix*/) {
         return nullopt;

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <mbgl/layout/symbol_projection.hpp>
+#include <mbgl/renderer/renderer.hpp>
+#include <mbgl/style/transition_options.hpp>
+#include <mbgl/text/collision_index.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <string>
 #include <unordered_map>
-#include <mbgl/util/chrono.hpp>
-#include <mbgl/text/collision_index.hpp>
-#include <mbgl/layout/symbol_projection.hpp>
-#include <mbgl/style/transition_options.hpp>
 #include <unordered_set>
 
 namespace mbgl {
@@ -122,6 +123,8 @@ public:
     virtual float symbolFadeChange(TimePoint now) const;
     virtual bool hasTransitions(TimePoint now) const;
     virtual bool transitionsEnabled() const;
+    virtual void collectPlacedSymbolData(bool /*enable*/) {}
+    virtual const std::vector<PlacedSymbolData>& getPlacedSymbolsData() const;
 
     const CollisionIndex& getCollisionIndex() const;
     TimePoint getCommitTime() const { return commitTime; }


### PR DESCRIPTION
The following methods are added to the `Renderer` class in implemented in the Tile map mode:
- `collectPlacedSymbolData()`
  enables or disables collecting of the placed symbols data

- `getPlacedSymbolsData()`
  if collecting of the placed symbols data is enabled, returns the
  reference to the `PlacedSymbolData` vector holding the collected data.

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/232