### PR TITLE
[core] Use const& for the OfflineRegion object

### DIFF
--- a/include/mbgl/storage/database_file_source.hpp
+++ b/include/mbgl/storage/database_file_source.hpp
@@ -159,12 +159,12 @@ public:
     /*
      * Register an observer to be notified when the state of the region changes.
      */
-    virtual void setOfflineRegionObserver(OfflineRegion&, std::unique_ptr<OfflineRegionObserver>);
+    virtual void setOfflineRegionObserver(const OfflineRegion&, std::unique_ptr<OfflineRegionObserver>);
 
     /*
      * Pause or resume downloading of regional resources.
      */
-    virtual void setOfflineRegionDownloadState(OfflineRegion&, OfflineRegionDownloadState);
+    virtual void setOfflineRegionDownloadState(const OfflineRegion&, OfflineRegionDownloadState);
 
     /*
      * Retrieve the current status of the region. The query will be executed
@@ -172,7 +172,7 @@ public:
      * executed on the database thread; it is the responsibility of the SDK bindings
      * to re-execute a user-provided callback on the main thread.
      */
-    virtual void getOfflineRegionStatus(OfflineRegion&,
+    virtual void getOfflineRegionStatus(const OfflineRegion&,
                                         std::function<void(expected<OfflineRegionStatus, std::exception_ptr>)>) const;
 
     /*
@@ -216,7 +216,7 @@ public:
      * executed on the database thread; it is the responsibility of the SDK bindings
      * to re-execute a user-provided callback on the main thread.
      */
-    virtual void deleteOfflineRegion(OfflineRegion&, std::function<void(std::exception_ptr)>);
+    virtual void deleteOfflineRegion(const OfflineRegion&, std::function<void(std::exception_ptr)>);
 
     /*
      * Invalidate all the tiles from an offline region forcing Mapbox GL to revalidate
@@ -224,7 +224,7 @@ public:
      * offline region and downloading it again because if the data on the cache matches
      * the server, no new data gets transmitted.
      */
-    virtual void invalidateOfflineRegion(OfflineRegion&, std::function<void(std::exception_ptr)>);
+    virtual void invalidateOfflineRegion(const OfflineRegion&, std::function<void(std::exception_ptr)>);
 
     /*
      * Changing or bypassing this limit without permission from Mapbox is prohibited

--- a/platform/default/src/mbgl/storage/database_file_source.cpp
+++ b/platform/default/src/mbgl/storage/database_file_source.cpp
@@ -248,26 +248,28 @@ void DatabaseFileSource::updateOfflineMetadata(
     impl->actor().invoke(&DatabaseFileSourceThread::updateMetadata, regionID, metadata, std::move(callback));
 }
 
-void DatabaseFileSource::deleteOfflineRegion(OfflineRegion& region, std::function<void(std::exception_ptr)> callback) {
+void DatabaseFileSource::deleteOfflineRegion(const OfflineRegion& region,
+                                             std::function<void(std::exception_ptr)> callback) {
     impl->actor().invoke(&DatabaseFileSourceThread::deleteRegion, region, std::move(callback));
 }
 
-void DatabaseFileSource::invalidateOfflineRegion(OfflineRegion& region,
+void DatabaseFileSource::invalidateOfflineRegion(const OfflineRegion& region,
                                                  std::function<void(std::exception_ptr)> callback) {
     impl->actor().invoke(&DatabaseFileSourceThread::invalidateRegion, region.getID(), std::move(callback));
 }
 
-void DatabaseFileSource::setOfflineRegionObserver(OfflineRegion& region,
+void DatabaseFileSource::setOfflineRegionObserver(const OfflineRegion& region,
                                                   std::unique_ptr<OfflineRegionObserver> observer) {
     impl->actor().invoke(&DatabaseFileSourceThread::setRegionObserver, region.getID(), std::move(observer));
 }
 
-void DatabaseFileSource::setOfflineRegionDownloadState(OfflineRegion& region, OfflineRegionDownloadState state) {
+void DatabaseFileSource::setOfflineRegionDownloadState(const OfflineRegion& region, OfflineRegionDownloadState state) {
     impl->actor().invoke(&DatabaseFileSourceThread::setRegionDownloadState, region.getID(), state);
 }
 
 void DatabaseFileSource::getOfflineRegionStatus(
-    OfflineRegion& region, std::function<void(expected<OfflineRegionStatus, std::exception_ptr>)> callback) const {
+    const OfflineRegion& region,
+    std::function<void(expected<OfflineRegionStatus, std::exception_ptr>)> callback) const {
     impl->actor().invoke(&DatabaseFileSourceThread::getRegionStatus, region.getID(), std::move(callback));
 }
 


### PR DESCRIPTION
It is used as const and also fixes a build issue on iOS:

```
Non-const lvalue reference to type ‘mbgl::OfflineRegion’ cannot bind
to a temporary of type ‘typename remove_reference<OfflineRegion &>::type’
(aka ‘mbgl::OfflineRegion’)
```