### PR TITLE
Add source property to limit parent's tile overscale factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@
 
 - [core] Move logging off the main thread ([#16325](https://github.com/mapbox/mapbox-gl-native/pull/16325))
 
+- Add source property to limit parent's tile overscale factor ([#16347](https://github.com/mapbox/mapbox-gl-native/pull/16347))
+
+  The new property sets a limit for how much parent tile can be overscaled.
+
 ### 🐞 Bug fixes
+
+- [core] Fix assert in gfx resources cleanup ([#16349](https://github.com/mapbox/mapbox-gl-native/pull/16349))
+
+  Fix a resource leak assertion in `gl::Context::~Context()` that is evaluating false in scenarios where graphics context has been marked as lost.
 
 - Hillshade bucket fix for mapbox-gl-native-ios #240 ([#16362](https://github.com/mapbox/mapbox-gl-native/pull/16362))
 
@@ -46,10 +54,6 @@
   Before, labels were arranged within one symbol layer (one bucket),which was not enough for several symbol layers being placed at the same time.
 
 - [core] Fix issue that `within` expression returns incorrect results for geometries crossing the anti-meridian ([#16330](https://github.com/mapbox/mapbox-gl-native/pull/16330))
-
-- [core] Fix assert in gfx resources cleanup ([#16349](https://github.com/mapbox/mapbox-gl-native/pull/16349))
-
-  Fix a resource leak assertion in `gl::Context::~Context()` that is evaluating false in scenarios where graphics context has been marked as lost.
 
 ## maps-v1.4.1
 

--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -75,6 +75,20 @@ public:
     virtual void loadDescription(FileSource&) = 0;
     void setPrefetchZoomDelta(optional<uint8_t> delta) noexcept;
     optional<uint8_t> getPrefetchZoomDelta() const noexcept;
+
+    // Sets a limit for how much a parent tile can be overscaled.
+    //
+    // When a set of tiles for a current zoom level is being rendered and some of the
+    // ideal tiles that cover the screen are not yet loaded, parent tile could be
+    // used instead. This might introduce unwanted rendering side-effects, especially
+    // for raster tiles that are overscaled multiple times.
+    //
+    // For example, an overscale factor of 3 would mean that on zoom level 3, the
+    // minimum zoom level of a parent tile that could be used in place of an ideal
+    // tile during rendering would be zoom 0. By default, no limit is set, so any
+    // parent tile may be used.
+    void setMaxOverscaleFactorForParentTiles(optional<uint8_t> overscaleFactor) noexcept;
+    optional<uint8_t> getMaxOverscaleFactorForParentTiles() const noexcept;
     void dumpDebugLogs() const;
 
     virtual bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const = 0;

--- a/platform/android/src/style/sources/source.cpp
+++ b/platform/android/src/style/sources/source.cpp
@@ -118,6 +118,22 @@ static std::unique_ptr<Source> createSourcePeer(jni::JNIEnv& env,
         return jni::Local<jni::Integer>(env, nullptr);
     }
 
+    void Source::setMaxOverscaleFactorForParentTiles(jni::JNIEnv& env, jni::Integer& maxOverscaleFactor) {
+        if (!maxOverscaleFactor) {
+            source.setMaxOverscaleFactorForParentTiles(nullopt);
+        } else {
+            source.setMaxOverscaleFactorForParentTiles(jni::Unbox(env, maxOverscaleFactor));
+        }
+    }
+
+    jni::Local<jni::Integer> Source::getMaxOverscaleFactorForParentTiles(jni::JNIEnv& env) {
+        auto maxOverscaleFactor = source.getMaxOverscaleFactorForParentTiles();
+        if (maxOverscaleFactor) {
+            return jni::Box(env, jni::jint(*maxOverscaleFactor));
+        }
+        return jni::Local<jni::Integer>(env, nullptr);
+    }
+
     void Source::addToStyle(JNIEnv& env, const jni::Object<Source>& obj, mbgl::style::Style& style) {
         if (!ownedSource) {
             throw std::runtime_error("Cannot add source twice");
@@ -189,13 +205,16 @@ static std::unique_ptr<Source> createSourcePeer(jni::JNIEnv& env,
         #define METHOD(MethodPtr, name) jni::MakeNativePeerMethod<decltype(MethodPtr), (MethodPtr)>(name)
 
         // Register the peer
-        jni::RegisterNativePeer<Source>(env,
-                                        javaClass,
-                                        "nativePtr",
-                                        METHOD(&Source::getId, "nativeGetId"),
-                                        METHOD(&Source::getAttribution, "nativeGetAttribution"),
-                                        METHOD(&Source::setPrefetchZoomDelta, "nativeSetPrefetchZoomDelta"),
-                                        METHOD(&Source::getPrefetchZoomDelta, "nativeGetPrefetchZoomDelta"));
+        jni::RegisterNativePeer<Source>(
+            env,
+            javaClass,
+            "nativePtr",
+            METHOD(&Source::getId, "nativeGetId"),
+            METHOD(&Source::getAttribution, "nativeGetAttribution"),
+            METHOD(&Source::setPrefetchZoomDelta, "nativeSetPrefetchZoomDelta"),
+            METHOD(&Source::getPrefetchZoomDelta, "nativeGetPrefetchZoomDelta"),
+            METHOD(&Source::setMaxOverscaleFactorForParentTiles, "nativeSetMaxOverscaleFactorForParentTiles"),
+            METHOD(&Source::getMaxOverscaleFactorForParentTiles, "nativeGetMaxOverscaleFactorForParentTiles"));
 
         // Register subclasses
         GeoJSONSource::registerNative(env);

--- a/platform/android/src/style/sources/source.hpp
+++ b/platform/android/src/style/sources/source.hpp
@@ -48,6 +48,10 @@ public:
 
     jni::Local<jni::Integer> getPrefetchZoomDelta(jni::JNIEnv&);
 
+    void setMaxOverscaleFactorForParentTiles(jni::JNIEnv& env, jni::Integer& delta);
+
+    jni::Local<jni::Integer> getMaxOverscaleFactorForParentTiles(jni::JNIEnv&);
+
     void addToStyle(JNIEnv& env, const jni::Object<Source>& obj, mbgl::style::Style& style);
 
 protected:

--- a/src/mbgl/algorithm/update_renderables.hpp
+++ b/src/mbgl/algorithm/update_renderables.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/tile/tile_necessity.hpp>
+#include <mbgl/util/optional.hpp>
 #include <mbgl/util/range.hpp>
 
 #include <unordered_set>
@@ -20,7 +21,8 @@ void updateRenderables(GetTileFn getTile,
                        RenderTileFn renderTile,
                        const IdealTileIDs& idealTileIDs,
                        const Range<uint8_t>& zoomRange,
-                       const uint8_t dataTileZoom) {
+                       const uint8_t dataTileZoom,
+                       const optional<uint8_t>& maxParentOverscaleFactor = nullopt) {
     std::unordered_set<OverscaledTileID> checked;
     bool covered;
     int32_t overscaledZ;
@@ -85,6 +87,11 @@ void updateRenderables(GetTileFn getTile,
                 // We couldn't find child tiles that entirely cover the ideal tile.
                 for (overscaledZ = dataTileZoom - 1; overscaledZ >= zoomRange.min; --overscaledZ) {
                     const auto parentDataTileID = idealDataTileID.scaledTo(overscaledZ);
+
+                    // Request / render parent tile only if it's overscale factor is less than defined maximum.
+                    if (maxParentOverscaleFactor && (dataTileZoom - overscaledZ) > *maxParentOverscaleFactor) {
+                        break;
+                    }
 
                     if (checked.find(parentDataTileID) != checked.end()) {
                         // Break parent tile ascent, this route has been checked by another child

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -40,7 +40,8 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
         {0, 16},
         optional<LatLngBounds>{},
         [&](const OverscaledTileID& tileID) { return std::make_unique<AnnotationTile>(tileID, parameters); },
-        baseImpl->getPrefetchZoomDelta());
+        baseImpl->getPrefetchZoomDelta(),
+        baseImpl->getMaxOverscaleFactorForParentTiles());
 }
 
 std::unordered_map<std::string, std::vector<Feature>>

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -53,7 +53,8 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
             return std::make_unique<CustomGeometryTile>(
                 tileID, impl().id, parameters, impl().getTileOptions(), *tileLoader);
         },
-        baseImpl->getPrefetchZoomDelta());
+        baseImpl->getPrefetchZoomDelta(),
+        baseImpl->getMaxOverscaleFactorForParentTiles());
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -118,7 +118,8 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
         [&, data_](const OverscaledTileID& tileID) {
             return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data_);
         },
-        baseImpl->getPrefetchZoomDelta());
+        baseImpl->getPrefetchZoomDelta(),
+        baseImpl->getMaxOverscaleFactorForParentTiles());
 }
 
 mapbox::util::variant<Value, FeatureCollection>

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -37,7 +37,8 @@ void RenderRasterDEMSource::updateInternal(const Tileset& tileset,
         tileset.zoomRange,
         tileset.bounds,
         [&](const OverscaledTileID& tileID) { return std::make_unique<RasterDEMTile>(tileID, parameters, tileset); },
-        baseImpl->getPrefetchZoomDelta());
+        baseImpl->getPrefetchZoomDelta(),
+        baseImpl->getMaxOverscaleFactorForParentTiles());
     algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -35,7 +35,8 @@ void RenderRasterSource::updateInternal(const Tileset& tileset,
         tileset.zoomRange,
         tileset.bounds,
         [&](const OverscaledTileID& tileID) { return std::make_unique<RasterTile>(tileID, parameters, tileset); },
-        baseImpl->getPrefetchZoomDelta());
+        baseImpl->getPrefetchZoomDelta(),
+        baseImpl->getMaxOverscaleFactorForParentTiles());
     algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -33,7 +33,8 @@ void RenderVectorSource::updateInternal(const Tileset& tileset,
         [&](const OverscaledTileID& tileID) {
             return std::make_unique<VectorTile>(tileID, baseImpl->id, parameters, tileset);
         },
-        baseImpl->getPrefetchZoomDelta());
+        baseImpl->getPrefetchZoomDelta(),
+        baseImpl->getMaxOverscaleFactorForParentTiles());
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -58,7 +58,8 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
                          const Range<uint8_t> zoomRange,
                          optional<LatLngBounds> bounds,
                          std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile,
-                         optional<uint8_t> sourcePrefetchZoomDelta) {
+                         const optional<uint8_t>& sourcePrefetchZoomDelta,
+                         const optional<uint8_t>& maxParentTileOverscaleFactor) {
     // If we need a relayout, abandon any cached tiles; they're now stale.
     if (needsRelayout) {
         cache.clear();
@@ -177,13 +178,26 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
     renderedTiles.clear();
 
     if (!panTiles.empty()) {
-        algorithm::updateRenderables(getTileFn, createTileFn, retainTileFn,
-                [](const UnwrappedTileID&, Tile&) {}, panTiles, zoomRange, panZoom);
+        algorithm::updateRenderables(
+            getTileFn,
+            createTileFn,
+            retainTileFn,
+            [](const UnwrappedTileID&, Tile&) {},
+            panTiles,
+            zoomRange,
+            panZoom,
+            maxParentTileOverscaleFactor);
     }
 
-    algorithm::updateRenderables(getTileFn, createTileFn, retainTileFn, renderTileFn,
-                                 idealTiles, zoomRange, tileZoom);
-    
+    algorithm::updateRenderables(getTileFn,
+                                 createTileFn,
+                                 retainTileFn,
+                                 renderTileFn,
+                                 idealTiles,
+                                 zoomRange,
+                                 tileZoom,
+                                 maxParentTileOverscaleFactor);
+
     for (auto previouslyRenderedTile : previouslyRenderedTiles) {
         Tile& tile = previouslyRenderedTile.second;
         tile.markRenderedPreviously();

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -42,7 +42,8 @@ public:
                 Range<uint8_t> zoomRange,
                 optional<LatLngBounds> bounds,
                 std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile,
-                optional<uint8_t> sourcePrefetchZoomDelta);
+                const optional<uint8_t>& sourcePrefetchZoomDelta,
+                const optional<uint8_t>& maxParentTileOverscaleFactor);
 
     const std::map<UnwrappedTileID, std::reference_wrapper<Tile>>& getRenderedTiles() const { return renderedTiles; }
     Tile* getTile(const OverscaledTileID&);

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -43,6 +43,18 @@ optional<uint8_t> Source::getPrefetchZoomDelta() const noexcept {
     return baseImpl->getPrefetchZoomDelta();
 }
 
+void Source::setMaxOverscaleFactorForParentTiles(optional<uint8_t> overscaleFactor) noexcept {
+    if (getMaxOverscaleFactorForParentTiles() == overscaleFactor) return;
+    auto newImpl = createMutable();
+    newImpl->setMaxOverscaleFactorForParentTiles(std::move(overscaleFactor));
+    baseImpl = std::move(newImpl);
+    observer->onSourceChanged(*this);
+}
+
+optional<uint8_t> Source::getMaxOverscaleFactorForParentTiles() const noexcept {
+    return baseImpl->getMaxOverscaleFactorForParentTiles();
+}
+
 void Source::dumpDebugLogs() const {
     Log::Info(Event::General, "Source::id: %s", getID().c_str());
     Log::Info(Event::General, "Source::loaded: %d", loaded);

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -1,7 +1,18 @@
 #include <mbgl/style/source_impl.hpp>
+#include <mbgl/util/constants.hpp>
+#include <mbgl/util/logging.hpp>
 
 namespace mbgl {
 namespace style {
+
+namespace {
+void WarnIfOverscaleFactorCapsPrefetchDelta(const optional<uint8_t>& overscale, const optional<uint8_t>& prefetch) {
+    const uint8_t prefetchDelta = std::max<uint8_t>(util::DEFAULT_PREFETCH_ZOOM_DELTA, prefetch.value_or(0u));
+    if (overscale && *overscale < prefetchDelta) {
+        Log::Warning(Event::Style, "Parent tile overscale factor will cap prefetch delta to %d", int(*overscale));
+    }
+}
+} // namespace
 
 Source::Impl::Impl(SourceType type_, std::string id_)
     : type(type_),
@@ -10,10 +21,20 @@ Source::Impl::Impl(SourceType type_, std::string id_)
 
 void Source::Impl::setPrefetchZoomDelta(optional<uint8_t> delta) noexcept {
     prefetchZoomDelta = std::move(delta);
+    WarnIfOverscaleFactorCapsPrefetchDelta(maxOverscaleFactor, prefetchZoomDelta);
 }
 
 optional<uint8_t> Source::Impl::getPrefetchZoomDelta() const noexcept {
     return prefetchZoomDelta;
+}
+
+void Source::Impl::setMaxOverscaleFactorForParentTiles(optional<uint8_t> overscaleFactor) noexcept {
+    maxOverscaleFactor = std::move(overscaleFactor);
+    WarnIfOverscaleFactorCapsPrefetchDelta(maxOverscaleFactor, prefetchZoomDelta);
+}
+
+optional<uint8_t> Source::Impl::getMaxOverscaleFactorForParentTiles() const noexcept {
+    return maxOverscaleFactor;
 }
 
 } // namespace style

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -22,10 +22,13 @@ public:
     virtual optional<std::string> getAttribution() const = 0;
     void setPrefetchZoomDelta(optional<uint8_t> delta) noexcept;
     optional<uint8_t> getPrefetchZoomDelta() const noexcept;
+    void setMaxOverscaleFactorForParentTiles(optional<uint8_t> overscaleFactor) noexcept;
+    optional<uint8_t> getMaxOverscaleFactorForParentTiles() const noexcept;
 
     const SourceType type;
     const std::string id;
     optional<uint8_t> prefetchZoomDelta;
+    optional<uint8_t> maxOverscaleFactor;
 
 protected:
     Impl(SourceType, std::string);


### PR DESCRIPTION
The new property sets a limit for how much parent tile can be overscaled.

When a set of tiles for a current zoom level is being rendered and some of the ideal tiles that cover the screen are not yet loaded, parent tile could be used instead. This might introduce unwanted rendering side-effects, especially for raster tiles that are overscaled multiple times.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
 - [x] tagged `@mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk` if this PR adds or updates a public API
 - [ ] tagged `@mapbox/gl-js` if this PR includes shader changes or needs a js port
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)

/cc @mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk
/cc @asheemmamoowala