### PR TITLE
Fix assert in gfx resources cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 
 - [core] Fix issue that `within` expression returns incorrect results for geometries crossing the anti-meridian ([#16330](https://github.com/mapbox/mapbox-gl-native/pull/16330))
 
+- [core] Fix assert in gfx resources cleanup ([#16349](https://github.com/mapbox/mapbox-gl-native/pull/16349))
+
+  Fix a resource leak assertion in `gl::Context::~Context()` that is evaluating false in scenarios where graphics context has been marked as lost.
+
 ## maps-v1.4.1
 
 ### 🐞 Bug fixes

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -61,8 +61,8 @@ Context::Context(RendererBackend& backend_)
 Context::~Context() {
     if (cleanupOnDestruction) {
         reset();
+        assert(stats.isZero());
     }
-    assert(stats.isZero());
 }
 
 void Context::initializeExtensions(const std::function<gl::ProcAddress(const char*)>& getProcAddress) {


### PR DESCRIPTION
A resource leak assertion in `gl::Context::~Context()` is evaluating false in scenarios where graphics context has been marked as lost. In these cases the underlying system handles resource cleanup and the assertion should not be checked.

This change fixes the issue https://github.com/mapbox/mapbox-gl-native-android/issues/300