### PR TITLE
[core] Fix remaining clang-tidy issues

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,31 @@
-Checks: '-*,bugprone-*,clang-analyzer-*,google-*,modernize-*,performance-*,-clang-analyzer-osx.*,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references,-modernize-avoid-c-arrays'
-WarningsAsErrors: 'bugprone-use-after-move,modernize-*,performance-*'
+Checks: >
+    -*,
+    bugprone-*,
+    clang-diagnostic-*,
+    google-*,
+    misc-*,
+    modernize-*,
+    performance-*,
+    portability-*,
+    readability-*,
+    -bugprone-narrowing-conversions,
+    -google-build-using-namespace,
+    -google-readability-braces-around-statements,
+    -google-readability-todo,
+    -google-runtime-int,
+    -google-runtime-references,
+    -modernize-avoid-c-arrays,
+    -readability-braces-around-statements,
+    -readability-else-after-return,
+    -readability-implicit-bool-conversion,
+    -readability-magic-numbers,
+    -readability-named-parameter,
+    -readability-uppercase-literal-suffix
+
+WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: file
+
+CheckOptions:
+  - key:   misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: '1'

--- a/circle.yml
+++ b/circle.yml
@@ -684,8 +684,8 @@ jobs:
       - run:
           name: Clang Tidy
           command: |
-            run-clang-tidy-8 -quiet -j $(nproc) -p build $PWD/src/.*cpp $PWD/platform/.*cpp |tee clang-tidy.log
-            grep -o \\[[a-z].*-.*[a-z]\] clang-tidy.log |sort |uniq -c |sort -n
+            # FIXME: Run on the headers, add -header-filter='.*'
+            run-clang-tidy-8 -quiet -j $(nproc) -p build $PWD/src/.*cpp $PWD/platform/.*cpp
       - save
   baselines:
     executor: ubuntu-disco

--- a/include/mbgl/style/expression/parsing_context.hpp
+++ b/include/mbgl/style/expression/parsing_context.hpp
@@ -87,7 +87,7 @@ public:
     std::string getKey() const { return key; }
     optional<type::Type> getExpected() const { return expected; }
     const std::vector<ParsingError>& getErrors() const { return *errors; }
-    const std::string getCombinedErrors() const;
+    std::string getCombinedErrors() const;
 
     /*
         Parse the given style-spec JSON value as an expression.

--- a/platform/default/include/mbgl/gfx/headless_frontend.hpp
+++ b/platform/default/include/mbgl/gfx/headless_frontend.hpp
@@ -24,12 +24,12 @@ public:
     };
 
     HeadlessFrontend(float pixelRatio_,
-                     gfx::HeadlessBackend::SwapBehaviour swapBehviour = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
+                     gfx::HeadlessBackend::SwapBehaviour swapBehavior = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
                      const optional<std::string>& localFontFamily = {});
     HeadlessFrontend(Size,
                      float pixelRatio_,
-                     gfx::HeadlessBackend::SwapBehaviour swapBehviour = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
+                     gfx::HeadlessBackend::SwapBehaviour swapBehavior = gfx::HeadlessBackend::SwapBehaviour::NoFlush,
                      gfx::ContextMode mode = gfx::ContextMode::Unique,
                      const optional<std::string>& localFontFamily = {});
     ~HeadlessFrontend() override;

--- a/platform/default/src/mbgl/i18n/collator.cpp
+++ b/platform/default/src/mbgl/i18n/collator.cpp
@@ -21,7 +21,8 @@
 namespace {
 std::string unaccent(const std::string& str) {
     std::stringstream output;
-    char const *itr = str.c_str(), *nitr;
+    char const* itr = str.c_str();
+    char const* nitr;
     char const* end = itr + str.length();
     char lo[5] = {0};
 

--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -71,8 +71,8 @@ public:
     void handleResult(CURLcode code);
 
 private:
-    static size_t headerCallback(char *const buffer, const size_t size, const size_t nmemb, void *userp);
-    static size_t writeCallback(void *const contents, const size_t size, const size_t nmemb, void *userp);
+    static size_t headerCallback(char *buffer, size_t size, size_t nmemb, void *userp);
+    static size_t writeCallback(void *contents, size_t size, size_t nmemb, void *userp);
 
     HTTPFileSource::Impl* context = nullptr;
     Resource resource;
@@ -328,7 +328,7 @@ size_t HTTPRequest::headerCallback(char *const buffer, const size_t size, const 
         baton->response->etag = std::string(buffer + begin, length - begin - 2); // remove \r\n
     } else if ((begin = headerMatches("cache-control: ", buffer, length)) != std::string::npos) {
         const std::string value { buffer + begin, length - begin - 2 }; // remove \r\n
-        const auto cc = http::CacheControl::parse(value.c_str());
+        const auto cc = http::CacheControl::parse(value);
         baton->response->expires = cc.toTimePoint();
         baton->response->mustRevalidate = cc.mustRevalidate;
     } else if ((begin = headerMatches("expires: ", buffer, length)) != std::string::npos) {

--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -286,7 +286,7 @@ size_t HTTPRequest::writeCallback(void *const contents, const size_t size, const
         impl->data = std::make_shared<std::string>();
     }
 
-    impl->data->append((char *)contents, size * nmemb);
+    impl->data->append(static_cast<char *>(contents), size * nmemb);
     return size * nmemb;
 }
 

--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -266,7 +266,10 @@ HTTPRequest::HTTPRequest(HTTPFileSource::Impl* context_, Resource resource_, Fil
 }
 
 HTTPRequest::~HTTPRequest() {
-    handleError(curl_multi_remove_handle(context->multi, handle));
+    if (curl_multi_remove_handle(context->multi, handle) != CURLM_OK) {
+        mbgl::Log::Error(mbgl::Event::HttpRequest, "Error removing curl multi handle");
+    }
+
     context->returnHandle(handle);
     handle = nullptr;
 

--- a/platform/default/src/mbgl/storage/local_file_source.cpp
+++ b/platform/default/src/mbgl/storage/local_file_source.cpp
@@ -19,7 +19,7 @@ namespace mbgl {
 
 class LocalFileSource::Impl {
 public:
-    Impl(const ActorRef<Impl>&) {}
+    explicit Impl(const ActorRef<Impl>&) {}
 
     void request(const std::string& url, const ActorRef<FileSourceRequest>& req) {
         if (!acceptsURL(url)) {

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -97,11 +97,7 @@ bool OfflineDatabase::disabled() {
     }
 
     auto regions = listRegions();
-    if (regions && !regions.value().empty()) {
-        return false;
-    }
-
-    return true;
+    return !(regions && !regions.value().empty());
 }
 
 void OfflineDatabase::handleError(const mapbox::sqlite::Exception& ex, const char* action) {

--- a/platform/default/src/mbgl/storage/online_file_source.cpp
+++ b/platform/default/src/mbgl/storage/online_file_source.cpp
@@ -213,7 +213,7 @@ private:
     //                              firstLowPriorityRequest
 
     struct PendingRequests {
-        PendingRequests() : queue(), firstLowPriorityRequest(queue.begin()) {}
+        PendingRequests() : firstLowPriorityRequest(queue.begin()) {}
 
         std::list<OnlineFileRequest*> queue;
         std::list<OnlineFileRequest*>::iterator firstLowPriorityRequest;

--- a/platform/default/src/mbgl/storage/sqlite3.cpp
+++ b/platform/default/src/mbgl/storage/sqlite3.cpp
@@ -46,9 +46,7 @@ void setTempPath(const std::string& path) {
 
 class DatabaseImpl {
 public:
-    DatabaseImpl(sqlite3* db_)
-        : db(db_)
-    {
+    explicit DatabaseImpl(sqlite3* db_) : db(db_) {
         const int error = sqlite3_extended_result_codes(db, true);
         if (error != SQLITE_OK) {
             mbgl::Log::Warning(mbgl::Event::Database, error, "Failed to enable extended result codes: %s", sqlite3_errmsg(db));

--- a/platform/default/src/mbgl/storage/sqlite3.cpp
+++ b/platform/default/src/mbgl/storage/sqlite3.cpp
@@ -132,7 +132,7 @@ mapbox::util::variant<Database, Exception> Database::tryOpen(const std::string &
 Database Database::open(const std::string &filename, int flags) {
     auto result = tryOpen(filename, flags);
     if (result.is<Exception>()) {
-        throw result.get<Exception>();
+        throw std::move(result.get<Exception>());
     } else {
         return std::move(result.get<Database>());
     }

--- a/platform/default/src/mbgl/util/async_task.cpp
+++ b/platform/default/src/mbgl/util/async_task.cpp
@@ -12,10 +12,7 @@ namespace util {
 
 class AsyncTask::Impl {
 public:
-    Impl(std::function<void()>&& fn)
-        : async(new uv_async_t),
-          task(std::move(fn)) {
-
+    explicit Impl(std::function<void()> fn) : async(new uv_async_t), task(std::move(fn)) {
         auto* loop = reinterpret_cast<uv_loop_t*>(RunLoop::getLoopHandle());
         if (uv_async_init(loop, async, asyncCallback) != 0) {
             throw std::runtime_error("Failed to initialize async.");

--- a/platform/default/src/mbgl/util/compression.cpp
+++ b/platform/default/src/mbgl/util/compression.cpp
@@ -40,7 +40,7 @@ std::string compress(const std::string &raw) {
         throw std::runtime_error("failed to initialize deflate");
     }
 
-    deflate_stream.next_in = (Bytef *)raw.data();
+    deflate_stream.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(raw.data()));
     deflate_stream.avail_in = uInt(raw.size());
 
     std::string result;
@@ -75,7 +75,7 @@ std::string decompress(const std::string &raw) {
         throw std::runtime_error("failed to initialize inflate");
     }
 
-    inflate_stream.next_in = (Bytef *)raw.data();
+    inflate_stream.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(raw.data()));
     inflate_stream.avail_in = uInt(raw.size());
 
     std::string result;

--- a/platform/default/src/mbgl/util/jpeg_reader.cpp
+++ b/platform/default/src/mbgl/util/jpeg_reader.cpp
@@ -79,8 +79,7 @@ static void on_error_message(j_common_ptr cinfo) {
 }
 
 struct jpeg_info_guard {
-    jpeg_info_guard(jpeg_decompress_struct* cinfo)
-        : i_(cinfo) {}
+    explicit jpeg_info_guard(jpeg_decompress_struct* cinfo) : i_(cinfo) {}
 
     ~jpeg_info_guard() {
         jpeg_destroy_decompress(i_);

--- a/platform/default/src/mbgl/util/jpeg_reader.cpp
+++ b/platform/default/src/mbgl/util/jpeg_reader.cpp
@@ -56,8 +56,8 @@ static void term(j_decompress_ptr) {}
 
 static void attach_stream(j_decompress_ptr cinfo, std::istream* in) {
     if (cinfo->src == nullptr) {
-        cinfo->src = (struct jpeg_source_mgr *)
-            (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_PERMANENT, sizeof(jpeg_stream_wrapper));
+        cinfo->src = static_cast<struct jpeg_source_mgr*>((*cinfo->mem->alloc_small)(
+            reinterpret_cast<j_common_ptr>(cinfo), JPOOL_PERMANENT, sizeof(jpeg_stream_wrapper)));
     }
     auto * src = reinterpret_cast<jpeg_stream_wrapper*> (cinfo->src);
     src->manager.init_source = init_source;
@@ -122,7 +122,7 @@ PremultipliedImage decodeJPEG(const uint8_t* data, size_t size) {
     PremultipliedImage image({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
     uint8_t* dst = image.data.get();
 
-    JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr) &cinfo, JPOOL_IMAGE, rowStride, 1);
+    JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)(reinterpret_cast<j_common_ptr>(&cinfo), JPOOL_IMAGE, rowStride, 1);
 
     while (cinfo.output_scanline < cinfo.output_height) {
         jpeg_read_scanlines(&cinfo, buffer, 1);

--- a/platform/default/src/mbgl/util/png_writer.cpp
+++ b/platform/default/src/mbgl/util/png_writer.cpp
@@ -59,7 +59,7 @@ std::string encodePNG(const PremultipliedImage& pre) {
     for (uint32_t y = 0; y < src.size.height; y++) {
         // Every scanline needs to be prefixed with one byte that indicates the filter type.
         idat.append(1, 0); // filter type 0
-        idat.append((const char*)(src.data.get() + y * stride), stride);
+        idat.append(reinterpret_cast<const char*>(src.data.get() + y * stride), stride);
     }
     idat = util::compress(idat);
 

--- a/platform/default/src/mbgl/util/png_writer.cpp
+++ b/platform/default/src/mbgl/util/png_writer.cpp
@@ -7,8 +7,7 @@
 #include <cassert>
 #include <cstring>
 
-#define NETWORK_BYTE_UINT32(value)                                                                 \
-    char(value >> 24), char(value >> 16), char(value >> 8), char(value >> 0)
+#define NETWORK_BYTE_UINT32(value) char((value) >> 24), char((value) >> 16), char((value) >> 8), char((value) >> 0)
 
 namespace {
 

--- a/platform/default/src/mbgl/util/string_stdlib.cpp
+++ b/platform/default/src/mbgl/util/string_stdlib.cpp
@@ -8,7 +8,8 @@ namespace mbgl { namespace platform {
 std::string uppercase(const std::string& str)
 {
     std::stringstream output;
-    char const *itr = str.c_str(), *nitr;
+    char const *itr = str.c_str();
+    char const *nitr;
     char const *end = itr + str.length();
     char lo[5] = { 0 };
 
@@ -41,7 +42,8 @@ std::string uppercase(const std::string& str)
 std::string lowercase(const std::string& str)
 {
     std::stringstream output;
-    char const *itr = str.c_str(), *nitr;
+    char const *itr = str.c_str();
+    char const *nitr;
     char const *end = itr + str.length();
     char lo[5] = { 0 };
 

--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -7,8 +7,7 @@
 
 class GLFWGLRenderableResource final : public mbgl::gl::RenderableResource {
 public:
-    GLFWGLRenderableResource(GLFWGLBackend& backend_) : backend(backend_) {
-    }
+    explicit GLFWGLRenderableResource(GLFWGLBackend& backend_) : backend(backend_) {}
 
     void bind() override {
         backend.setFramebufferBinding(0);

--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -26,7 +26,8 @@ GLFWGLBackend::GLFWGLBackend(GLFWwindow* window_, const bool capFrameRate)
     : mbgl::gl::RendererBackend(mbgl::gfx::ContextMode::Unique),
       mbgl::gfx::Renderable(
           [window_] {
-              int fbWidth, fbHeight;
+              int fbWidth;
+              int fbHeight;
               glfwGetFramebufferSize(window_, &fbWidth, &fbHeight);
               return mbgl::Size{ static_cast<uint32_t>(fbWidth), static_cast<uint32_t>(fbHeight) };
           }(),

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -764,7 +764,7 @@ void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
         using namespace mbgl;
         FeatureState newState;
 
-        if (result.size() > 0) {
+        if (!result.empty()) {
             FeatureIdentifier id = result[0].id;
             optional<std::string> idStr = featureIDtoString(id);
 

--- a/platform/glfw/test_writer.cpp
+++ b/platform/glfw/test_writer.cpp
@@ -20,7 +20,7 @@ public:
 
 class SetCamera final : public TestOperationSerializer {
 public:
-    SetCamera(mbgl::CameraOptions camera_) : camera(std::move(camera_)) {}
+    explicit SetCamera(mbgl::CameraOptions camera_) : camera(std::move(camera_)) {}
 
     void serialize(Writer& writer) const override {
         if (camera.zoom) {
@@ -59,7 +59,7 @@ private:
 
 class SetStyle final : public TestOperationSerializer {
 public:
-    SetStyle(const mbgl::style::Style& style) : url(style.getURL()) {}
+    explicit SetStyle(const mbgl::style::Style& style) : url(style.getURL()) {}
 
     void serialize(Writer& writer) const override {
         writer.StartArray();
@@ -74,7 +74,7 @@ private:
 
 class SetInitialSize final : public TestOperationSerializer {
 public:
-    SetInitialSize(const mbgl::Size& size) : width(size.width), height(size.height) {}
+    explicit SetInitialSize(const mbgl::Size& size) : width(size.width), height(size.height) {}
 
     void serialize(Writer& writer) const override {
         writer.Key("width");

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -17,7 +17,7 @@ private:
     struct Key { explicit Key() = default; };
 
 public:
-    GLXDisplayConfig(Key) {
+    explicit GLXDisplayConfig(Key) {
         if (!XInitThreads()) {
             throw std::runtime_error("Failed to XInitThreads.");
         }

--- a/platform/node/src/node_expression.cpp
+++ b/platform/node/src/node_expression.cpp
@@ -94,7 +94,7 @@ void NodeExpression::Parse(const Nan::FunctionCallbackInfo<v8::Value>& info) {
             Nan::Set(err,
                     Nan::New("error").ToLocalChecked(),
                     Nan::New(error.message.c_str()).ToLocalChecked());
-            Nan::Set(result, Nan::New((uint32_t)i), err);
+            Nan::Set(result, Nan::New(static_cast<uint32_t>(i)), err);
         }
         info.GetReturnValue().Set(result);
     };

--- a/platform/node/src/node_expression.cpp
+++ b/platform/node/src/node_expression.cpp
@@ -157,7 +157,7 @@ struct ToValue {
     v8::Local<v8::Value> operator()(const std::vector<Value>& array) {
         Nan::EscapableHandleScope scope;
         v8::Local<v8::Array> result = Nan::New<v8::Array>();
-        for (unsigned int i = 0; i < array.size(); i++) {
+        for (std::size_t i = 0; i < array.size(); i++) {
             result->Set(i, toJS(array[i]));
         }
         return scope.Escape(result);

--- a/platform/node/src/node_feature.cpp
+++ b/platform/node/src/node_feature.cpp
@@ -112,7 +112,7 @@ struct ToValue {
     v8::Local<v8::Value> operator()(const std::vector<mbgl::Value>& array) {
         Nan::EscapableHandleScope scope;
         v8::Local<v8::Array> result = Nan::New<v8::Array>();
-        for (unsigned int i = 0; i < array.size(); i++) {
+        for (std::size_t i = 0; i < array.size(); i++) {
             result->Set(i, toJS(array[i]));
         }
         return scope.Escape(result);

--- a/platform/node/src/node_logging.hpp
+++ b/platform/node/src/node_logging.hpp
@@ -20,7 +20,10 @@ public:
     ~NodeLogObserver();
 
     // Log::Observer implementation
-    virtual bool onRecord(mbgl::EventSeverity severity, mbgl::Event event, int64_t code, const std::string &msg) override;
+    virtual bool onRecord(mbgl::EventSeverity severity,
+                          mbgl::Event event,
+                          int64_t code,
+                          const std::string& text) override;
 
 private:
     Nan::Persistent<v8::Object> module;

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -315,7 +315,7 @@ NodeMap::RenderOptions NodeMap::ParseOptions(v8::Local<v8::Object> obj) {
         if (auto light = mbgl::style::conversion::convert<mbgl::style::Light>(lightObj, conversionError)) {
             options.light = *light;
         } else {
-            throw conversionError;
+            throw std::move(conversionError);
         }
     }
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -1374,7 +1374,7 @@ void NodeMap::QueryRenderedFeatures(const Nan::FunctionCallbackInfo<v8::Value>& 
         }
 
         auto array = Nan::New<v8::Array>();
-        for (unsigned int i = 0; i < optional.size(); i++) {
+        for (std::size_t i = 0; i < optional.size(); i++) {
             array->Set(i, toJS(optional[i]));
         }
         info.GetReturnValue().Set(array);

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -1086,7 +1086,8 @@ void NodeMap::SetFeatureState(const Nan::FunctionCallbackInfo<v8::Value>& info) 
         return Nan::ThrowTypeError("Both arguments must be objects");
     }
 
-    std::string sourceID, featureID;
+    std::string sourceID;
+    std::string featureID;
     mbgl::optional<std::string> sourceLayerID;
     auto feature = Nan::To<v8::Object>(info[0]).ToLocalChecked();
     if (Nan::Has(feature, Nan::New("source").ToLocalChecked()).FromJust()) {
@@ -1186,7 +1187,8 @@ void NodeMap::GetFeatureState(const Nan::FunctionCallbackInfo<v8::Value>& info) 
         return Nan::ThrowTypeError("Argument must be object");
     }
 
-    std::string sourceID, featureID;
+    std::string sourceID;
+    std::string featureID;
     mbgl::optional<std::string> sourceLayerID;
     auto feature = Nan::To<v8::Object>(info[0]).ToLocalChecked();
     if (Nan::Has(feature, Nan::New("source").ToLocalChecked()).FromJust()) {
@@ -1244,7 +1246,9 @@ void NodeMap::RemoveFeatureState(const Nan::FunctionCallbackInfo<v8::Value>& inf
     }
 
     std::string sourceID;
-    mbgl::optional<std::string> sourceLayerID, featureID, stateKey;
+    mbgl::optional<std::string> sourceLayerID;
+    mbgl::optional<std::string> featureID;
+    mbgl::optional<std::string> stateKey;
     auto feature = Nan::To<v8::Object>(info[0]).ToLocalChecked();
     if (Nan::Has(feature, Nan::New("source").ToLocalChecked()).FromJust()) {
         auto sourceOption = Nan::Get(feature, Nan::New("source").ToLocalChecked()).ToLocalChecked();

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -391,7 +391,7 @@ NodeMap::RenderOptions NodeMap::ParseOptions(v8::Local<v8::Object> obj) {
 
 class RenderRequest : public Nan::AsyncResource {
 public:
-    RenderRequest(v8::Local<v8::Function> callback_) : AsyncResource("mbgl:RenderRequest") {
+    explicit RenderRequest(v8::Local<v8::Function> callback_) : AsyncResource("mbgl:RenderRequest") {
         callback.Reset(callback_);
     }
     ~RenderRequest() {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -29,6 +29,7 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/async_request.hpp>
 #include <mbgl/util/exception.hpp>
+#include <mbgl/util/logging.hpp>
 #include <mbgl/util/premultiply.hpp>
 
 #include <unistd.h>
@@ -1428,7 +1429,11 @@ NodeMap::NodeMap(v8::Local<v8::Object> options)
 }
 
 NodeMap::~NodeMap() {
-    if (map) release();
+    try {
+        if (map) release();
+    } catch (...) {
+        mbgl::Log::Error(mbgl::Event::General, "Error release the map object when destroying NodeMap");
+    }
 }
 
 std::unique_ptr<mbgl::AsyncRequest> NodeFileSource::request(const mbgl::Resource& resource, mbgl::FileSource::Callback callback_) {

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -60,7 +60,7 @@ void NodeRequest::HandleCallback(const Nan::FunctionCallbackInfo<v8::Value>& inf
     auto callback = std::move(request->callback);
     request->callback = {};
     if (!callback) {
-        request->unref();
+        request->unrefRequest();
         return info.GetReturnValue().SetUndefined();
     }
 
@@ -84,7 +84,7 @@ void NodeRequest::HandleCallback(const Nan::FunctionCallbackInfo<v8::Value>& inf
             *Nan::Utf8String(info[0])
         );
     } else if (info.Length() < 2 || !info[1]->IsObject()) {
-        request->unref();
+        request->unrefRequest();
         return Nan::ThrowTypeError("Second argument must be a response object");
     } else {
         auto res = Nan::To<v8::Object>(info[1]).ToLocalChecked();
@@ -118,7 +118,7 @@ void NodeRequest::HandleCallback(const Nan::FunctionCallbackInfo<v8::Value>& inf
                     node::Buffer::Length(data)
                 );
             } else {
-                request->unref();
+                request->unrefRequest();
                 return Nan::ThrowTypeError("Response data must be a Buffer");
             }
         }
@@ -126,15 +126,15 @@ void NodeRequest::HandleCallback(const Nan::FunctionCallbackInfo<v8::Value>& inf
 
     // Send the response object to the NodeFileSource object
     callback(response);
-    request->unref();
+    request->unrefRequest();
     info.GetReturnValue().SetUndefined();
 }
 
-void NodeRequest::unref() {
-  Nan::HandleScope scope;
-  delete asyncResource;
-  asyncResource = nullptr;
-  Unref();
+void NodeRequest::unrefRequest() {
+    Nan::HandleScope scope;
+    delete asyncResource;
+    asyncResource = nullptr;
+    Unref();
 }
 
 NodeAsyncRequest::NodeAsyncRequest() : request(nullptr) {}

--- a/platform/node/src/node_request.hpp
+++ b/platform/node/src/node_request.hpp
@@ -34,7 +34,7 @@ public:
     static void New(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void HandleCallback(const Nan::FunctionCallbackInfo<v8::Value>&);
 
-    void unref();
+    void unrefRequest();
 
     mbgl::FileSource::Callback callback;
     NodeAsyncRequest* asyncRequest;

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -70,8 +70,7 @@ const GeometryCollection& AnnotationTileFeature::getGeometries() const {
 
 class AnnotationTileLayerData {
 public:
-    AnnotationTileLayerData(std::string name_) : name(std::move(name_)) {
-    }
+    explicit AnnotationTileLayerData(std::string name_) : name(std::move(name_)) {}
 
     const std::string name;
     std::vector<std::shared_ptr<const AnnotationTileFeatureData>> features;

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -11,7 +11,6 @@
 namespace mbgl {
 
 using namespace style;
-namespace geojsonvt = mapbox::geojsonvt;
 
 ShapeAnnotationImpl::ShapeAnnotationImpl(const AnnotationID id_)
     : id(id_),

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -23,9 +23,8 @@ void ShapeAnnotationImpl::updateTileData(const CanonicalTileID& tileID, Annotati
 
     if (!shapeTiler) {
         mapbox::feature::feature_collection<double> features;
-        features.emplace_back(ShapeAnnotationGeometry::visit(geometry(), [] (auto&& geom) {
-            return Feature { std::move(geom) };
-        }));
+        features.emplace_back(ShapeAnnotationGeometry::visit(
+            geometry(), [](auto&& geom) { return Feature{std::forward<decltype(geom)>(geom)}; }));
         mapbox::geojsonvt::Options options;
         // The annotation source is currently hard coded to maxzoom 16, so we're topping out at z16
         // here as well.

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -187,8 +187,7 @@ private:
     State<value::PointSize> pointSize;
 #endif // MBGL_USE_GLES2
 
-    std::unique_ptr<gfx::OffscreenTexture> createOffscreenTexture(
-        Size, gfx::TextureChannelDataType = gfx::TextureChannelDataType::UnsignedByte) override;
+    std::unique_ptr<gfx::OffscreenTexture> createOffscreenTexture(Size, gfx::TextureChannelDataType) override;
 
     std::unique_ptr<gfx::TextureResource>
         createTextureResource(Size, gfx::TexturePixelType, gfx::TextureChannelDataType) override;

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -90,7 +90,9 @@ void StencilFunc::Set(const Type& value) {
 }
 
 StencilFunc::Type StencilFunc::Get() {
-    GLint func, ref, mask;
+    GLint func;
+    GLint ref;
+    GLint mask;
     MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FUNC, &func));
     MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_REF, &ref));
     MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_VALUE_MASK, &mask));
@@ -118,7 +120,9 @@ void StencilOp::Set(const Type& value) {
 }
 
 StencilOp::Type StencilOp::Get() {
-    GLint sfail, dpfail, dppass;
+    GLint sfail;
+    GLint dpfail;
+    GLint dppass;
     MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FAIL, &sfail));
     MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_FAIL, &dpfail));
     MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_PASS, &dppass));
@@ -195,7 +199,8 @@ void BlendFunc::Set(const Type& value) {
 }
 
 BlendFunc::Type BlendFunc::Get() {
-    GLint sfactor, dfactor;
+    GLint sfactor;
+    GLint dfactor;
     MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_SRC_ALPHA, &sfactor));
     MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_DST_ALPHA, &dfactor));
     return { Enum<gfx::ColorBlendFactorType>::from(sfactor),
@@ -549,7 +554,8 @@ void PixelZoom::Set(const Type& value) {
 }
 
 PixelZoom::Type PixelZoom::Get() {
-    GLfloat xfactor, yfactor;
+    GLfloat xfactor;
+    GLfloat yfactor;
     MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_X, &xfactor));
     MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_Y, &yfactor));
     return { xfactor, yfactor };

--- a/src/mbgl/gl/vertex_array.cpp
+++ b/src/mbgl/gl/vertex_array.cpp
@@ -12,6 +12,8 @@ void VertexArray::bind(Context& context,
     state->indexBuffer = indexBuffer.getResource<gl::IndexBufferResource>().buffer;
 
     state->bindings.reserve(bindings.size());
+
+    // NOLINTNEXTLINE(bugprone-too-small-loop-variable)
     for (AttributeLocation location = 0; location < bindings.size(); ++location) {
         if (state->bindings.size() <= location) {
             state->bindings.emplace_back(context, AttributeLocation(location));

--- a/src/mbgl/layout/clip_lines.cpp
+++ b/src/mbgl/layout/clip_lines.cpp
@@ -24,19 +24,23 @@ GeometryCollection clipLines(const GeometryCollection &lines,
                 continue;
             } else if (p0.x < x1) {
                 p0 = {x1,
-                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x))))};
+                      static_cast<int16_t>(
+                          std::round(p0.y + (p1.y - p0.y) * (static_cast<float>(x1 - p0.x) / (p1.x - p0.x))))};
             } else if (p1.x < x1) {
                 p1 = {x1,
-                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x))))};
+                      static_cast<int16_t>(
+                          std::round(p0.y + (p1.y - p0.y) * (static_cast<float>(x1 - p0.x) / (p1.x - p0.x))))};
             }
 
             if (p0.y < y1 && p1.y < y1) {
                 continue;
             } else if (p0.y < y1) {
-                p0 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))),
+                p0 = {static_cast<int16_t>(
+                          std::round(p0.x + (p1.x - p0.x) * (static_cast<float>(y1 - p0.y) / (p1.y - p0.y)))),
                       y1};
             } else if (p1.y < y1) {
-                p1 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))),
+                p1 = {static_cast<int16_t>(
+                          std::round(p0.x + (p1.x - p0.x) * (static_cast<float>(y1 - p0.y) / (p1.y - p0.y)))),
                       y1};
             }
 
@@ -44,19 +48,23 @@ GeometryCollection clipLines(const GeometryCollection &lines,
                 continue;
             } else if (p0.x >= x2) {
                 p0 = {x2,
-                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x))))};
+                      static_cast<int16_t>(
+                          std::round(p0.y + (p1.y - p0.y) * (static_cast<float>(x2 - p0.x) / (p1.x - p0.x))))};
             } else if (p1.x >= x2) {
                 p1 = {x2,
-                      static_cast<int16_t>(std::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x))))};
+                      static_cast<int16_t>(
+                          std::round(p0.y + (p1.y - p0.y) * (static_cast<float>(x2 - p0.x) / (p1.x - p0.x))))};
             }
 
             if (p0.y >= y2 && p1.y >= y2) {
                 continue;
             } else if (p0.y >= y2) {
-                p0 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))),
+                p0 = {static_cast<int16_t>(
+                          std::round(p0.x + (p1.x - p0.x) * (static_cast<float>(y2 - p0.y) / (p1.y - p0.y)))),
                       y2};
             } else if (p1.y >= y2) {
-                p1 = {static_cast<int16_t>(std::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))),
+                p1 = {static_cast<int16_t>(
+                          std::round(p0.x + (p1.x - p0.x) * (static_cast<float>(y2 - p0.y) / (p1.y - p0.y)))),
                       y2};
             }
 

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -210,7 +210,7 @@ SymbolLayout::SymbolLayout(const BucketParameters& parameters,
 }
 
 bool SymbolLayout::hasDependencies() const {
-    return features.size() != 0;
+    return !features.empty();
 }
 
 bool SymbolLayout::hasSymbolInstances() const {

--- a/src/mbgl/layout/symbol_projection.hpp
+++ b/src/mbgl/layout/symbol_projection.hpp
@@ -58,9 +58,10 @@ namespace mbgl {
                                                             const mat4& labelPlaneMatrix,
                                                             const bool returnTileDistance);
 
-    void hideGlyphs(std::size_t numGlyphs, gfx::VertexVector<gfx::Vertex<SymbolDynamicLayoutAttributes>>& dynamicVertices);
+    void hideGlyphs(std::size_t numGlyphs,
+                    gfx::VertexVector<gfx::Vertex<SymbolDynamicLayoutAttributes>>& dynamicVertexArray);
     void addDynamicAttributes(const Point<float>& anchorPoint,
                               const float angle,
-                              gfx::VertexVector<gfx::Vertex<SymbolDynamicLayoutAttributes>>& dynamicVertices);
+                              gfx::VertexVector<gfx::Vertex<SymbolDynamicLayoutAttributes>>& dynamicVertexArray);
 
 } // end namespace mbgl

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -131,7 +131,8 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
 
     matrix::rotate_z(projMatrix, projMatrix, getBearing() + getNorthOrientationAngle());
 
-    const double dx = pixel_x() - size.width / 2.0f, dy = pixel_y() - size.height / 2.0f;
+    const double dx = pixel_x() - size.width / 2.0f;
+    const double dy = pixel_y() - size.height / 2.0f;
     matrix::translate(projMatrix, projMatrix, dx, dy, 0);
 
     if (axonometric) {
@@ -153,8 +154,10 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
     // of the transformation so that 0°, 90°, 180°, and 270° rasters are crisp, and adjust the shift so that
     // it is always <= 0.5 pixels.
     if (aligned) {
-        const float xShift = float(size.width % 2) / 2, yShift = float(size.height % 2) / 2;
-        const double bearingCos = std::cos(bearing), bearingSin = std::sin(bearing);
+        const float xShift = float(size.width % 2) / 2;
+        const float yShift = float(size.height % 2) / 2;
+        const double bearingCos = std::cos(bearing);
+        const double bearingSin = std::sin(bearing);
         double devNull;
         const float dxa = -std::modf(dx, &devNull) + bearingCos * xShift + bearingSin * yShift;
         const float dya = -std::modf(dy, &devNull) + bearingCos * yShift + bearingSin * xShift;

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -80,7 +80,7 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
             vertices.emplace_back(FillProgram::layoutVertex(ring[0]));
             lines.emplace_back(lineIndex + nVertices - 1, lineIndex);
 
-            for (uint32_t i = 1; i < nVertices; i++) {
+            for (std::size_t i = 1; i < nVertices; i++) {
                 vertices.emplace_back(FillProgram::layoutVertex(ring[i]));
                 lines.emplace_back(lineIndex + i - 1, lineIndex + i);
             }
@@ -102,7 +102,7 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
         assert(triangleSegment.vertexLength <= std::numeric_limits<uint16_t>::max());
         uint16_t triangleIndex = triangleSegment.vertexLength;
 
-        for (uint32_t i = 0; i < nIndicies; i += 3) {
+        for (std::size_t i = 0; i < nIndicies; i += 3) {
             triangles.emplace_back(triangleIndex + indices[i],
                                    triangleIndex + indices[i + 1],
                                    triangleIndex + indices[i + 2]);

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -96,7 +96,7 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
 
             std::size_t edgeDistance = 0;
 
-            for (uint32_t i = 0; i < nVertices; i++) {
+            for (std::size_t i = 0; i < nVertices; i++) {
                 const auto& p1 = ring[i];
 
                 vertices.emplace_back(
@@ -147,7 +147,7 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
         std::size_t nIndices = indices.size();
         assert(nIndices % 3 == 0);
 
-        for (uint32_t i = 0; i < nIndices; i += 3) {
+        for (std::size_t i = 0; i < nIndices; i += 3) {
             // Counter-Clockwise winding order.
             triangles.emplace_back(flatIndices[indices[i]], flatIndices[indices[i + 2]],
                                    flatIndices[indices[i + 1]]);

--- a/src/mbgl/renderer/buckets/line_bucket.hpp
+++ b/src/mbgl/renderer/buckets/line_bucket.hpp
@@ -60,10 +60,15 @@ private:
     };
 
     class Distances;
-    void addCurrentVertex(const GeometryCoordinate& currentVertex, double& distance,
-            const Point<double>& normal, double endLeft, double endRight, bool round,
-            std::size_t startVertex, std::vector<LineBucket::TriangleElement>& triangleStore,
-            optional<Distances> distances);
+    void addCurrentVertex(const GeometryCoordinate& currentCoordinate,
+                          double& distance,
+                          const Point<double>& normal,
+                          double endLeft,
+                          double endRight,
+                          bool round,
+                          std::size_t startVertex,
+                          std::vector<LineBucket::TriangleElement>& triangleStore,
+                          optional<Distances> distances);
 
     void addPieSliceVertex(const GeometryCoordinate& currentVertex, double distance,
             const Point<double>& extrude, bool lineTurnsLeft, std::size_t startVertex,

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -72,7 +72,7 @@ public:
                  float zoom,
                  bool iconsNeedLinear,
                  bool sortFeaturesByY,
-                 std::string bucketLeaderID,
+                 std::string bucketName_,
                  const std::vector<SymbolInstance>&&,
                  const std::vector<SortKeyRange>&&,
                  const float tilePixelRatio,

--- a/src/mbgl/renderer/image_atlas.cpp
+++ b/src/mbgl/renderer/image_atlas.cpp
@@ -33,10 +33,10 @@ const mapbox::Bin& _packImage(mapbox::ShelfPack& pack, const style::Image::Impl&
                                 bin.y + padding
                              },
                              image.image.size);
-    uint32_t x = bin.x + padding,
-            y = bin.y + padding,
-            w = image.image.size.width,
-            h = image.image.size.height;
+    uint32_t x = bin.x + padding;
+    uint32_t y = bin.y + padding;
+    uint32_t w = image.image.size.width;
+    uint32_t h = image.image.size.height;
 
     if (imageType == ImageType::Pattern) {
             // Add 1 pixel wrapped padding on each side of the image.

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -100,7 +100,7 @@ void RenderBackgroundLayer::render(PaintParameters& parameters) {
     };
 
     if (segments.empty()) {
-        segments = parameters.staticData.tileTriangleSegments();
+        segments = RenderStaticData::tileTriangleSegments();
     }
 
     const auto& evaluated = static_cast<const BackgroundLayerProperties&>(*evaluatedProperties).evaluated;

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -68,12 +68,11 @@ void RenderBackgroundLayer::render(PaintParameters& parameters) {
     const BackgroundProgram::Binders paintAttributeData(properties, 0);
 
     auto draw = [&](auto& program, auto&& uniformValues, const auto& textureBindings, const uint32_t id) {
-        const auto allUniformValues = program.computeAllUniformValues(
-            std::move(uniformValues),
-            paintAttributeData,
-            properties,
-            parameters.state.getZoom()
-        );
+        const auto allUniformValues =
+            program.computeAllUniformValues(std::forward<decltype(uniformValues)>(uniformValues),
+                                            paintAttributeData,
+                                            properties,
+                                            parameters.state.getZoom());
         const auto allAttributeBindings = program.computeAllAttributeBindings(
             *parameters.staticData.tileVertexBuffer,
             paintAttributeData,

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -75,35 +75,26 @@ void RenderCircleLayer::render(PaintParameters& parameters) {
         const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
         auto& programInstance = parameters.programs.getCircleLayerPrograms().circle;
-   
-        const auto allUniformValues = programInstance.computeAllUniformValues(
-            CircleProgram::LayoutUniformValues {
-                uniforms::matrix::Value(
-                    tile.translatedMatrix(evaluated.get<CircleTranslate>(),
-                                          evaluated.get<CircleTranslateAnchor>(),
-                                          parameters.state)
-                ),
-                uniforms::scale_with_map::Value( scaleWithMap ),
-                uniforms::extrude_scale::Value( pitchWithMap
-                    ? std::array<float, 2> {{
-                        tile.id.pixelsToTileUnits(1, parameters.state.getZoom()),
-                        tile.id.pixelsToTileUnits(1, parameters.state.getZoom()) }}
-                    : parameters.pixelsToGLUnits ),
-                uniforms::device_pixel_ratio::Value( parameters.pixelRatio ),
-                uniforms::camera_to_center_distance::Value( parameters.state.getCameraToCenterDistance() ),
-                uniforms::pitch_with_map::Value( pitchWithMap )
-            },
+
+        const auto allUniformValues = CircleProgram::computeAllUniformValues(
+            CircleProgram::LayoutUniformValues{
+                uniforms::matrix::Value(tile.translatedMatrix(
+                    evaluated.get<CircleTranslate>(), evaluated.get<CircleTranslateAnchor>(), parameters.state)),
+                uniforms::scale_with_map::Value(scaleWithMap),
+                uniforms::extrude_scale::Value(
+                    pitchWithMap ? std::array<float, 2>{{tile.id.pixelsToTileUnits(1, parameters.state.getZoom()),
+                                                         tile.id.pixelsToTileUnits(1, parameters.state.getZoom())}}
+                                 : parameters.pixelsToGLUnits),
+                uniforms::device_pixel_ratio::Value(parameters.pixelRatio),
+                uniforms::camera_to_center_distance::Value(parameters.state.getCameraToCenterDistance()),
+                uniforms::pitch_with_map::Value(pitchWithMap)},
             paintPropertyBinders,
             evaluated,
-            parameters.state.getZoom()
-        );
-        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-            *bucket.vertexBuffer,
-            paintPropertyBinders,
-            evaluated
-        );
+            parameters.state.getZoom());
+        const auto allAttributeBindings =
+            CircleProgram::computeAllAttributeBindings(*bucket.vertexBuffer, paintPropertyBinders, evaluated);
 
-        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+        checkRenderability(parameters, CircleProgram::activeBindingCount(allAttributeBindings));
 
         programInstance.draw(
             parameters.context,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -113,21 +113,19 @@ void RenderFillLayer::render(PaintParameters& parameters) {
 
                 checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
-                programInstance.draw(
-                    parameters.context,
-                    *parameters.renderPass,
-                    drawMode,
-                    depthMode,
-                    parameters.stencilModeForClipping(tile.id),
-                    parameters.colorModeForRenderPass(),
-                    gfx::CullFaceMode::disabled(),
-                    indexBuffer,
-                    segments,
-                    allUniformValues,
-                    allAttributeBindings,
-                    std::move(textureBindings),
-                    getID()
-                );
+                programInstance.draw(parameters.context,
+                                     *parameters.renderPass,
+                                     drawMode,
+                                     depthMode,
+                                     parameters.stencilModeForClipping(tile.id),
+                                     parameters.colorModeForRenderPass(),
+                                     gfx::CullFaceMode::disabled(),
+                                     indexBuffer,
+                                     segments,
+                                     allUniformValues,
+                                     allAttributeBindings,
+                                     std::forward<decltype(textureBindings)>(textureBindings),
+                                     getID());
             };
 
             auto fillRenderPass = (evaluated.get<FillColor>().constantOr(Color()).a >= 1.0f
@@ -208,21 +206,19 @@ void RenderFillLayer::render(PaintParameters& parameters) {
 
                 checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
-                programInstance.draw(
-                    parameters.context,
-                    *parameters.renderPass,
-                    drawMode,
-                    depthMode,
-                    parameters.stencilModeForClipping(tile.id),
-                    parameters.colorModeForRenderPass(),
-                    gfx::CullFaceMode::disabled(),
-                    indexBuffer,
-                    segments,
-                    allUniformValues,
-                    allAttributeBindings,
-                    std::move(textureBindings),
-                    getID()
-                );
+                programInstance.draw(parameters.context,
+                                     *parameters.renderPass,
+                                     drawMode,
+                                     depthMode,
+                                     parameters.stencilModeForClipping(tile.id),
+                                     parameters.colorModeForRenderPass(),
+                                     gfx::CullFaceMode::disabled(),
+                                     indexBuffer,
+                                     segments,
+                                     allUniformValues,
+                                     allAttributeBindings,
+                                     std::forward<decltype(textureBindings)>(textureBindings),
+                                     getID());
             };
 
             if (bucket.triangleIndexBuffer) {

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -112,23 +112,18 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
 
             auto& programInstance = parameters.programs.getHeatmapLayerPrograms().heatmap;
 
-            const auto allUniformValues = programInstance.computeAllUniformValues(
-                HeatmapProgram::LayoutUniformValues {
-                    uniforms::intensity::Value( evaluated.get<style::HeatmapIntensity>() ),
-                    uniforms::matrix::Value( tile.matrix ),
-                    uniforms::heatmap::extrude_scale::Value( extrudeScale )
-                },
+            const auto allUniformValues = HeatmapProgram::computeAllUniformValues(
+                HeatmapProgram::LayoutUniformValues{
+                    uniforms::intensity::Value(evaluated.get<style::HeatmapIntensity>()),
+                    uniforms::matrix::Value(tile.matrix),
+                    uniforms::heatmap::extrude_scale::Value(extrudeScale)},
                 paintPropertyBinders,
                 evaluated,
-                parameters.state.getZoom()
-            );
-            const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-                *bucket.vertexBuffer,
-                paintPropertyBinders,
-                evaluated
-            );
+                parameters.state.getZoom());
+            const auto allAttributeBindings =
+                HeatmapProgram::computeAllAttributeBindings(*bucket.vertexBuffer, paintPropertyBinders, evaluated);
 
-            checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+            checkRenderability(parameters, HeatmapProgram::activeBindingCount(allAttributeBindings));
 
             programInstance.draw(parameters.context,
                                  *renderPass,
@@ -156,27 +151,23 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
 
         auto& programInstance = parameters.programs.getHeatmapLayerPrograms().heatmapTexture;
 
-        const auto allUniformValues = programInstance.computeAllUniformValues(
+        const auto allUniformValues = HeatmapTextureProgram::computeAllUniformValues(
             HeatmapTextureProgram::LayoutUniformValues{
-                uniforms::matrix::Value( viewportMat ),
-                uniforms::world::Value( size ),
-                uniforms::opacity::Value( getEvaluated<HeatmapLayerProperties>(evaluatedProperties).get<HeatmapOpacity>() )
-            },
+                uniforms::matrix::Value(viewportMat),
+                uniforms::world::Value(size),
+                uniforms::opacity::Value(
+                    getEvaluated<HeatmapLayerProperties>(evaluatedProperties).get<HeatmapOpacity>())},
             paintAttributeData,
             properties,
-            parameters.state.getZoom()
-        );
-        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-            *parameters.staticData.heatmapTextureVertexBuffer,
-            paintAttributeData,
-            properties
-        );
+            parameters.state.getZoom());
+        const auto allAttributeBindings = HeatmapTextureProgram::computeAllAttributeBindings(
+            *parameters.staticData.heatmapTextureVertexBuffer, paintAttributeData, properties);
 
-        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+        checkRenderability(parameters, HeatmapTextureProgram::activeBindingCount(allAttributeBindings));
 
         if (segments.empty()) {
             // Copy over the segments so that we can create our own DrawScopes.
-            segments = parameters.staticData.heatmapTextureSegments();
+            segments = RenderStaticData::heatmapTextureSegments();
         }
         programInstance.draw(
             parameters.context,

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -36,7 +36,7 @@ RenderHillshadeLayer::~RenderHillshadeLayer() = default;
 const std::array<float, 2> RenderHillshadeLayer::getLatRange(const UnwrappedTileID& id) {
    const LatLng latlng0 = LatLng(id);
    const LatLng latlng1 = LatLng(UnwrappedTileID(id.canonical.z, id.canonical.x, id.canonical.y + 1));
-   return {{ (float)latlng0.latitude(), (float)latlng1.latitude() }};
+   return {{static_cast<float>(latlng0.latitude()), static_cast<float>(latlng1.latitude())}};
 }
 
 const std::array<float, 2> RenderHillshadeLayer::getLight(const PaintParameters& parameters) {

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -25,8 +25,8 @@ private:
     style::HillshadePaintProperties::Unevaluated unevaluated;
     uint8_t maxzoom = util::TERRAIN_RGB_MAXZOOM;
 
-    const std::array<float, 2> getLatRange(const UnwrappedTileID& id);
-    const std::array<float, 2> getLight(const PaintParameters& parameters);
+    std::array<float, 2> getLatRange(const UnwrappedTileID& id);
+    std::array<float, 2> getLight(const PaintParameters& parameters);
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -114,12 +114,11 @@ void RenderLineLayer::render(PaintParameters& parameters) {
 
             paintPropertyBinders.setPatternParameters(patternPositionA, patternPositionB, crossfade);
 
-            const auto allUniformValues = programInstance.computeAllUniformValues(
-                std::move(uniformValues),
-                paintPropertyBinders,
-                evaluated,
-                parameters.state.getZoom()
-            );
+            const auto allUniformValues =
+                programInstance.computeAllUniformValues(std::forward<decltype(uniformValues)>(uniformValues),
+                                                        paintPropertyBinders,
+                                                        evaluated,
+                                                        parameters.state.getZoom());
             const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
                 *bucket.vertexBuffer,
                 paintPropertyBinders,
@@ -128,21 +127,19 @@ void RenderLineLayer::render(PaintParameters& parameters) {
 
             checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
-            programInstance.draw(
-                parameters.context,
-                *parameters.renderPass,
-                gfx::Triangles(),
-                parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                parameters.stencilModeForClipping(tile.id),
-                parameters.colorModeForRenderPass(),
-                gfx::CullFaceMode::disabled(),
-                *bucket.indexBuffer,
-                bucket.segments,
-                allUniformValues,
-                allAttributeBindings,
-                std::move(textureBindings),
-                getID()
-            );
+            programInstance.draw(parameters.context,
+                                 *parameters.renderPass,
+                                 gfx::Triangles(),
+                                 parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
+                                 parameters.stencilModeForClipping(tile.id),
+                                 parameters.colorModeForRenderPass(),
+                                 gfx::CullFaceMode::disabled(),
+                                 *bucket.indexBuffer,
+                                 bucket.segments,
+                                 allUniformValues,
+                                 allAttributeBindings,
+                                 std::forward<decltype(textureBindings)>(textureBindings),
+                                 getID());
         };
 
         if (!evaluated.get<LineDasharray>().from.empty()) {

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -100,31 +100,27 @@ void RenderRasterLayer::render(PaintParameters& parameters) {
                      const std::string& drawScopeID) {
         auto& programInstance = parameters.programs.getRasterLayerPrograms().raster;
 
-        const auto allUniformValues = programInstance.computeAllUniformValues(
-            RasterProgram::LayoutUniformValues {
-                uniforms::matrix::Value( matrix ),
-                uniforms::opacity::Value( evaluated.get<RasterOpacity>() ),
-                uniforms::fade_t::Value( 1 ),
-                uniforms::brightness_low::Value( evaluated.get<RasterBrightnessMin>() ),
-                uniforms::brightness_high::Value( evaluated.get<RasterBrightnessMax>() ),
-                uniforms::saturation_factor::Value( saturationFactor(evaluated.get<RasterSaturation>()) ),
-                uniforms::contrast_factor::Value( contrastFactor(evaluated.get<RasterContrast>()) ),
-                uniforms::spin_weights::Value( spinWeights(evaluated.get<RasterHueRotate>()) ),
-                uniforms::buffer_scale::Value( 1.0f ),
-                uniforms::scale_parent::Value( 1.0f ),
-                uniforms::tl_parent::Value( std::array<float, 2> {{ 0.0f, 0.0f }} ),
+        const auto allUniformValues = RasterProgram::computeAllUniformValues(
+            RasterProgram::LayoutUniformValues{
+                uniforms::matrix::Value(matrix),
+                uniforms::opacity::Value(evaluated.get<RasterOpacity>()),
+                uniforms::fade_t::Value(1),
+                uniforms::brightness_low::Value(evaluated.get<RasterBrightnessMin>()),
+                uniforms::brightness_high::Value(evaluated.get<RasterBrightnessMax>()),
+                uniforms::saturation_factor::Value(saturationFactor(evaluated.get<RasterSaturation>())),
+                uniforms::contrast_factor::Value(contrastFactor(evaluated.get<RasterContrast>())),
+                uniforms::spin_weights::Value(spinWeights(evaluated.get<RasterHueRotate>())),
+                uniforms::buffer_scale::Value(1.0f),
+                uniforms::scale_parent::Value(1.0f),
+                uniforms::tl_parent::Value(std::array<float, 2>{{0.0f, 0.0f}}),
             },
             paintAttributeData,
             evaluated,
-            parameters.state.getZoom()
-        );
-        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-            vertexBuffer,
-            paintAttributeData,
-            evaluated
-        );
+            parameters.state.getZoom());
+        const auto allAttributeBindings =
+            RasterProgram::computeAllAttributeBindings(vertexBuffer, paintAttributeData, evaluated);
 
-        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
+        checkRenderability(parameters, RasterProgram::activeBindingCount(allAttributeBindings));
 
         programInstance.draw(
             parameters.context,
@@ -188,7 +184,7 @@ void RenderRasterLayer::render(PaintParameters& parameters) {
                 // Draw the full tile.
                 if (bucket.segments.empty()) {
                     // Copy over the segments so that we can create our own DrawScopes.
-                    bucket.segments = parameters.staticData.rasterSegments();
+                    bucket.segments = RenderStaticData::rasterSegments();
                 }
                 draw(parameters.matrixForTile(tile.id, true),
                      *parameters.staticData.rasterVertexBuffer,

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -143,14 +143,15 @@ void PaintParameters::renderTileClippingMasks(const RenderTiles& renderTiles) {
                      gfx::CullFaceMode::disabled(),
                      *staticData.quadTriangleIndexBuffer,
                      staticData.clippingMaskSegments,
-                     program.computeAllUniformValues(
+                     ClippingMaskProgram::computeAllUniformValues(
                          ClippingMaskProgram::LayoutUniformValues{
                              uniforms::matrix::Value(matrixForTile(renderTile.id)),
                          },
                          paintAttributeData,
                          properties,
                          state.getZoom()),
-                     program.computeAllAttributeBindings(*staticData.tileVertexBuffer, paintAttributeData, properties),
+                     ClippingMaskProgram::computeAllAttributeBindings(
+                         *staticData.tileVertexBuffer, paintAttributeData, properties),
                      ClippingMaskProgram::TextureBindings{},
                      "clipping/" + util::toString(stencilID));
     }

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -73,16 +73,16 @@ void RenderLayer::checkRenderability(const PaintParameters& parameters,
                    "supports, and will have rendering errors. To ensure compatibility with this "
                    "device, use %d fewer data driven properties in this layer.",
                    getID().c_str(),
-                   activeBindingCount - parameters.context.minimumRequiredVertexBindingCount);
+                   activeBindingCount - gfx::Context::minimumRequiredVertexBindingCount);
         hasRenderFailures = true;
-    } else if (activeBindingCount > parameters.context.minimumRequiredVertexBindingCount) {
+    } else if (activeBindingCount > gfx::Context::minimumRequiredVertexBindingCount) {
         Log::Warning(Event::OpenGL,
-                   "The layer '%s' uses more data-driven properties than some devices may support. "
-                   "Though it will render correctly on this device, it may have rendering errors "
-                   "on other devices. To ensure compatibility with all devices, use %d fewer "
-                   "data-driven properties in this layer.",
-                   getID().c_str(),
-                   activeBindingCount - parameters.context.minimumRequiredVertexBindingCount);
+                     "The layer '%s' uses more data-driven properties than some devices may support. "
+                     "Though it will render correctly on this device, it may have rendering errors "
+                     "on other devices. To ensure compatibility with all devices, use %d fewer "
+                     "data-driven properties in this layer.",
+                     getID().c_str(),
+                     activeBindingCount - gfx::Context::minimumRequiredVertexBindingCount);
         hasRenderFailures = true;
     }
 }

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -43,16 +43,16 @@ public:
     LayerRenderItem(RenderLayer& layer_, RenderSource* source_, uint32_t index_)
         : layer(layer_), source(source_), index(index_) {}
     bool operator<(const LayerRenderItem& other) const { return index < other.index; }
+
     std::reference_wrapper<RenderLayer> layer;
     RenderSource* source;
+    const uint32_t index;
 
 private:
     bool hasRenderPass(RenderPass pass) const override { return layer.get().hasRenderPass(pass); }
     void upload(gfx::UploadPass& pass) const override { layer.get().upload(pass); }
     void render(PaintParameters& parameters) const override { layer.get().render(parameters); }
     const std::string& getName() const override { return layer.get().getID(); } 
-
-    uint32_t index;
 };
 
 class RenderTreeImpl final : public RenderTree {

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -681,11 +681,7 @@ bool RenderOrchestrator::isLoaded() const {
         }
     }
 
-    if (!imageManager->isLoaded()) {
-        return false;
-    }
-
-    return true;
+    return imageManager->isLoaded();
 }
 
 void RenderOrchestrator::clearData() {

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -305,7 +305,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         bool sourceNeedsRendering = false;
         bool sourceNeedsRelayout = false;
 
-        for (uint32_t index = 0u; index < orderedLayers.size(); ++index) {
+        for (std::size_t index = 0; index < orderedLayers.size(); ++index) {
             RenderLayer& layer = orderedLayers[index];
             const auto* layerInfo = layer.baseImpl->getTypeInfo();
             const bool layerIsVisible = layer.baseImpl->visibility != style::VisibilityType::None;

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -138,57 +138,54 @@ void RenderTile::finishRender(PaintParameters& parameters) const {
 
     if (parameters.debugOptions & (MapDebugOptions::Timestamps | MapDebugOptions::ParseStatus)) {
         assert(debugBucket);
-        const auto allAttributeBindings = program.computeAllAttributeBindings(
-            *debugBucket->vertexBuffer,
-            paintAttributeData,
-            properties
-        );
+        const auto allAttributeBindings =
+            DebugProgram::computeAllAttributeBindings(*debugBucket->vertexBuffer, paintAttributeData, properties);
 
-        program.draw(
-            parameters.context,
-            *parameters.renderPass,
-            gfx::Lines{4.0f * parameters.pixelRatio},
-            gfx::DepthMode::disabled(),
-            gfx::StencilMode::disabled(),
-            gfx::ColorMode::unblended(),
-            gfx::CullFaceMode::disabled(),
-            *debugBucket->indexBuffer,
-            debugBucket->segments,
-            program.computeAllUniformValues(DebugProgram::LayoutUniformValues{uniforms::matrix::Value(matrix),
-                                                                              uniforms::color::Value(Color::white()),
-                                                                              uniforms::overlay_scale::Value(1.0f)},
-                                            paintAttributeData,
-                                            properties,
-                                            parameters.state.getZoom()),
-            allAttributeBindings,
-            DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},
-            "text-outline");
+        program.draw(parameters.context,
+                     *parameters.renderPass,
+                     gfx::Lines{4.0f * parameters.pixelRatio},
+                     gfx::DepthMode::disabled(),
+                     gfx::StencilMode::disabled(),
+                     gfx::ColorMode::unblended(),
+                     gfx::CullFaceMode::disabled(),
+                     *debugBucket->indexBuffer,
+                     debugBucket->segments,
+                     DebugProgram::computeAllUniformValues(
+                         DebugProgram::LayoutUniformValues{uniforms::matrix::Value(matrix),
+                                                           uniforms::color::Value(Color::white()),
+                                                           uniforms::overlay_scale::Value(1.0f)},
+                         paintAttributeData,
+                         properties,
+                         parameters.state.getZoom()),
+                     allAttributeBindings,
+                     DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},
+                     "text-outline");
 
-        program.draw(
-            parameters.context,
-            *parameters.renderPass,
-            gfx::Lines{2.0f * parameters.pixelRatio},
-            gfx::DepthMode::disabled(),
-            gfx::StencilMode::disabled(),
-            gfx::ColorMode::unblended(),
-            gfx::CullFaceMode::disabled(),
-            *debugBucket->indexBuffer,
-            debugBucket->segments,
-            program.computeAllUniformValues(DebugProgram::LayoutUniformValues{uniforms::matrix::Value(matrix),
-                                                                              uniforms::color::Value(Color::black()),
-                                                                              uniforms::overlay_scale::Value(1.0f)},
-                                            paintAttributeData,
-                                            properties,
-                                            parameters.state.getZoom()),
-            allAttributeBindings,
-            DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},
-            "text");
+        program.draw(parameters.context,
+                     *parameters.renderPass,
+                     gfx::Lines{2.0f * parameters.pixelRatio},
+                     gfx::DepthMode::disabled(),
+                     gfx::StencilMode::disabled(),
+                     gfx::ColorMode::unblended(),
+                     gfx::CullFaceMode::disabled(),
+                     *debugBucket->indexBuffer,
+                     debugBucket->segments,
+                     DebugProgram::computeAllUniformValues(
+                         DebugProgram::LayoutUniformValues{uniforms::matrix::Value(matrix),
+                                                           uniforms::color::Value(Color::black()),
+                                                           uniforms::overlay_scale::Value(1.0f)},
+                         paintAttributeData,
+                         properties,
+                         parameters.state.getZoom()),
+                     allAttributeBindings,
+                     DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},
+                     "text");
     }
 
     if (parameters.debugOptions & MapDebugOptions::TileBorders) {
         assert(debugBucket);
         if (debugBucket->tileBorderSegments.empty()) {
-            debugBucket->tileBorderSegments = parameters.staticData.tileBorderSegments();
+            debugBucket->tileBorderSegments = RenderStaticData::tileBorderSegments();
         }
         parameters.programs.debug.draw(
             parameters.context,
@@ -200,13 +197,14 @@ void RenderTile::finishRender(PaintParameters& parameters) const {
             gfx::CullFaceMode::disabled(),
             *parameters.staticData.tileBorderIndexBuffer,
             debugBucket->tileBorderSegments,
-            program.computeAllUniformValues(DebugProgram::LayoutUniformValues{uniforms::matrix::Value(matrix),
-                                                                              uniforms::color::Value(Color::red()),
-                                                                              uniforms::overlay_scale::Value(1.0f)},
-                                            paintAttributeData,
-                                            properties,
-                                            parameters.state.getZoom()),
-            program.computeAllAttributeBindings(
+            DebugProgram::computeAllUniformValues(
+                DebugProgram::LayoutUniformValues{uniforms::matrix::Value(matrix),
+                                                  uniforms::color::Value(Color::red()),
+                                                  uniforms::overlay_scale::Value(1.0f)},
+                paintAttributeData,
+                properties,
+                parameters.state.getZoom()),
+            DebugProgram::computeAllAttributeBindings(
                 *parameters.staticData.tileVertexBuffer, paintAttributeData, properties),
             DebugProgram::TextureBindings{textures::image::Value{debugBucket->texture->getResource()}},
             "border");

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -41,11 +41,11 @@ public:
     // Contains the tile ID string for painting debug information.
     std::unique_ptr<DebugBucket> debugBucket;
 
-    mat4 translatedMatrix(const std::array<float, 2>& translate,
+    mat4 translatedMatrix(const std::array<float, 2>& translation,
                           style::TranslateAnchorType anchor,
                           const TransformState&) const;
 
-    mat4 translatedClipMatrix(const std::array<float, 2>& translate,
+    mat4 translatedClipMatrix(const std::array<float, 2>& translation,
                               style::TranslateAnchorType anchor,
                               const TransformState&) const;
 

--- a/src/mbgl/renderer/renderer_state.cpp
+++ b/src/mbgl/renderer/renderer_state.cpp
@@ -13,7 +13,7 @@ CameraOptions RendererState::getCameraOptions(const UpdateParameters& updatePara
 
 bool RendererState::hasImage(const UpdateParameters& updateParameters, const std::string& id) {
     for (const auto& image : *updateParameters.images) {
-        if (image.get()->id == id) {
+        if (image->id == id) {
             return true;
         }
     }
@@ -22,7 +22,7 @@ bool RendererState::hasImage(const UpdateParameters& updateParameters, const std
 
 bool RendererState::hasLayer(const UpdateParameters& updateParameters, const std::string& id) {
     for (const auto& layer : *updateParameters.layers) {
-        if (layer.get()->id == id) {
+        if (layer->id == id) {
             return true;
         }
     }
@@ -31,7 +31,7 @@ bool RendererState::hasLayer(const UpdateParameters& updateParameters, const std
 
 bool RendererState::hasSource(const UpdateParameters& updateParameters, const std::string& id) {
     for (const auto& source : *updateParameters.sources) {
-        if (source.get()->id == id) {
+        if (source->id == id) {
             return true;
         }
     }

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -50,15 +50,15 @@ void ImageSourceRenderData::render(PaintParameters& parameters) const {
                              gfx::ColorMode::unblended(),
                              gfx::CullFaceMode::disabled(),
                              *parameters.staticData.tileBorderIndexBuffer,
-                             parameters.staticData.tileBorderSegments(),
-                             programInstance.computeAllUniformValues(
+                             RenderStaticData::tileBorderSegments(),
+                             DebugProgram::computeAllUniformValues(
                                  DebugProgram::LayoutUniformValues{uniforms::matrix::Value(matrix),
                                                                    uniforms::color::Value(Color::red()),
                                                                    uniforms::overlay_scale::Value(1.0f)},
                                  paintAttributeData,
                                  properties,
                                  parameters.state.getZoom()),
-                             programInstance.computeAllAttributeBindings(
+                             DebugProgram::computeAllAttributeBindings(
                                  *parameters.staticData.tileVertexBuffer, paintAttributeData, properties),
                              DebugProgram::TextureBindings{textures::image::Value{debugTexture->getResource()}},
                              "image");

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -145,7 +145,8 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
     // tiles are used from the cache, but not created.
     optional<util::TileRange> tileRange = {};
     if (bounds) {
-        tileRange = util::TileRange::fromLatLngBounds(*bounds, zoomRange.min, std::min(tileZoom, (int32_t)zoomRange.max));
+        tileRange = util::TileRange::fromLatLngBounds(
+            *bounds, zoomRange.min, std::min(tileZoom, static_cast<int32_t>(zoomRange.max)));
     }
     auto createTileFn = [&](const OverscaledTileID& tileID) -> Tile* {
         if (tileRange && !tileRange->contains(tileID.canonical)) {
@@ -196,10 +197,9 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
 
     if (type != SourceType::Annotations) {
         size_t conservativeCacheSize =
-            std::max((float)parameters.transformState.getSize().width / tileSize, 1.0f) *
-            std::max((float)parameters.transformState.getSize().height / tileSize, 1.0f) *
-            (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) *
-            0.5;
+            std::max(static_cast<float>(parameters.transformState.getSize().width) / tileSize, 1.0f) *
+            std::max(static_cast<float>(parameters.transformState.getSize().height) / tileSize, 1.0f) *
+            (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) * 0.5;
         cache.setSize(conservativeCacheSize);
     }
 

--- a/src/mbgl/storage/asset_file_source.hpp
+++ b/src/mbgl/storage/asset_file_source.hpp
@@ -10,7 +10,7 @@ template <typename T> class Thread;
 
 class AssetFileSource : public FileSource {
 public:
-    AssetFileSource(const std::string& assetPath);
+    AssetFileSource(const std::string& root);
     ~AssetFileSource() override;
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;

--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -15,7 +15,7 @@ static std::string getQuadKey(int32_t x, int32_t y, int8_t z) {
     int32_t mask;
     for (int8_t i = z; i > 0; i--) {
         mask = 1 << (i - 1);
-        quadKey += '0' + ((x & mask ? 1 : 0) + (y & mask ? 2 : 0));
+        quadKey += static_cast<char>('0' + ((x & mask ? 1 : 0) + (y & mask ? 2 : 0)));
     }
     return quadKey;
 }

--- a/src/mbgl/style/conversion/filter.cpp
+++ b/src/mbgl/style/conversion/filter.cpp
@@ -254,7 +254,7 @@ optional<mbgl::Value> serializeLegacyFilter(const Convertible& values) {
                 result.emplace_back(NullValue());
             }
         }
-        return (mbgl::Value)result;
+        return mbgl::Value(result);
     }
     return toValue(values);
 }

--- a/src/mbgl/style/custom_tile_loader.cpp
+++ b/src/mbgl/style/custom_tile_loader.cpp
@@ -52,7 +52,7 @@ void CustomTileLoader::removeTile(const OverscaledTileID& tileID) {
             break;
         }
     }
-    if (tileCallbacks->second.size() == 0) {
+    if (tileCallbacks->second.empty()) {
         tileCallbackMap.erase(tileCallbacks);
         dataCache.erase(tileID.canonical);
     }

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -368,7 +368,7 @@ const auto& hasContextCompoundExpression() {
             };
         }
 
-        return params.feature->getValue(key) ? true : false;
+        return static_cast<bool>(params.feature->getValue(key));
     });
     return signature;
 }
@@ -996,7 +996,7 @@ std::string expectedTypesError(const Definitions& definitions,
     
     std::string actualTypes;
     for (const auto& arg : args) {
-        if (actualTypes.size() > 0) {
+        if (!actualTypes.empty()) {
             actualTypes += ", ";
         }
         actualTypes += toString(arg->getType());
@@ -1043,7 +1043,7 @@ static ParseResult createCompoundExpression(const Definitions& definitions,
             }
         }
 
-        if (signatureContext.getErrors().size() == 0) {
+        if (signatureContext.getErrors().empty()) {
             return ParseResult(std::make_unique<CompoundExpression>(*signature, std::move(args)));
         }
     }

--- a/src/mbgl/style/expression/compound_expression.cpp
+++ b/src/mbgl/style/expression/compound_expression.cpp
@@ -33,7 +33,7 @@ bool operator==(const VarargsType& lhs, const VarargsType& rhs) {
 template <typename T>
 struct Varargs : std::vector<T> {
     template <class... Args>
-    Varargs(Args&&... args) : std::vector<T>(std::forward<Args>(args)...) {}
+    explicit Varargs(Args&&... args) : std::vector<T>(std::forward<Args>(args)...) {}
 };
 
 namespace detail {

--- a/src/mbgl/style/expression/expression.cpp
+++ b/src/mbgl/style/expression/expression.cpp
@@ -12,7 +12,7 @@ public:
     const Feature& feature;
     mutable optional<GeometryCollection> geometry;
 
-    GeoJSONFeature(const Feature& feature_) : feature(feature_) {}
+    explicit GeoJSONFeature(const Feature& feature_) : feature(feature_) {}
     GeoJSONFeature(const Feature& feature_, const CanonicalTileID& canonical) : feature(feature_) {
         geometry = convertGeometry(feature.geometry, canonical);
         // https://github.com/mapbox/geojson-vt-cpp/issues/44

--- a/src/mbgl/style/expression/parsing_context.cpp
+++ b/src/mbgl/style/expression/parsing_context.cpp
@@ -207,7 +207,7 @@ ParseResult ParsingContext::parse(const Convertible& value,
             parsed = { annotate(std::move(*parsed), *expected, typeAnnotationOption.value_or(TypeAnnotationOption::coerce)) };
         } else {
             checkType((*parsed)->getType());
-            if (errors->size() > 0) {
+            if (!errors->empty()) {
                 return ParseResult();
             }
         }
@@ -265,13 +265,13 @@ ParseResult ParsingContext::parseLayerPropertyExpression(const Convertible& valu
     return parsed;
 }
 
-const std::string ParsingContext::getCombinedErrors() const {
+std::string ParsingContext::getCombinedErrors() const {
     std::string combinedError;
     for (const ParsingError& parsingError : *errors) {
-        if (combinedError.size() > 0) {
+        if (!combinedError.empty()) {
             combinedError += "\n";
         }
-        if (parsingError.key.size() > 0) {
+        if (!parsingError.key.empty()) {
             combinedError += parsingError.key + ": ";
         }
         combinedError += parsingError.message;

--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -94,33 +94,33 @@ void Layer::setMaxZoom(float maxZoom) {
 
 Value Layer::serialize() const {
     mapbox::base::ValueObject result;
-    result.emplace(std::make_pair<std::string, Value>("id", getID()));
-    result.emplace(std::make_pair<std::string, Value>("type", Layer::getTypeInfo()->type));
+    result.emplace(std::make_pair("id", getID()));
+    result.emplace(std::make_pair("type", Layer::getTypeInfo()->type));
 
     auto source = getSourceID();
     if (!source.empty()) {
-        result.emplace(std::make_pair<std::string, Value>("source", std::move(source)));
+        result.emplace(std::make_pair("source", std::move(source)));
     }
 
     auto sourceLayer = getSourceLayer();
     if (!sourceLayer.empty()) {
-        result.emplace(std::make_pair<std::string, Value>("source-layer", std::move(sourceLayer)));
+        result.emplace(std::make_pair("source-layer", std::move(sourceLayer)));
     }
 
     if (getFilter()) {
-        result.emplace(std::make_pair<std::string, Value>("filter", getFilter().serialize()));
+        result.emplace(std::make_pair("filter", getFilter().serialize()));
     }
 
     if (getMinZoom() != -std::numeric_limits<float>::infinity()) {
-        result.emplace(std::make_pair<std::string, Value>("minzoom", getMinZoom()));
+        result.emplace(std::make_pair("minzoom", getMinZoom()));
     }
 
     if (getMaxZoom() != std::numeric_limits<float>::infinity()) {
-        result.emplace(std::make_pair<std::string, Value>("maxzoom", getMaxZoom()));
+        result.emplace(std::make_pair("maxzoom", getMaxZoom()));
     }
 
     if (getVisibility() == VisibilityType::None) {
-        result["layout"] = mapbox::base::ValueObject{std::make_pair<std::string, Value>("visibility", "none")};
+        result["layout"] = mapbox::base::ValueObject{std::make_pair("visibility", "none")};
     }
 
     return result;
@@ -131,7 +131,7 @@ void Layer::serializeProperty(Value& out, const StyleProperty& property, const c
     auto& object = *(out.getObject());
     std::string propertyType = isPaint ? "paint" : "layout";
     auto it = object.find(propertyType);
-    auto pair = std::make_pair<std::string, Value>(std::string(propertyName), Value{property.getValue()});
+    auto pair = std::make_pair(std::string(propertyName), Value{property.getValue()});
     if (it != object.end()) {
         assert(it->second.getObject());
         it->second.getObject()->emplace(std::move(pair));

--- a/src/mbgl/style/sources/image_source_impl.hpp
+++ b/src/mbgl/style/sources/image_source_impl.hpp
@@ -12,7 +12,7 @@ namespace style {
 class ImageSource::Impl : public Source::Impl {
 public:
     Impl(std::string id, std::array<LatLng, 4> coords);
-    Impl(const Impl& rhs, std::array<LatLng, 4> coords);
+    Impl(const Impl& other, std::array<LatLng, 4> coords);
     Impl(const Impl& rhs, PremultipliedImage&& image);
 
     ~Impl() final;

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -143,7 +143,7 @@ private:
                       GeometryCoordinate& anchorPoint,
                       std::size_t segment,
                       const float length,
-                      const float height,
+                      const float boxSize,
                       const float overscaling);
 };
 

--- a/src/mbgl/text/collision_index.cpp
+++ b/src/mbgl/text/collision_index.cpp
@@ -191,7 +191,8 @@ std::pair<bool, bool> CollisionIndex::placeLineFeature(
     // equivalent to pixel_to_tile_units
     const auto pixelsToTileUnits = 1 / (textPixelRatio * scale);
 
-    float firstTileDistance = 0, lastTileDistance = 0;
+    float firstTileDistance = 0.f;
+    float lastTileDistance = 0.f;
     if (firstAndLastGlyph) {
         firstTileDistance = approximateTileDistance(*(firstAndLastGlyph->first.tileDistance), firstAndLastGlyph->first.angle, pixelsToTileUnits, projectedAnchor.second, pitchWithMap);
         lastTileDistance = approximateTileDistance(*(firstAndLastGlyph->second.tileDistance), firstAndLastGlyph->second.angle, pixelsToTileUnits, projectedAnchor.second, pitchWithMap);

--- a/src/mbgl/text/collision_index.hpp
+++ b/src/mbgl/text/collision_index.hpp
@@ -53,8 +53,8 @@ public:
 private:
     bool isOffscreen(const CollisionBoundaries&) const;
     bool isInsideGrid(const CollisionBoundaries&) const;
-    bool isInsideTile(const CollisionBoundaries& box, const CollisionBoundaries& tileBoundaries) const;
-    bool overlapsTile(const CollisionBoundaries& box, const CollisionBoundaries& tileBoundaries) const;
+    bool isInsideTile(const CollisionBoundaries& boundaries, const CollisionBoundaries& tileBoundaries) const;
+    bool overlapsTile(const CollisionBoundaries& boundaries, const CollisionBoundaries& tileBoundaries) const;
 
     std::pair<bool, bool> placeLineFeature(
         const CollisionFeature& feature,

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -51,9 +51,9 @@ static Anchors resample(const GeometryCoordinates& line,
         while (markedDistance + spacing < distance + segmentDist) {
             markedDistance += spacing;
 
-            float t = (markedDistance - distance) / segmentDist,
-                  x = util::interpolate(float(a.x), float(b.x), t),
-                  y = util::interpolate(float(a.y), float(b.y), t);
+            float t = (markedDistance - distance) / segmentDist;
+            float x = util::interpolate(float(a.x), float(b.x), t);
+            float y = util::interpolate(float(a.y), float(b.y), t);
 
             // Check that the point is within the tile boundaries and that
             // the label would fit before the beginning and end of the line
@@ -157,9 +157,9 @@ optional<Anchor> getCenterAnchor(const GeometryCoordinates& line,
         
         if (prevDistance + segmentDistance > centerDistance) {
             // The center is on this segment
-            float t = (centerDistance - prevDistance) / segmentDistance,
-                  x = util::interpolate(float(a.x), float(b.x), t),
-                  y = util::interpolate(float(a.y), float(b.y), t);
+            float t = (centerDistance - prevDistance) / segmentDistance;
+            float x = util::interpolate(float(a.x), float(b.x), t);
+            float y = util::interpolate(float(a.y), float(b.y), t);
 
             Anchor anchor(std::round(x), std::round(y), util::angle_to(b, a), i);
 

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -18,8 +18,12 @@ std::vector<Glyph> parseGlyphPBF(const GlyphRange& glyphRange, const std::string
             Glyph glyph;
             protozero::data_view glyphData;
 
-            bool hasID = false, hasWidth = false, hasHeight = false, hasLeft = false,
-                 hasTop = false, hasAdvance = false;
+            bool hasID = false;
+            bool hasWidth = false;
+            bool hasHeight = false;
+            bool hasLeft = false;
+            bool hasTop = false;
+            bool hasAdvance = false;
 
             while (glyph_pbf.next()) {
                 switch (glyph_pbf.tag()) {

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -19,7 +19,7 @@ enum class PlacedSymbolOrientation : bool;
 class OpacityState {
 public:
     OpacityState(bool placed, bool skipFade);
-    OpacityState(const OpacityState& prevOpacityState, float increment, bool placed);
+    OpacityState(const OpacityState& prevState, float increment, bool placed);
     bool isHidden() const;
     float opacity;
     bool placed;
@@ -27,8 +27,8 @@ public:
 
 class JointOpacityState {
 public:
-    JointOpacityState(bool placedIcon, bool placedText, bool skipFade);
-    JointOpacityState(const JointOpacityState& prevOpacityState, float increment, bool placedIcon, bool placedText);
+    JointOpacityState(bool placedText, bool placedIcon, bool skipFade);
+    JointOpacityState(const JointOpacityState& prevOpacityState, float increment, bool placedText, bool placedIcon);
     bool isHidden() const;
     OpacityState icon;
     OpacityState text;

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -496,7 +496,7 @@ void shapeLines(Shaping& shaping,
         }
 
         // Only justify if we placed at least one glyph
-        if (positionedGlyphs.size() != 0) {
+        if (!positionedGlyphs.empty()) {
             float lineLength = x - spacing; // Don't count trailing spacing
             maxLineLength = util::max(lineLength, maxLineLength);
             justifyLine(positionedGlyphs, justify, lineOffset);
@@ -528,21 +528,21 @@ void shapeLines(Shaping& shaping,
     shaping.right = shaping.left + maxLineLength;
 }
 
-const Shaping getShaping(const TaggedString& formattedString,
-                         const float maxWidth,
-                         const float lineHeight,
-                         const style::SymbolAnchorType textAnchor,
-                         const style::TextJustifyType textJustify,
-                         const float spacing,
-                         const std::array<float, 2>& translate,
-                         const WritingModeType writingMode,
-                         BiDi& bidi,
-                         const GlyphMap& glyphMap,
-                         const GlyphPositions& glyphPositions,
-                         const ImagePositions& imagePositions,
-                         float layoutTextSize,
-                         float layoutTextSizeAtBucketZoomLevel,
-                         bool allowVerticalPlacement) {
+Shaping getShaping(const TaggedString& formattedString,
+                   const float maxWidth,
+                   const float lineHeight,
+                   const style::SymbolAnchorType textAnchor,
+                   const style::TextJustifyType textJustify,
+                   const float spacing,
+                   const std::array<float, 2>& translate,
+                   const WritingModeType writingMode,
+                   BiDi& bidi,
+                   const GlyphMap& glyphMap,
+                   const GlyphPositions& glyphPositions,
+                   const ImagePositions& imagePositions,
+                   float layoutTextSize,
+                   float layoutTextSizeAtBucketZoomLevel,
+                   bool allowVerticalPlacement) {
     assert(layoutTextSize);
     std::vector<TaggedString> reorderedLines;
     if (formattedString.sectionCount() == 1) {

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -79,20 +79,20 @@ public:
     const Padding& collisionPadding() const { return _collisionPadding; }
 };
 
-const Shaping getShaping(const TaggedString& string,
-                         float maxWidth,
-                         float lineHeight,
-                         style::SymbolAnchorType textAnchor,
-                         style::TextJustifyType textJustify,
-                         float spacing,
-                         const std::array<float, 2>& translate,
-                         const WritingModeType,
-                         BiDi& bidi,
-                         const GlyphMap& glyphMap,
-                         const GlyphPositions& glyphPositions,
-                         const ImagePositions& imagePositions,
-                         float layoutTextSize,
-                         float layoutTextSizeAtBucketZoomLevel,
-                         bool allowVerticalPlacement);
+Shaping getShaping(const TaggedString& string,
+                   float maxWidth,
+                   float lineHeight,
+                   style::SymbolAnchorType textAnchor,
+                   style::TextJustifyType textJustify,
+                   float spacing,
+                   const std::array<float, 2>& translate,
+                   const WritingModeType,
+                   BiDi& bidi,
+                   const GlyphMap& glyphMap,
+                   const GlyphPositions& glyphPositions,
+                   const ImagePositions& imagePositions,
+                   float layoutTextSize,
+                   float layoutTextSizeAtBucketZoomLevel,
+                   bool allowVerticalPlacement);
 
 } // namespace mbgl

--- a/src/mbgl/tile/custom_geometry_tile.cpp
+++ b/src/mbgl/tile/custom_geometry_tile.cpp
@@ -8,6 +8,8 @@
 #include <mbgl/style/custom_tile_loader.hpp>
 
 #include <mapbox/geojsonvt.hpp>
+
+#include <cassert>
 #include <utility>
 
 namespace mbgl {
@@ -32,7 +34,8 @@ void CustomGeometryTile::setTileData(const GeoJSON& geoJSON) {
 
     auto featureData = mapbox::feature::feature_collection<int16_t>();
     if (geoJSON.is<FeatureCollection>() && !geoJSON.get<FeatureCollection>().empty()) {
-        const double scale = util::EXTENT / options->tileSize;
+        auto scale = util::EXTENT / options->tileSize;
+        assert(util::EXTENT % options->tileSize == 0);
 
         mapbox::geojsonvt::TileOptions vtOptions;
         vtOptions.extent = util::EXTENT;

--- a/src/mbgl/tile/custom_geometry_tile.hpp
+++ b/src/mbgl/tile/custom_geometry_tile.hpp
@@ -23,7 +23,7 @@ public:
                        ActorRef<style::CustomTileLoader> loader);
     ~CustomGeometryTile() override;
 
-    void setTileData(const GeoJSON& data);
+    void setTileData(const GeoJSON& geoJSON);
     void invalidateTileData();
 
     void setNecessity(TileNecessity) final;

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -279,7 +279,7 @@ void GeometryTile::getImages(ImageRequestPair pair) {
     imageManager.getImages(*this, std::move(pair));
 }
 
-const std::shared_ptr<FeatureIndex> GeometryTile::getFeatureIndex() const {
+std::shared_ptr<FeatureIndex> GeometryTile::getFeatureIndex() const {
     return layoutResult ? layoutResult->featureIndex : nullptr;
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -91,8 +91,8 @@ public:
     void markRenderedIdeal() override;
     void markRenderedPreviously() override;
     void performedFadePlacement() override;
-    const std::shared_ptr<FeatureIndex> getFeatureIndex() const;
-    
+    std::shared_ptr<FeatureIndex> getFeatureIndex() const;
+
     const std::string sourceID;
 
     void setFeatureState(const LayerFeatureStates&) override;

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -46,9 +46,12 @@ public:
                  uint64_t correlationID);
     void reset(uint64_t correlationID_);
     void setShowCollisionBoxes(bool showCollisionBoxes_, uint64_t correlationID_);
-    
-    void onGlyphsAvailable(GlyphMap glyphs);
-    void onImagesAvailable(ImageMap icons, ImageMap patterns, ImageVersionMap versionMap, uint64_t imageCorrelationID);
+
+    void onGlyphsAvailable(GlyphMap newGlyphMap);
+    void onImagesAvailable(ImageMap newIconMap,
+                           ImageMap newPatternMap,
+                           ImageVersionMap versionMap,
+                           uint64_t imageCorrelationID);
 
 private:
     void coalesced();

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -63,7 +63,7 @@ void RasterDEMTile::onParsed(std::unique_ptr<HillshadeBucket> result, const uint
     if (resultCorrelationID == correlationID) {
         pending = false;
     }
-    renderable = bucket ? true : false;
+    renderable = static_cast<bool>(bucket);
     observer->onTileChanged(*this);
 }
 

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -52,7 +52,7 @@ void RasterTile::onParsed(std::unique_ptr<RasterBucket> result, const uint64_t r
     if (resultCorrelationID == correlationID) {
         pending = false;
     }
-    renderable = bucket ? true : false;
+    renderable = static_cast<bool>(bucket);
     observer->onTileChanged(*this);
 }
 

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -16,7 +16,7 @@ public:
 
     void setSize(size_t);
     size_t getSize() const { return size; };
-    void add(const OverscaledTileID& key, std::unique_ptr<Tile> data);
+    void add(const OverscaledTileID& key, std::unique_ptr<Tile> tile);
     std::unique_ptr<Tile> pop(const OverscaledTileID& key);
     Tile* get(const OverscaledTileID& key);
     bool has(const OverscaledTileID& key);

--- a/src/mbgl/util/geometry_within.cpp
+++ b/src/mbgl/util/geometry_within.cpp
@@ -38,7 +38,12 @@ bool lineIntersectLine(const Point<int64_t>& a,
     // check if p1 and p2 are in different sides of line segment q1->q2
     const auto twoSided =
         [](const Point<int64_t>& p1, const Point<int64_t>& p2, const Point<int64_t>& q1, const Point<int64_t>& q2) {
-            int64_t x1, y1, x2, y2, x3, y3;
+            int64_t x1;
+            int64_t y1;
+            int64_t x2;
+            int64_t y2;
+            int64_t x3;
+            int64_t y3;
 
             // q1->p1 (x1, y1), q1->p2 (x2, y2), q1->q2 (x3, y3)
             x1 = p1.x - q1.x;
@@ -49,17 +54,13 @@ bool lineIntersectLine(const Point<int64_t>& a,
             y3 = q2.y - q1.y;
             auto ret1 = (x1 * y3 - x3 * y1);
             auto ret2 = (x2 * y3 - x3 * y2);
-            if ((ret1 > 0 && ret2 < 0) || (ret1 < 0 && ret2 > 0)) {
-                return true;
-            }
-            return false;
+            return (ret1 > 0 && ret2 < 0) || (ret1 < 0 && ret2 > 0);
         };
 
     // If lines are intersecting with each other, the relative location should be:
     // a and b lie in different sides of segment c->d
     // c and d lie in different sides of segment a->b
-    if (twoSided(a, b, c, d) && twoSided(c, d, a, b)) return true;
-    return false;
+    return twoSided(a, b, c, d) && twoSided(c, d, a, b);
 }
 
 bool lineIntersectPolygon(const Point<int64_t>& p1, const Point<int64_t>& p2, const Polygon<int64_t>& polygon) {

--- a/src/mbgl/util/grid_index.cpp
+++ b/src/mbgl/util/grid_index.cpp
@@ -32,7 +32,9 @@ void GridIndex<T>::insert(T&& t, const BBox& bbox) {
     auto cx2 = convertToXCellCoord(bbox.max.x);
     auto cy2 = convertToYCellCoord(bbox.max.y);
 
-    std::size_t x, y, cellIndex;
+    std::size_t x;
+    std::size_t y;
+    std::size_t cellIndex;
     for (x = cx1; x <= cx2; ++x) {
         for (y = cy1; y <= cy2; ++y) {
             cellIndex = xCellCount * y + x;
@@ -52,7 +54,9 @@ void GridIndex<T>::insert(T&& t, const BCircle& bcircle) {
     auto cx2 = convertToXCellCoord(bcircle.center.x + bcircle.radius);
     auto cy2 = convertToYCellCoord(bcircle.center.y + bcircle.radius);
 
-    std::size_t x, y, cellIndex;
+    std::size_t x;
+    std::size_t y;
+    std::size_t cellIndex;
     for (x = cx1; x <= cx2; ++x) {
         for (y = cy1; y <= cy2; ++y) {
             cellIndex = xCellCount * y + x;
@@ -153,7 +157,9 @@ void GridIndex<T>::query(const BBox& queryBBox, std::function<bool (const T&, co
     auto cx2 = convertToXCellCoord(queryBBox.max.x);
     auto cy2 = convertToYCellCoord(queryBBox.max.y);
 
-    std::size_t x, y, cellIndex;
+    std::size_t x;
+    std::size_t y;
+    std::size_t cellIndex;
     for (x = cx1; x <= cx2; ++x) {
         for (y = cy1; y <= cy2; ++y) {
             cellIndex = xCellCount * y + x;
@@ -216,7 +222,9 @@ void GridIndex<T>::query(const BCircle& queryBCircle, std::function<bool (const 
     auto cx2 = convertToXCellCoord(queryBCircle.center.x + queryBCircle.radius);
     auto cy2 = convertToYCellCoord(queryBCircle.center.y + queryBCircle.radius);
 
-    std::size_t x, y, cellIndex;
+    std::size_t x;
+    std::size_t y;
+    std::size_t cellIndex;
     for (x = cx1; x <= cx2; ++x) {
         for (y = cy1; y <= cy2; ++y) {
             cellIndex = xCellCount * y + x;

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -12,10 +12,8 @@ namespace {
     @param first The first codepoint in the block, inclusive.
     @param last The last codepoint in the block, inclusive.
  */
-#define DEFINE_IS_IN_UNICODE_BLOCK(name, first, last)                                              \
-    inline bool isIn##name(char16_t codepoint) {                                                   \
-        return codepoint >= first && codepoint <= last;                                            \
-    }
+#define DEFINE_IS_IN_UNICODE_BLOCK(name, first, last) \
+    inline bool isIn##name(char16_t codepoint) { return codepoint >= (first) && codepoint <= (last); }
 
 // The following table comes from <http://www.unicode.org/Public/12.0.0/ucd/Blocks.txt>.
 // Keep it synchronized with <http://www.unicode.org/Public/UCD/latest/ucd/Blocks.txt>.

--- a/src/mbgl/util/i18n.cpp
+++ b/src/mbgl/util/i18n.cpp
@@ -614,21 +614,19 @@ bool charInSupportedScript(char16_t chr) {
     // actually depends on the properties of the font being used
     // and whether differences from the ideal rendering are considered
     // semantically significant.
-    
+
     // Even in Latin script, we "can't render" combinations such as the fi
     // ligature, but we don't consider that semantically significant.n false;
-    if ((chr >= 0x0900 && chr <= 0x0DFF) ||
-        // Main blocks for Indic scripts and Sinhala
-        (chr >= 0x0F00 && chr <= 0x109F) ||
-        // Main blocks for Tibetan and Myanmar
-        isInKhmer(chr)) {
-        // These blocks cover common scripts that require
-        // complex text shaping, based on unicode script metadata:
-        // http://www.unicode.org/repos/cldr/trunk/common/properties/scriptMetadata.txt
-        // where "Web Rank <= 32" "Shaping Required = YES"
-        return false;
-    }
-    return true;
+
+    // These blocks cover common scripts that require
+    // complex text shaping, based on unicode script metadata:
+    // http://www.unicode.org/repos/cldr/trunk/common/properties/scriptMetadata.txt
+    // where "Web Rank <= 32" "Shaping Required = YES"
+    return !((chr >= 0x0900 && chr <= 0x0DFF) ||
+             // Main blocks for Indic scripts and Sinhala
+             (chr >= 0x0F00 && chr <= 0x109F) ||
+             // Main blocks for Tibetan and Myanmar
+             isInKhmer(chr));
 }
     
 bool isStringInSupportedScript(const std::string& input) {

--- a/src/mbgl/util/intersection_tests.cpp
+++ b/src/mbgl/util/intersection_tests.cpp
@@ -30,7 +30,7 @@ bool pointIntersectsBufferedLine(const GeometryCoordinate& p, const GeometryCoor
     const float radiusSquared = radius * radius;
 
     if (line.size() == 1) return util::distSqr<float>(p, line.at(0)) < radiusSquared;
-    if (line.size() == 0) return false;
+    if (line.empty()) return false;
 
     for (auto i = line.begin() + 1; i != line.end(); i++) {
         // Find line segments that have a distance <= radius^2 to p
@@ -52,7 +52,7 @@ bool lineSegmentIntersectsLineSegment(const GeometryCoordinate& a0, const Geomet
         isCounterClockwise(a0, a1, b0) != isCounterClockwise(a0, a1, b1);
 }
 bool lineIntersectsLine(const GeometryCoordinates& lineA, const GeometryCoordinates& lineB) {
-    if (lineA.size() == 0 || lineB.size() == 0) return false;
+    if (lineA.empty() || lineB.empty()) return false;
     for (auto i = lineA.begin(); i != lineA.end() - 1; i++) {
         auto& a0 = *i;
         auto& a1 = *(i + 1);
@@ -120,9 +120,7 @@ bool polygonIntersectsPolygon(const GeometryCoordinates& polygonA, const Geometr
         if (polygonContainsPoint(polygonA, p)) return true;
     }
 
-    if (lineIntersectsLine(polygonA, polygonB)) return true;
-
-    return false;
+    return lineIntersectsLine(polygonA, polygonB);
 }
 
 bool polygonIntersectsMultiPolygon(const GeometryCoordinates& polygon, const GeometryCollection& multiPolygon) {

--- a/src/mbgl/util/logging.cpp
+++ b/src/mbgl/util/logging.cpp
@@ -10,7 +10,7 @@ namespace mbgl {
 
 namespace {
 
-static std::unique_ptr<Log::Observer> currentObserver;
+std::unique_ptr<Log::Observer> currentObserver;
 
 } // namespace
 

--- a/src/mbgl/util/mapbox.hpp
+++ b/src/mbgl/util/mapbox.hpp
@@ -12,14 +12,14 @@ namespace mapbox {
 
 bool isMapboxURL(const std::string& url);
 
-std::string normalizeSourceURL(const std::string& baseURL, const std::string& url, const std::string& accessToken);
-std::string normalizeStyleURL(const std::string& baseURL, const std::string& url, const std::string& accessToken);
-std::string normalizeSpriteURL(const std::string& baseURL, const std::string& url, const std::string& accessToken);
-std::string normalizeGlyphsURL(const std::string& baseURL, const std::string& url, const std::string& accessToken);
-std::string normalizeTileURL(const std::string& baseURL, const std::string& url, const std::string& accessToken);
+std::string normalizeSourceURL(const std::string& baseURL, const std::string& str, const std::string& accessToken);
+std::string normalizeStyleURL(const std::string& baseURL, const std::string& str, const std::string& accessToken);
+std::string normalizeSpriteURL(const std::string& baseURL, const std::string& str, const std::string& accessToken);
+std::string normalizeGlyphsURL(const std::string& baseURL, const std::string& str, const std::string& accessToken);
+std::string normalizeTileURL(const std::string& baseURL, const std::string& str, const std::string& accessToken);
 
 // Return a "mapbox://tiles/..." URL (suitable for normalizeTileURL) for the given Mapbox tile URL.
-std::string canonicalizeTileURL(const std::string& url, style::SourceType, uint16_t tileSize);
+std::string canonicalizeTileURL(const std::string& str, style::SourceType, uint16_t tileSize);
 
 // Replace URL templates with "mapbox://tiles/..." URLs (suitable for normalizeTileURL).
 void canonicalizeTileset(Tileset&, const std::string& url, style::SourceType, uint16_t tileSize);

--- a/src/mbgl/util/mat2.cpp
+++ b/src/mbgl/util/mat2.cpp
@@ -34,9 +34,12 @@ void matrix::identity(mat2& out) {
 }
 
 void matrix::rotate(mat2& out, const mat2& a, double rad) {
-    double a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3],
-        s = std::sin(rad),
-        c = std::cos(rad);
+    double a0 = a[0];
+    double a1 = a[1];
+    double a2 = a[2];
+    double a3 = a[3];
+    double s = std::sin(rad);
+    double c = std::cos(rad);
     out[0] = a0 *  c + a2 * s;
     out[1] = a1 *  c + a3 * s;
     out[2] = a0 * -s + a2 * c;
@@ -44,7 +47,10 @@ void matrix::rotate(mat2& out, const mat2& a, double rad) {
 }
 
 void matrix::scale(mat2& out, const mat2& a, double v0, double v1) {
-    double a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
+    double a0 = a[0];
+    double a1 = a[1];
+    double a2 = a[2];
+    double a3 = a[3];
     out[0] = a0 * v0;
     out[1] = a1 * v0;
     out[2] = a2 * v1;

--- a/src/mbgl/util/mat3.cpp
+++ b/src/mbgl/util/mat3.cpp
@@ -40,9 +40,15 @@ void identity(mat3& out) {
 }
 
 void translate(mat3& out, const mat3& a, double x, double y) {
-    double a00 = a[0], a01 = a[1], a02 = a[2],
-          a10 = a[3], a11 = a[4], a12 = a[5],
-          a20 = a[6], a21 = a[7], a22 = a[8];
+    double a00 = a[0];
+    double a01 = a[1];
+    double a02 = a[2];
+    double a10 = a[3];
+    double a11 = a[4];
+    double a12 = a[5];
+    double a20 = a[6];
+    double a21 = a[7];
+    double a22 = a[8];
 
     out[0] = a00;
     out[1] = a01;
@@ -58,17 +64,17 @@ void translate(mat3& out, const mat3& a, double x, double y) {
 }
 
 void rotate(mat3& out, const mat3& a, double rad) {
-    double s = std::sin(rad),
-          c = std::cos(rad),
-          a00 = a[0],
-          a01 = a[1],
-          a02 = a[2],
-          a10 = a[3],
-          a11 = a[4],
-          a12 = a[5],
-          a20 = a[6],
-          a21 = a[7],
-          a22 = a[8];
+    double s = std::sin(rad);
+    double c = std::cos(rad);
+    double a00 = a[0];
+    double a01 = a[1];
+    double a02 = a[2];
+    double a10 = a[3];
+    double a11 = a[4];
+    double a12 = a[5];
+    double a20 = a[6];
+    double a21 = a[7];
+    double a22 = a[8];
 
     out[0] = c * a00 + s * a10;
     out[1] = c * a01 + s * a11;

--- a/src/mbgl/util/mat4.cpp
+++ b/src/mbgl/util/mat4.cpp
@@ -48,26 +48,36 @@ void identity(mat4& out) {
 }
 
 bool invert(mat4& out, const mat4& a) {
-    double a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3],
-          a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7],
-          a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11],
-          a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15],
-
-          b00 = a00 * a11 - a01 * a10,
-          b01 = a00 * a12 - a02 * a10,
-          b02 = a00 * a13 - a03 * a10,
-          b03 = a01 * a12 - a02 * a11,
-          b04 = a01 * a13 - a03 * a11,
-          b05 = a02 * a13 - a03 * a12,
-          b06 = a20 * a31 - a21 * a30,
-          b07 = a20 * a32 - a22 * a30,
-          b08 = a20 * a33 - a23 * a30,
-          b09 = a21 * a32 - a22 * a31,
-          b10 = a21 * a33 - a23 * a31,
-          b11 = a22 * a33 - a23 * a32,
-
-          // Calculate the determinant
-          det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
+    double a00 = a[0];
+    double a01 = a[1];
+    double a02 = a[2];
+    double a03 = a[3];
+    double a10 = a[4];
+    double a11 = a[5];
+    double a12 = a[6];
+    double a13 = a[7];
+    double a20 = a[8];
+    double a21 = a[9];
+    double a22 = a[10];
+    double a23 = a[11];
+    double a30 = a[12];
+    double a31 = a[13];
+    double a32 = a[14];
+    double a33 = a[15];
+    double b00 = a00 * a11 - a01 * a10;
+    double b01 = a00 * a12 - a02 * a10;
+    double b02 = a00 * a13 - a03 * a10;
+    double b03 = a01 * a12 - a02 * a11;
+    double b04 = a01 * a13 - a03 * a11;
+    double b05 = a02 * a13 - a03 * a12;
+    double b06 = a20 * a31 - a21 * a30;
+    double b07 = a20 * a32 - a22 * a30;
+    double b08 = a20 * a33 - a23 * a30;
+    double b09 = a21 * a32 - a22 * a31;
+    double b10 = a21 * a33 - a23 * a31;
+    double b11 = a22 * a33 - a23 * a32;
+    double // Calculate the determinant
+        det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
 
     if (!det) {
         return true;
@@ -95,9 +105,9 @@ bool invert(mat4& out, const mat4& a) {
 }
 
 void ortho(mat4& out, double left, double right, double bottom, double top, double near, double far) {
-    double lr = 1.0f / (left - right),
-          bt = 1.0f / (bottom - top),
-          nf = 1.0f / (near - far);
+    double lr = 1.0f / (left - right);
+    double bt = 1.0f / (bottom - top);
+    double nf = 1.0f / (near - far);
     out[0] = -2.0f * lr;
     out[1] = 0.0f;
     out[2] = 0.0f;
@@ -117,8 +127,8 @@ void ortho(mat4& out, double left, double right, double bottom, double top, doub
 }
 
 void perspective(mat4& out, double fovy, double aspect, double near, double far) {
-    double f = 1.0f / std::tan(fovy / 2.0f),
-          nf = 1.0f / (near - far);
+    double f = 1.0f / std::tan(fovy / 2.0f);
+    double nf = 1.0f / (near - far);
     out[0] = f / aspect;
     out[1] = 0.0f;
     out[2] = 0.0f;
@@ -163,9 +173,18 @@ void translate(mat4& out, const mat4& a, double x, double y, double z) {
         out[14] = a[2] * x + a[6] * y + a[10] * z + a[14];
         out[15] = a[3] * x + a[7] * y + a[11] * z + a[15];
     } else {
-        double a00, a01, a02, a03,
-              a10, a11, a12, a13,
-              a20, a21, a22, a23;
+        double a00;
+        double a01;
+        double a02;
+        double a03;
+        double a10;
+        double a11;
+        double a12;
+        double a13;
+        double a20;
+        double a21;
+        double a22;
+        double a23;
 
         a00 = a[0]; a01 = a[1]; a02 = a[2]; a03 = a[3];
         a10 = a[4]; a11 = a[5]; a12 = a[6]; a13 = a[7];
@@ -183,16 +202,16 @@ void translate(mat4& out, const mat4& a, double x, double y, double z) {
 }
 
 void rotate_x(mat4& out, const mat4& a, double rad) {
-    double s = std::sin(rad),
-        c = std::cos(rad),
-        a10 = a[4],
-        a11 = a[5],
-        a12 = a[6],
-        a13 = a[7],
-        a20 = a[8],
-        a21 = a[9],
-        a22 = a[10],
-        a23 = a[11];
+    double s = std::sin(rad);
+    double c = std::cos(rad);
+    double a10 = a[4];
+    double a11 = a[5];
+    double a12 = a[6];
+    double a13 = a[7];
+    double a20 = a[8];
+    double a21 = a[9];
+    double a22 = a[10];
+    double a23 = a[11];
 
     if (&a != &out) { // If the source and destination differ, copy the unchanged rows
         out[0]  = a[0];
@@ -217,16 +236,16 @@ void rotate_x(mat4& out, const mat4& a, double rad) {
 }
 
 void rotate_y(mat4& out, const mat4& a, double rad) {
-    double s = std::sin(rad),
-        c = std::cos(rad),
-        a00 = a[0],
-        a01 = a[1],
-        a02 = a[2],
-        a03 = a[3],
-        a20 = a[8],
-        a21 = a[9],
-        a22 = a[10],
-        a23 = a[11];
+    double s = std::sin(rad);
+    double c = std::cos(rad);
+    double a00 = a[0];
+    double a01 = a[1];
+    double a02 = a[2];
+    double a03 = a[3];
+    double a20 = a[8];
+    double a21 = a[9];
+    double a22 = a[10];
+    double a23 = a[11];
 
     if (&a != &out) { // If the source and destination differ, copy the unchanged rows
         out[4]  = a[4];
@@ -251,16 +270,16 @@ void rotate_y(mat4& out, const mat4& a, double rad) {
 }
 
 void rotate_z(mat4& out, const mat4& a, double rad) {
-    double s = std::sin(rad),
-          c = std::cos(rad),
-          a00 = a[0],
-          a01 = a[1],
-          a02 = a[2],
-          a03 = a[3],
-          a10 = a[4],
-          a11 = a[5],
-          a12 = a[6],
-          a13 = a[7];
+    double s = std::sin(rad);
+    double c = std::cos(rad);
+    double a00 = a[0];
+    double a01 = a[1];
+    double a02 = a[2];
+    double a03 = a[3];
+    double a10 = a[4];
+    double a11 = a[5];
+    double a12 = a[6];
+    double a13 = a[7];
 
     if (&a != &out) { // If the source and destination differ, copy the unchanged last row
         out[8]  = a[8];
@@ -304,13 +323,28 @@ void scale(mat4& out, const mat4& a, double x, double y, double z) {
 }
 
 void multiply(mat4& out, const mat4& a, const mat4& b) {
-    double a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3],
-          a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7],
-          a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11],
-          a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15];
+    double a00 = a[0];
+    double a01 = a[1];
+    double a02 = a[2];
+    double a03 = a[3];
+    double a10 = a[4];
+    double a11 = a[5];
+    double a12 = a[6];
+    double a13 = a[7];
+    double a20 = a[8];
+    double a21 = a[9];
+    double a22 = a[10];
+    double a23 = a[11];
+    double a30 = a[12];
+    double a31 = a[13];
+    double a32 = a[14];
+    double a33 = a[15];
 
     // Cache only the current line of the second matrix
-    double b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3];
+    double b0 = b[0];
+    double b1 = b[1];
+    double b2 = b[2];
+    double b3 = b[3];
     out[0] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
     out[1] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
     out[2] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
@@ -336,7 +370,10 @@ void multiply(mat4& out, const mat4& a, const mat4& b) {
 }
 
 void transformMat4(vec4& out, const vec4& a, const mat4& m) {
-    double x = a[0], y = a[1], z = a[2], w = a[3];
+    double x = a[0];
+    double y = a[1];
+    double z = a[2];
+    double w = a[3];
     out[0] = m[0] * x + m[4] * y + m[8] * z + m[12] * w;
     out[1] = m[1] * x + m[5] * y + m[9] * z + m[13] * w;
     out[2] = m[2] * x + m[6] * y + m[10] * z + m[14] * w;

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -34,7 +34,7 @@ struct edge {
 };
 
 // scan-line conversion
-static void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine& scanLine) {
+void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine& scanLine) {
     double y0 = ::fmax(ymin, std::floor(e1.y0));
     double y1 = ::fmin(ymax, std::ceil(e1.y1));
 
@@ -58,7 +58,12 @@ static void scanSpans(edge e0, edge e1, int32_t ymin, int32_t ymax, ScanLine& sc
 }
 
 // scan-line conversion
-static void scanTriangle(const Point<double>& a, const Point<double>& b, const Point<double>& c, int32_t ymin, int32_t ymax, ScanLine& scanLine) {
+void scanTriangle(const Point<double>& a,
+                  const Point<double>& b,
+                  const Point<double>& c,
+                  int32_t ymin,
+                  int32_t ymax,
+                  ScanLine& scanLine) {
     edge ab = edge(a, b);
     edge bc = edge(b, c);
     edge ca = edge(c, a);
@@ -98,7 +103,8 @@ std::vector<UnwrappedTileID> tileCover(const Point<double>& tl,
         int32_t x;
         if (y >= 0 && y <= tiles) {
             for (x = x0; x < x1; ++x) {
-                const auto dx = x + 0.5 - c.x, dy = y + 0.5 - c.y;
+                const auto dx = x + 0.5 - c.x;
+                const auto dy = y + 0.5 - c.y;
                 t.emplace_back(ID{ x, y, dx * dx + dy * dy });
             }
         }

--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -113,11 +113,13 @@ void build_bounds_map(PointList& points, uint32_t maxTile, BoundsMap& et, bool c
 
         if (to_max.points.size() >= 2) {
             // Projections may result in values beyond the bounds, clamp to max tile coordinates
-            const auto y = static_cast<uint32_t>(std::floor(clamp(to_max.points.front().y, 0.0, (double)maxTile)));
+            const auto y =
+                static_cast<uint32_t>(std::floor(clamp(to_max.points.front().y, 0.0, static_cast<double>(maxTile))));
             et[y].push_back(to_max);
         }
         if (to_min.points.size() >= 2) {
-            const auto y = static_cast<uint32_t>(std::floor(clamp(to_min.points.front().y, 0.0, (double)maxTile)));
+            const auto y =
+                static_cast<uint32_t>(std::floor(clamp(to_min.points.front().y, 0.0, static_cast<double>(maxTile))));
             et[y].push_back(to_min);
         }
     }
@@ -218,7 +220,7 @@ struct BuildBoundsMap {
         bnd.points.insert(bnd.points.end(), 2, point);
         bnd.winding = false;
         BoundsMap et;
-        const auto y = static_cast<uint32_t>(std::floor(clamp(point.y, 0.0, (double)(1 << zoom))));
+        const auto y = static_cast<uint32_t>(std::floor(clamp(point.y, 0.0, static_cast<double>(1 << zoom))));
         et[y].push_back(bnd);
         return et;
     }
@@ -233,7 +235,7 @@ struct BuildBoundsMap {
             }
             bnd.points.insert(bnd.points.end(), 2, point);
             bnd.winding = false;
-            const auto y = static_cast<uint32_t>(std::floor(clamp(point.y, 0.0, (double)(1 << zoom))));
+            const auto y = static_cast<uint32_t>(std::floor(clamp(point.y, 0.0, static_cast<double>(1 << zoom))));
             et[y].push_back(bnd);
         }
         return et;

--- a/src/mbgl/util/tile_cover_impl.cpp
+++ b/src/mbgl/util/tile_cover_impl.cpp
@@ -281,7 +281,7 @@ TileCover::Impl::Impl(int32_t z, const Geometry<double>& geom, bool project)
 
     BuildBoundsMap toBoundsMap(z, project);
     boundsMap = apply_visitor(toBoundsMap, geom);
-    if (boundsMap.size() == 0) return;
+    if (boundsMap.empty()) return;
 
     //Iniitalize the active edge table, and current row span
     currentBounds = boundsMap.begin();
@@ -300,7 +300,7 @@ TileCover::Impl::Impl(int32_t z, const Geometry<double>& geom, bool project)
 void TileCover::Impl::nextRow() {
     // Update activeBounds for next row
     if (currentBounds != boundsMap.end()) {
-        if (activeBounds.size() == 0 && currentBounds->first > tileY) {
+        if (activeBounds.empty() && currentBounds->first > tileY) {
             //For multi-geoms: use the next row with an edge table starting point
             tileY = currentBounds->first;
         }
@@ -312,7 +312,7 @@ void TileCover::Impl::nextRow() {
     }
     //Scan the active bounds and update currentRange with x_min, x_max pairs
     auto xps = util::scan_row(tileY, activeBounds);
-    if (xps.size() == 0) {
+    if (xps.empty()) {
         return;
     }
 

--- a/src/mbgl/util/url.hpp
+++ b/src/mbgl/util/url.hpp
@@ -45,7 +45,7 @@ public:
 // * {filename} == "baz"
 // * {extension} == ".png"
 // The query string of the source URL will always be appended.
-std::string transformURL(const std::string& tpl, const std::string& url, const URL&);
+std::string transformURL(const std::string& tpl, const std::string& str, const URL&);
 inline std::string transformURL(const std::string& tpl, const std::string& url) {
     return transformURL(tpl, url, URL(url));
 }


### PR DESCRIPTION
Now this bot will fail on any clang-tidy violation. There is one more thing to be fixed which is get clang-tidy running on code inlined in the headers, but the current state should cover most of the code already.

Fixes: https://github.com/mapbox/mapbox-gl-native-team/issues/45
