### PR TITLE
Hillshade bucket fix for mapbox-gl-native-ios #240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - [core] Move logging off the main thread ([#16325](https://github.com/mapbox/mapbox-gl-native/pull/16325))
 
+### 🐞 Bug fixes
+
+- Hillshade bucket fix for mapbox-gl-native-ios #240 ([#16362](https://github.com/mapbox/mapbox-gl-native/pull/16362))
+
+  When dem tiles are loaded, border in neighboring tiles is updated, too leading to bucket re-upload. if std::move moved indices / vertices previously, they are empty and we get crash. Re-upload requires that only DEM texture is re-uploaded, not the quad vertices and indices.
+
 ## maps-v1.5.0
 
 ### ✨ New features

--- a/src/mbgl/renderer/buckets/hillshade_bucket.cpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.cpp
@@ -31,14 +31,16 @@ void HillshadeBucket::upload(gfx::UploadPass& uploadPass) {
         return;
     }
 
-
     const PremultipliedImage* image = demdata.getImage();
     dem = uploadPass.createTexture(*image);
 
-    if (!segments.empty()) {
+    if (!vertices.empty()) {
         vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
+    }
+    if (!indices.empty()) {
         indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
     }
+
     uploaded = true;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-gl-native-ios/issues/240

Approach copied from RasterBucket::upload - they both use SharedBucketTileRenderData.
 
I don't have render test for this: it is a bit tricky since neighboring DEM tiles should not be available in the same time (otherwise this cannot be reproduced).
When dem tiles are loaded, border in neighboring tiles is updated, too leading to bucket re-upload. if std::move moved indices / vertices previously, they are empty and we get crash.
Re-upload requires that only DEM texture is re-uploaded, not the quad vertices and indices.

Verified running macosapp.