### PR TITLE
[build] Cascade some bots so we trigger less jobs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,43 +15,20 @@ workflows:
   development:
     jobs:
       - sanity-checks
-      - android-benchmark-runner
-      - android-api-breakage
-      - android-render-test-runner
-      - android-unit-test-runner
-      - ios-render-test-runner
-      - ios-unit-test-runner
-      - ios-benchmark-runner
-      - baselines:
-          requires:
-            - android-arm64-v8a-release
-            - android-armeabi-v7a-release
-            - android-render-test-runner
-            - android-x86-release
-            - android-x86_64-release
-            - linux-clang8-release
-            - linux-gcc8-release
-            - macos-xcode11-release
-            - ios-render-test-runner
-      - trigger-pipeline:
-          requires:
-            - android-render-test-runner
-            - ios-render-test-runner
-            - linux-clang8-release
-            - linux-gcc8-release
-            - macos-xcode11-release
-          name: mapboxci
-          slug: mapbox/mapbox-gl-native-internal
       - build-template:
           name: android-armeabi-v7a-release
           executor_name: ubuntu-disco
           target_is_android: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=armeabi-v7a'
           install: true
       - build-template:
           name: android-arm64-v8a-release
           executor_name: ubuntu-disco
           target_is_android: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=arm64-v8a'
           build_params: '--target libmapbox-gl.so'
           install: true
@@ -59,6 +36,8 @@ workflows:
           name: android-x86-release
           executor_name: ubuntu-disco
           target_is_android: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=x86'
           build_params: '--target libmapbox-gl.so'
           install: true
@@ -66,6 +45,8 @@ workflows:
           name: android-x86_64-release
           executor_name: ubuntu-disco
           target_is_android: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_CCACHE=/usr/bin/ccache -DANDROID_ABI=x86_64'
           build_params: '--target libmapbox-gl.so'
           install: true
@@ -73,6 +54,8 @@ workflows:
           name: linux-gcc8-release
           executor_name: ubuntu-disco
           target_is_linux: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8'
           install: true
           metrics: true
@@ -99,6 +82,8 @@ workflows:
           name: linux-clang8-release
           executor_name: ubuntu-disco
           target_is_linux: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8'
           install: true
           metrics: true
@@ -124,6 +109,8 @@ workflows:
           name: FIXME-linux-valgrind
           executor_name: ubuntu-disco
           target_is_linux: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_CXX_FLAGS=-DSANITIZE'
           test_params: '-j 4 -E "mbgl-node|gl-benchmark" -D ExperimentalMemCheck || true'
       - build-template:
@@ -139,18 +126,22 @@ workflows:
           name: qt5-linux-gcc5-release
           executor_name: ubuntu-disco
           target_is_linux: true
+          requires:
+            - sanity-checks
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 -DMBGL_WITH_QT=ON'
       - build-template:
           name: qt5-macos-gcc5-release
           executor_name: macos-11_1_0
           target_is_macos: true
           requires:
-            - qt5-linux-gcc5-release
+            - linux-gcc8-release
           config_params: '-G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMBGL_WITH_QT=ON -DCMAKE_PREFIX_PATH=$(echo /usr/local/Cellar/qt/5.*/lib/cmake)'
       - build-template:
           name: macos-xcode11-release
           executor_name: macos-11_1_0
           target_is_macos: true
+          requires:
+            - linux-gcc8-release
           config_params: '-G Ninja -DCMAKE_INSTALL_PREFIX=/tmp/workspace/install/$CIRCLE_JOB -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
           install: true
           metrics: true
@@ -168,8 +159,47 @@ workflows:
           name: ios-xcode11-release
           executor_name: macos-11_3_1
           target_is_macos: true
+          requires:
+            - linux-gcc8-release
           config_params: '-G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64e -DCMAKE_OSX_SYSROOT=iphoneos -DMBGL_WITH_IOS_CCACHE=ON'
           build_params: '--config Release'
+      - android-benchmark-runner:
+          requires:
+            - linux-gcc8-release
+      - android-render-test-runner:
+          requires:
+            - linux-gcc8-release
+      - android-unit-test-runner:
+          requires:
+            - linux-gcc8-release
+      - ios-render-test-runner:
+          requires:
+            - linux-gcc8-release
+      - ios-unit-test-runner:
+          requires:
+            - linux-gcc8-release
+      - ios-benchmark-runner:
+          requires:
+            - linux-gcc8-release
+      - baselines:
+          requires:
+            - android-arm64-v8a-release
+            - android-armeabi-v7a-release
+            - android-render-test-runner
+            - android-x86-release
+            - android-x86_64-release
+            - linux-clang8-release
+            - linux-gcc8-release
+            - macos-xcode11-release
+            - ios-render-test-runner
+      - trigger-pipeline:
+          requires:
+            - baselines
+          name: mapboxci
+          slug: mapbox/mapbox-gl-native-internal
+      - android-api-breakage:
+          requires:
+            - baselines
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
Now that we have clang-tidy with more checks enable,
make sure the code is tidy before we can move forward
with the pipeline.

Also cascade macOS bots, which are way slower after
basic compilation is done on Linux.