### PR TITLE
[build] Make the docker image smaller

### DIFF
--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -10,69 +10,78 @@ COPY etc/apt/sources.list /etc/apt
 
 RUN set -eu \
     && apt-get update \
-    && apt-get dist-upgrade -y
+    && apt-get dist-upgrade -y \
+    && apt-get autoremove --purge -y && apt-get clean
 
 # CI requirements
 RUN set -eu && apt-get install -y \
-    ca-certificates \
-    git \
-    gzip \
-    ssh \
-    tar
+      ca-certificates \
+      git \
+      gzip \
+      ssh \
+      tar \
+    && apt-get autoremove --purge -y && apt-get clean
 
 # Base dependencies
 RUN set -eu && apt-get install -y \
-    ccache \
-    clang-8 \
-    clang-format-8 \
-    clang-tidy-8 \
-    cmake \
-    fonts-noto \
-    g++-8 \
-    libc++-8-dev \
-    libc++abi-8-dev \
-    mesa-common-dev \
-    ninja-build \
-    nodejs \
-    npm \
-    pkg-config \
-    python3-pip \
-    software-properties-common \
-    valgrind \
-    xvfb
+      ccache \
+      clang-8 \
+      clang-format-8 \
+      clang-tidy-8 \
+      cmake \
+      fonts-noto \
+      g++-8 \
+      libc++-8-dev \
+      libc++abi-8-dev \
+      mesa-common-dev \
+      ninja-build \
+      nodejs \
+      npm \
+      pkg-config \
+      python3-pip \
+      python3-requests \
+      python3-github \
+      software-properties-common \
+      valgrind \
+      xvfb \
+    && apt-get autoremove --purge -y && apt-get clean
 
 RUN pip3 install cmake-format==0.5.5
 
 # Linux dependencies
 RUN set -eu && apt-get install -y \
-    libcurl4-openssl-dev \
-    libgl1-mesa-dev \
-    libgles2-mesa-dev \
-    libglfw3-dev \
-    libicu-dev \
-    libjpeg-turbo8-dev \
-    libpng-dev \
-    libuv1-dev \
-    zlib1g-dev
+      libcurl4-openssl-dev \
+      libgl1-mesa-dev \
+      libgles2-mesa-dev \
+      libglfw3-dev \
+      libicu-dev \
+      libjpeg-turbo8-dev \
+      libpng-dev \
+      libuv1-dev \
+      zlib1g-dev \
+    && apt-get autoremove --purge -y && apt-get clean
 
 # Qt dependencies
 RUN set -eu && apt-get install -y \
-    qdoc-qt5 \
-    qt5-default
+      qdoc-qt5 \
+      qt5-default \
+    && apt-get autoremove --purge -y && apt-get clean
 
 # Android dependencies
 RUN set -eu && apt-get install -y \
-    coreutils \
-    curl \
-    openjdk-8-jdk-headless \
-    unzip
+      coreutils \
+      curl \
+      openjdk-8-jdk-headless \
+      unzip \
+    && apt-get autoremove --purge -y && apt-get clean
 
 # Install old compilers
 RUN set -eu \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F \
     && add-apt-repository "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu xenial main" \
     && add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ xenial main universe" \
-    && apt-get install -y g++-5
+    && apt-get install -y g++-5 \
+    && apt-get autoremove --purge -y && apt-get clean
 
 # Install Android NDK
 RUN set -eu \
@@ -107,10 +116,9 @@ RUN set -eu \
 RUN set -eu \
     && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
-    && apt-get update -y && apt-get install google-cloud-sdk -y
+    && apt-get update -y \
+    && apt-get install google-cloud-sdk -y \
+    && apt-get autoremove --purge -y && apt-get clean
 
 # Configure ccache
 RUN set -eu && /usr/sbin/update-ccache-symlinks
-
-# Cleanup
-RUN set -eu && apt-get clean


### PR DESCRIPTION
It could be made even smaller by splitting Android and Linux builds, but so far CircleCI is handling it fine. The idea is to clear the cache per docker layer instead of clearing it in the end, otherwise clearing the cache has no effect.