### PR TITLE
[cp] Hillshade bucket fix for mapbox-gl-native-ios #240 to 1.5.0

### DIFF
--- a/src/mbgl/renderer/buckets/hillshade_bucket.cpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.cpp
@@ -31,14 +31,16 @@ void HillshadeBucket::upload(gfx::UploadPass& uploadPass) {
         return;
     }
 
-
     const PremultipliedImage* image = demdata.getImage();
     dem = uploadPass.createTexture(*image);
 
-    if (!segments.empty()) {
+    if (!vertices.empty()) {
         vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
+    }
+    if (!indices.empty()) {
         indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
     }
+
     uploaded = true;
 }
 


### PR DESCRIPTION
Cherry-pick #16362 `Hillshade bucket fix for mapbox-gl-native-ios #240` to release-v1.5.0

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
