### PR TITLE
[build] Bump googletest to 1.10.0

### DIFF
--- a/test/style/expression/expression.test.cpp
+++ b/test/style/expression/expression.test.cpp
@@ -79,28 +79,29 @@ TEST_P(ExpressionEqualityTest, ExpressionEquality) {
     EXPECT_TRUE(*expression_a1 != *expression_b);
 }
 
-INSTANTIATE_TEST_CASE_P(Expression, ExpressionEqualityTest, ::testing::ValuesIn([] {
-    std::vector<std::string> names;
-    const std::string ending = ".a.json";
+INSTANTIATE_TEST_SUITE_P(Expression, ExpressionEqualityTest, ::testing::ValuesIn([] {
+                             std::vector<std::string> names;
+                             const std::string ending = ".a.json";
 
-    const std::string style_directory = "test/fixtures/expression_equality";
-    DIR *dir = opendir(style_directory.c_str());
-    if (dir != nullptr) {
-        for (dirent *dp = nullptr; (dp = readdir(dir)) != nullptr;) {
-            const std::string name = dp->d_name;
+                             const std::string style_directory = "test/fixtures/expression_equality";
+                             DIR* dir = opendir(style_directory.c_str());
+                             if (dir != nullptr) {
+                                 for (dirent* dp = nullptr; (dp = readdir(dir)) != nullptr;) {
+                                     const std::string name = dp->d_name;
 #if ANDROID
-            // Android unit test uses number-format stub implementation so skip the tests
-            if (name.find("number-format") != std::string::npos) {
-                continue;
-            }
+                                     // Android unit test uses number-format stub implementation so skip the tests
+                                     if (name.find("number-format") != std::string::npos) {
+                                         continue;
+                                     }
 #endif
-            if (name.length() >= ending.length() && name.compare(name.length() - ending.length(), ending.length(), ending) == 0) {
-                names.push_back(name.substr(0, name.length() - ending.length()));
-            }
-        }
-        closedir(dir);
-    }
+                                     if (name.length() >= ending.length() &&
+                                         name.compare(name.length() - ending.length(), ending.length(), ending) == 0) {
+                                         names.push_back(name.substr(0, name.length() - ending.length()));
+                                     }
+                                 }
+                                 closedir(dir);
+                             }
 
-    EXPECT_GT(names.size(), 0u);
-    return names;
-}()));
+                             EXPECT_GT(names.size(), 0u);
+                             return names;
+                         }()));

--- a/test/style/style_parser.test.cpp
+++ b/test/style/style_parser.test.cpp
@@ -74,25 +74,26 @@ TEST_P(StyleParserTest, ParseStyle) {
     }
 }
 
-INSTANTIATE_TEST_CASE_P(StyleParser, StyleParserTest, ::testing::ValuesIn([] {
-    std::vector<std::string> names;
-    const std::string ending = ".info.json";
+INSTANTIATE_TEST_SUITE_P(StyleParser, StyleParserTest, ::testing::ValuesIn([] {
+                             std::vector<std::string> names;
+                             const std::string ending = ".info.json";
 
-    const std::string style_directory = "test/fixtures/style_parser";
-    DIR *dir = opendir(style_directory.c_str());
-    if (dir != nullptr) {
-        for (dirent *dp = nullptr; (dp = readdir(dir)) != nullptr;) {
-            const std::string name = dp->d_name;
-            if (name.length() >= ending.length() && name.compare(name.length() - ending.length(), ending.length(), ending) == 0) {
-                names.push_back(name.substr(0, name.length() - ending.length()));
-            }
-        }
-        closedir(dir);
-    }
+                             const std::string style_directory = "test/fixtures/style_parser";
+                             DIR *dir = opendir(style_directory.c_str());
+                             if (dir != nullptr) {
+                                 for (dirent *dp = nullptr; (dp = readdir(dir)) != nullptr;) {
+                                     const std::string name = dp->d_name;
+                                     if (name.length() >= ending.length() &&
+                                         name.compare(name.length() - ending.length(), ending.length(), ending) == 0) {
+                                         names.push_back(name.substr(0, name.length() - ending.length()));
+                                     }
+                                 }
+                                 closedir(dir);
+                             }
 
-    EXPECT_GT(names.size(), 0u);
-    return names;
-}()));
+                             EXPECT_GT(names.size(), 0u);
+                             return names;
+                         }()));
 
 TEST(StyleParser, FontStacks) {
     style::Parser parser;


### PR DESCRIPTION
Reason: gmock supports better syntax for defining mock methods.