### PR TITLE
[android] Fix onStyleImageMissing callback in Snapshotter not fired 

### DIFF
--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -76,6 +76,10 @@ public:
         rendererObserver->onDidFinishRenderingFrame(mode, repaintNeeded, placementChanged);
     }
 
+    void onStyleImageMissing(const std::string& id, StyleImageMissingCallback done) override {
+        rendererObserver->onStyleImageMissing(id, done);
+    }
+
     void setObserver(std::shared_ptr<RendererObserver> observer) {
         assert(observer);
         rendererObserver = std::move(observer);


### PR DESCRIPTION
Snapshotter will not fire onStyleImageMissing when image is missing because map_snapshotter not implement this function.
This pr add the implementation to let the out observer receive this event.

Test pr in android repo: https://github.com/mapbox/mapbox-gl-native-android/pull/317