### PR TITLE
When removing an image use the correct list ptr for presence verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
   The `symbolIntersectsTileEdges()` util in `mbgl::TilePlacement` now considers icon shift for the variable symbols with enabled icon-text-fit setting, thus providing more accurate results.
 
+- [core] Correctly log a warning instead of crashing when a non-existent image is attempted to be removed. ([#16391](https://github.com/mapbox/mapbox-gl-native/pull/16391))
+
 ## maps-v1.5.1
 
 ### 🐞 Bug fixes

--- a/src/mbgl/style/style_impl.cpp
+++ b/src/mbgl/style/style_impl.cpp
@@ -293,7 +293,7 @@ void Style::Impl::removeImage(const std::string& id) {
     auto newImages = makeMutable<ImageImpls>(*images);
     auto found =
         std::find_if(newImages->begin(), newImages->end(), [&id](const auto& image) { return image->id == id; });
-    if (found == images->end()) {
+    if (found == newImages->end()) {
         Log::Warning(Event::General, "Image '%s' is not present in style, cannot remove", id.c_str());
         return;
     }


### PR DESCRIPTION
This fixes an issues where calling `removeImage` would crash if the image was not present and the original images list was not empty.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [x] apply `needs changelog` label if a changelog is needed (remove label when added)
