### PR TITLE
Use single threaded fixture log

### DIFF
--- a/metrics/binary-size/macos-xcode11/metrics.json
+++ b/metrics/binary-size/macos-xcode11/metrics.json
@@ -3,17 +3,17 @@
         [
             "mbgl-glfw",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-glfw",
-            5152840
+            5198016
         ],
         [
             "mbgl-offline",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-offline",
-            4385280
+            4430448
         ],
         [
             "mbgl-render",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-render",
-            4999184
+            5044352
         ]
     ]
 }

--- a/test/api/api_misuse.test.cpp
+++ b/test/api/api_misuse.test.cpp
@@ -15,8 +15,7 @@ using namespace mbgl;
 
 
 TEST(API, RenderWithoutCallback) {
-    auto log = new FixtureLogObserver();
-    Log::setObserver(std::unique_ptr<Log::Observer>(log));
+    FixtureLog log;
 
     util::RunLoop loop;
 
@@ -37,5 +36,5 @@ TEST(API, RenderWithoutCallback) {
         "StillImageCallback not set",
     };
 
-    EXPECT_EQ(log->count(logMessage), 1u);
+    EXPECT_EQ(log.count(logMessage), 1u);
 }


### PR DESCRIPTION
Use single threaded fixture log to avoid unit test flakiness.

Fixes: https://github.com/mapbox/mapbox-gl-native-team/issues/336

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR