### PR TITLE
[build] Ignore location indicator on iOS until we port to ::gfx

### DIFF
--- a/metrics/ignores/platform-ios.json
+++ b/metrics/ignores/platform-ios.json
@@ -9,5 +9,19 @@
     "render-tests/regressions/mapbox-gl-js#5911a": "Needs to be investigated and fixed.",
     "render-tests/text-field/formatted-images": "Needs to be investigated and fixed.",
     "render-tests/symbol-visibility/visible": "Needs to be investigated and fixed.",
-    "location_indicator/image_pixel_ratio": "Renders a black square when loading from spritesheet. Needs to be investigated and fixed."
+    "location_indicator/dateline": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/default": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/image_pixel_ratio": "Renders a black square when loading from spritesheet. Needs to be investigated and fixed.",
+    "location_indicator/no_radius_border": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/no_radius_fill": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/no_textures": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/one_texture": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/rotated": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/tilted": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/tilted_texture_shift": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/tilted_texture_shift_bottom_left": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/tilted_texture_shift_bottom_right": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/tilted_texture_shift_top_left": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/tilted_texture_shift_top_right": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/two_textures": "https://github.com/mapbox/mapbox-gl-native/issues/16401"
 }


### PR DESCRIPTION
Remove the ignore after https://github.com/mapbox/mapbox-gl-native/issues/16401 is done.