### PR TITLE
Add name "custom" to Custom Layer's typeInfoCustom

### DIFF
--- a/src/mbgl/gl/custom_layer.cpp
+++ b/src/mbgl/gl/custom_layer.cpp
@@ -7,7 +7,7 @@ namespace mbgl {
 namespace style {
 
 namespace {
-const LayerTypeInfo typeInfoCustom{"",
+const LayerTypeInfo typeInfoCustom{"custom",
                                    LayerTypeInfo::Source::NotRequired,
                                    LayerTypeInfo::Pass3D::NotRequired,
                                    LayerTypeInfo::Layout::NotRequired,


### PR DESCRIPTION
This will make the case of an empty name in the LayerTypeInfo effectively an error, that can be logged.