### PR TITLE
Android and iOS benchmark changes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -426,7 +426,7 @@ commands:
     steps:
       - run:
           name: Run iOS Test App on Firebase
-          no_output_timeout: 20m
+          no_output_timeout: 30m
           command: |
             if [[ -n "${GCLOUD_SERVICE_ACCOUNT_JSON_IOS}" ]]; then
               # arrange files in a way Firebase expects it, and package them in a zip file
@@ -437,7 +437,7 @@ commands:
               gcloud firebase test ios models list
               gcloud firebase test ios run \
                 --test testapp.zip \
-                --device model=iphone11,version=13.3,locale=en,orientation=portrait --xcode-version=11.3.1 --timeout 20m \
+                --device model=iphone11,version=13.3,locale=en,orientation=portrait --xcode-version=11.3.1 --timeout 30m \
                 --verbosity=debug --no-record-video --results-dir ios-test-app-${CIRCLE_BUILD_NUM}
             fi
   upload-coverage-results:
@@ -579,13 +579,13 @@ jobs:
       - login-google-cloud-platform
       - run:
           name: Run BenchmarkRunner on Firebase
-          no_output_timeout: 20m
+          no_output_timeout: 30m
           command: |
             gcloud firebase test android models list
             gcloud firebase test android run --type instrumentation \
               --app benchmark/android/app/build/outputs/apk/release/app-release.apk \
               --test benchmark/android/app/build/outputs/apk/androidTest/release/app-release-androidTest.apk \
-              --device-ids flame --os-version-ids 29 --locales en --orientations portrait --timeout 20m \
+              --device-ids flame --os-version-ids 29 --locales en --orientations portrait --timeout 30m \
               --directories-to-pull /sdcard/benchmark/results --results-dir benchmark-${CIRCLE_BUILD_NUM} \
               --no-record-video --no-performance-metrics
       - run:

--- a/scripts/check_benchmark_results.sh
+++ b/scripts/check_benchmark_results.sh
@@ -4,12 +4,12 @@
 # check_benchmark_results.sh <baseline> <results> <comparison report in txt> <comparison report in html>
 
 # Benchmark comparison script uses a hard-coded 5% threshold by default, but it causes random failures
-# Increase the threshold to 10%
+# Increase the threshold to 15%
 
 if [ "$(uname)" == "Darwin" ]; then
-  sed -i '' s/"if res > 0.05"/"if res > 0.1"/ $PWD/vendor/benchmark/tools/gbench/report.py
+  sed -i '' s/"if res > 0.05"/"if res > 0.15"/ $PWD/vendor/benchmark/tools/gbench/report.py
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  sed -i s/"if res > 0.05"/"if res > 0.1"/ $PWD/vendor/benchmark/tools/gbench/report.py
+  sed -i s/"if res > 0.05"/"if res > 0.15"/ $PWD/vendor/benchmark/tools/gbench/report.py
 fi
 
 # Run the bencmark comparison
@@ -21,7 +21,7 @@ tests=`fgrep mean $3 | cut -c1-85 | grep 91m`
 if [ -z "$tests" ]
 then
       echo "" >> $3
-      echo "PASSED, all benchmarks within 10% threshold" >> $3
+      echo "PASSED, all benchmarks within 15% threshold" >> $3
 
       ansi2html < $3 > $4
       exit 0
@@ -29,7 +29,7 @@ else
       test_names=`fgrep mean $3 | cut -c1-85 | grep 91m | cut -f1 -d' '`
 
       echo "" >> $3
-      echo "FAILED, following benchmarks are not within 10% threshold:" >> $3
+      echo "FAILED, following benchmarks are not within 15% threshold:" >> $3
       echo "" >> $3
       for t in $test_names;
       do


### PR DESCRIPTION
- Increase the benchmark runner timeout to 30 minutes on Android and iOS
- Increase benchmark threshold to 15%