### PR TITLE
Fix segfault resulting from an invalid geometry.

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -696,10 +696,10 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
     } else if (type == FeatureType::LineString) {
         for (const auto& line : feature.geometry) {
             // Skip invalid LineStrings.
-            if (line.size() > 0) {
-              Anchor anchor(line[0].x, line[0].y, 0, minScale);
-              addSymbolInstance(anchor, createSymbolInstanceSharedData(line));
-            }
+            if (line.empty()) continue;
+
+            Anchor anchor(line[0].x, line[0].y, 0, minScale);
+            addSymbolInstance(anchor, createSymbolInstanceSharedData(line));
         }
     } else if (type == FeatureType::Point) {
         for (const auto& points : feature.geometry) {

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -695,8 +695,11 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
         }
     } else if (type == FeatureType::LineString) {
         for (const auto& line : feature.geometry) {
-            Anchor anchor(line[0].x, line[0].y, 0, minScale);
-            addSymbolInstance(anchor, createSymbolInstanceSharedData(line));
+            // Skip invalid LineStrings.
+            if (line.size() > 0) {
+              Anchor anchor(line[0].x, line[0].y, 0, minScale);
+              addSymbolInstance(anchor, createSymbolInstanceSharedData(line));
+            }
         }
     } else if (type == FeatureType::Point) {
         for (const auto& points : feature.geometry) {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] apply `needs changelog` label if a changelog is needed (remove label when added)

The current implementation of `SymbolLayout::addFeature` can segfault on an invalid LineString (containing a `Line` with no members). This skips adding invalid geometries (i.e., LineStrings) when encountered.

This is a trivial bug to verify based on reading the code. I'm happy to add a test case, if someone can point me to the right place.
