### PR TITLE
[build] Enable clang-analyzer checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,14 @@
 Checks: >
     -*,
+    android-*,
+    boost-*,
     bugprone-*,
+    clang-analyzer-core*
+    clang-analyzer-cplusplus*,
+    clang-analyzer-deadcode*,
+    clang-analyzer-optin.cplusplus*,
+    clang-analyzer-optin.performance.Padding,
+    clang-analyzer-security*,
     clang-diagnostic-*,
     google-*,
     misc-*,

--- a/src/mbgl/style/expression/expression.cpp
+++ b/src/mbgl/style/expression/expression.cpp
@@ -16,14 +16,13 @@ public:
     GeoJSONFeature(const Feature& feature_, const CanonicalTileID& canonical) : feature(feature_) {
         geometry = convertGeometry(feature.geometry, canonical);
         // https://github.com/mapbox/geojson-vt-cpp/issues/44
-        if (getType() == FeatureType::Polygon) {
+        if (getTypeImpl() == FeatureType::Polygon) {
             geometry = fixupPolygons(*geometry);
         }
     }
 
-    FeatureType getType() const override  {
-        return apply_visitor(ToFeatureType(), feature.geometry);
-    }
+    FeatureType getType() const override { return getTypeImpl(); }
+
     const PropertyMap& getProperties() const override { return feature.properties; }
     FeatureIdentifier getID() const override { return feature.id; }
     optional<mbgl::Value> getValue(const std::string& key) const override {
@@ -38,6 +37,9 @@ public:
         geometry = GeometryCollection();
         return *geometry;
     }
+
+private:
+    FeatureType getTypeImpl() const { return apply_visitor(ToFeatureType(), feature.geometry); }
 };
 
 EvaluationResult Expression::evaluate(optional<float> zoom,

--- a/src/mbgl/util/io.cpp
+++ b/src/mbgl/util/io.cpp
@@ -15,7 +15,7 @@ IOException::IOException(int err, const std::string& msg)
 }
 
 void write_file(const std::string &filename, const std::string &data) {
-    FILE *fd = fopen(filename.c_str(), "wb");
+    FILE *fd = fopen(filename.c_str(), "wbe");
     if (fd) {
         fwrite(data.data(), sizeof(std::string::value_type), data.size(), fd);
         fclose(fd);


### PR DESCRIPTION
Sadly they will make clang-tidy a lot slower, but they are useful to catch hard to find bugs.