### PR TITLE
[core] Fix -Werror={pessimizing,redundant}-move from GCC 9

### DIFF
--- a/platform/default/src/mbgl/storage/asset_file_source.cpp
+++ b/platform/default/src/mbgl/storage/asset_file_source.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource,
 
     impl->actor().invoke(&Impl::request, resource.url, req->actor());
 
-    return std::move(req);
+    return req;
 }
 
 bool AssetFileSource::canRequest(const Resource& resource) const {

--- a/platform/default/src/mbgl/storage/database_file_source.cpp
+++ b/platform/default/src/mbgl/storage/database_file_source.cpp
@@ -175,7 +175,7 @@ DatabaseFileSource::~DatabaseFileSource() = default;
 std::unique_ptr<AsyncRequest> DatabaseFileSource::request(const Resource& resource, Callback callback) {
     auto req = std::make_unique<FileSourceRequest>(std::move(callback));
     impl->actor().invoke(&DatabaseFileSourceThread::request, resource, req->actor());
-    return std::move(req);
+    return req;
 }
 
 void DatabaseFileSource::forward(const Resource& res, const Response& response, std::function<void()> callback) {

--- a/platform/default/src/mbgl/storage/local_file_source.cpp
+++ b/platform/default/src/mbgl/storage/local_file_source.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<AsyncRequest> LocalFileSource::request(const Resource& resource,
 
     impl->actor().invoke(&Impl::request, resource.url, req->actor());
 
-    return std::move(req);
+    return req;
 }
 
 bool LocalFileSource::canRequest(const Resource& resource) const {

--- a/platform/default/src/mbgl/storage/main_resource_loader.cpp
+++ b/platform/default/src/mbgl/storage/main_resource_loader.cpp
@@ -151,7 +151,7 @@ public:
             actorRef.invoke(&MainResourceLoaderThread::cancel, req);
         });
         thread->actor().invoke(&MainResourceLoaderThread::request, req.get(), resource, req->actor());
-        return std::move(req);
+        return req;
     }
 
     bool canRequest(const Resource& resource) const {

--- a/platform/default/src/mbgl/storage/online_file_source.cpp
+++ b/platform/default/src/mbgl/storage/online_file_source.cpp
@@ -302,7 +302,7 @@ public:
         req->onCancel(
             [actorRef = thread->actor(), req = req.get()]() { actorRef.invoke(&OnlineFileSourceThread::cancel, req); });
         thread->actor().invoke(&OnlineFileSourceThread::request, req.get(), std::move(res), req->actor());
-        return std::move(req);
+        return req;
     }
 
     void pause() { thread->pause(); }

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -72,9 +72,7 @@ public:
                 (programs::gl::shaderSource() + programs::gl::fragmentPreludeOffset),
                 (programs::gl::shaderSource() + fragmentOffset)
             };
-            auto result = std::make_unique<Instance>(context, vertexSource, fragmentSource);
-
-            return std::move(result);
+            return std::make_unique<Instance>(context, vertexSource, fragmentSource);
         }
 
         UniqueProgram program;

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -17,8 +17,7 @@ std::unique_ptr<gfx::Context> RendererBackend::createContext() {
     result->enableDebugging();
     result->initializeExtensions(
             std::bind(&RendererBackend::getExtensionFunctionPointer, this, std::placeholders::_1));
-    // Needs move to placate GCC 4.9
-    return std::move(result);
+    return result;
 }
 
 PremultipliedImage RendererBackend::readFramebuffer(const Size& size) {

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -73,7 +73,7 @@ inline Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> createLayout(
         layout->get<IconPitchAlignment>() = layout->get<IconRotationAlignment>();
     }
 
-    return std::move(layout);
+    return layout;
 }
 
 } // namespace

--- a/src/mbgl/style/conversion/layer.cpp
+++ b/src/mbgl/style/conversion/layer.cpp
@@ -92,7 +92,7 @@ optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operator()(c
         return nullopt;
     }
 
-    return std::move(layer);
+    return layer;
 }
 
 } // namespace conversion

--- a/test/src/mbgl/test/stub_file_source.cpp
+++ b/test/src/mbgl/test/stub_file_source.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<AsyncRequest> StubFileSource::request(const Resource& resource, 
     } else {
         pending.emplace(req.get(), std::make_tuple(resource, response, callback));
     }
-    return std::move(req);
+    return req;
 }
 
 void StubFileSource::remove(AsyncRequest* req) {


### PR DESCRIPTION
Fix warning-as-erros from GCC 9 related to either redundant or non-optimal moves.