### PR TITLE
[core] Introduce Source::setMinimumTileUpdateInterval API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## master
 
+### ✨ New features
+
+- [core] Introduce Source::setMinimumTileUpdateInterval API ([#16416](https://github.com/mapbox/mapbox-gl-native/pull/16416))
+
+  The `Source::setMinimumTileUpdateInterval(Duration)` method sets the minimum tile update interval, which is used to throttle the tile update network requests.
+
+  The corresponding `Source::getMinimumTileUpdateInterval()` getter is added too.
+
+  Default minimum tile update interval value is `Duration::zero()`.
+
 ## maps-v1.6.0-rc.1
 
 ### ✨ New features

--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -95,6 +95,7 @@ public:
     optional<Timestamp> priorExpires = {};
     optional<std::string> priorEtag = {};
     std::shared_ptr<const std::string> priorData;
+    Duration minimumUpdateInterval{Duration::zero()};
 };
 
 inline bool Resource::hasLoadingMethod(Resource::LoadingMethod method) const {

--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <mbgl/util/noncopyable.hpp>
-#include <mbgl/util/optional.hpp>
-#include <mbgl/util/immutable.hpp>
 #include <mbgl/style/types.hpp>
+#include <mbgl/util/chrono.hpp>
+#include <mbgl/util/immutable.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <mapbox/std/weak.hpp>
 #include <mapbox/util/type_wrapper.hpp>
@@ -40,8 +40,11 @@ struct LayerTypeInfo;
  *
  *     auto vectorSource = std::make_unique<VectorSource>("my-vector-source");
  */
-class Source : public mbgl::util::noncopyable {
+class Source {
 public:
+    Source(const Source&) = delete;
+    Source& operator=(const Source&) = delete;
+
     virtual ~Source();
 
     // Check whether this source is of the given subtype.
@@ -75,6 +78,14 @@ public:
     virtual void loadDescription(FileSource&) = 0;
     void setPrefetchZoomDelta(optional<uint8_t> delta) noexcept;
     optional<uint8_t> getPrefetchZoomDelta() const noexcept;
+
+    // If the given source supports loading tiles from a server,
+    // sets the minimum tile update interval, which is used to
+    // throttle the tile update network requests.
+    //
+    // Default value is `Duration::zero()`.
+    void setMinimumTileUpdateInterval(Duration) noexcept;
+    Duration getMinimumTileUpdateInterval() const noexcept;
 
     // Sets a limit for how much a parent tile can be overscaled.
     //

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -33,15 +33,13 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
         needsRendering,
         needsRelayout,
         parameters,
-        SourceType::Annotations,
+        *baseImpl,
         util::tileSize,
         // Zoom level 16 is typically sufficient for annotations.
         // See https://github.com/mapbox/mapbox-gl-native/issues/10197
         {0, 16},
         optional<LatLngBounds>{},
-        [&](const OverscaledTileID& tileID) { return std::make_unique<AnnotationTile>(tileID, parameters); },
-        baseImpl->getPrefetchZoomDelta(),
-        baseImpl->getMaxOverscaleFactorForParentTiles());
+        [&](const OverscaledTileID& tileID) { return std::make_unique<AnnotationTile>(tileID, parameters); });
 }
 
 std::unordered_map<std::string, std::vector<Feature>>

--- a/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
+++ b/src/mbgl/renderer/sources/render_custom_geometry_source.cpp
@@ -40,21 +40,18 @@ void RenderCustomGeometrySource::update(Immutable<style::Source::Impl> baseImpl_
         return;
     }
 
-    tilePyramid.update(
-        layers,
-        needsRendering,
-        needsRelayout,
-        parameters,
-        SourceType::CustomVector,
-        util::tileSize,
-        impl().getZoomRange(),
-        {},
-        [&](const OverscaledTileID& tileID) {
-            return std::make_unique<CustomGeometryTile>(
-                tileID, impl().id, parameters, impl().getTileOptions(), *tileLoader);
-        },
-        baseImpl->getPrefetchZoomDelta(),
-        baseImpl->getMaxOverscaleFactorForParentTiles());
+    tilePyramid.update(layers,
+                       needsRendering,
+                       needsRelayout,
+                       parameters,
+                       *baseImpl,
+                       util::tileSize,
+                       impl().getZoomRange(),
+                       {},
+                       [&](const OverscaledTileID& tileID) {
+                           return std::make_unique<CustomGeometryTile>(
+                               tileID, impl().id, parameters, impl().getTileOptions(), *tileLoader);
+                       });
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/sources/render_geojson_source.cpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -106,20 +106,17 @@ void RenderGeoJSONSource::update(Immutable<style::Source::Impl> baseImpl_,
 
     if (!data_) return;
 
-    tilePyramid.update(
-        layers,
-        needsRendering,
-        needsRelayout,
-        parameters,
-        SourceType::GeoJSON,
-        util::tileSize,
-        impl().getZoomRange(),
-        optional<LatLngBounds>{},
-        [&, data_](const OverscaledTileID& tileID) {
-            return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data_);
-        },
-        baseImpl->getPrefetchZoomDelta(),
-        baseImpl->getMaxOverscaleFactorForParentTiles());
+    tilePyramid.update(layers,
+                       needsRendering,
+                       needsRelayout,
+                       parameters,
+                       *baseImpl,
+                       util::tileSize,
+                       impl().getZoomRange(),
+                       optional<LatLngBounds>{},
+                       [&, data_](const OverscaledTileID& tileID) {
+                           return std::make_unique<GeoJSONTile>(tileID, impl().id, parameters, data_);
+                       });
 }
 
 mapbox::util::variant<Value, FeatureCollection>

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -32,13 +32,11 @@ void RenderRasterDEMSource::updateInternal(const Tileset& tileset,
         needsRendering,
         needsRelayout,
         parameters,
-        SourceType::RasterDEM,
+        *baseImpl,
         impl().getTileSize(),
         tileset.zoomRange,
         tileset.bounds,
-        [&](const OverscaledTileID& tileID) { return std::make_unique<RasterDEMTile>(tileID, parameters, tileset); },
-        baseImpl->getPrefetchZoomDelta(),
-        baseImpl->getMaxOverscaleFactorForParentTiles());
+        [&](const OverscaledTileID& tileID) { return std::make_unique<RasterDEMTile>(tileID, parameters, tileset); });
     algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 

--- a/src/mbgl/renderer/sources/render_raster_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_source.cpp
@@ -30,13 +30,11 @@ void RenderRasterSource::updateInternal(const Tileset& tileset,
         needsRendering,
         needsRelayout,
         parameters,
-        SourceType::Raster,
+        *baseImpl,
         impl().getTileSize(),
         tileset.zoomRange,
         tileset.bounds,
-        [&](const OverscaledTileID& tileID) { return std::make_unique<RasterTile>(tileID, parameters, tileset); },
-        baseImpl->getPrefetchZoomDelta(),
-        baseImpl->getMaxOverscaleFactorForParentTiles());
+        [&](const OverscaledTileID& tileID) { return std::make_unique<RasterTile>(tileID, parameters, tileset); });
     algorithm::updateTileMasks(tilePyramid.getRenderedTiles());
 }
 

--- a/src/mbgl/renderer/sources/render_vector_source.cpp
+++ b/src/mbgl/renderer/sources/render_vector_source.cpp
@@ -21,20 +21,17 @@ void RenderVectorSource::updateInternal(const Tileset& tileset,
                                         const bool needsRendering,
                                         const bool needsRelayout,
                                         const TileParameters& parameters) {
-    tilePyramid.update(
-        layers,
-        needsRendering,
-        needsRelayout,
-        parameters,
-        SourceType::Vector,
-        util::tileSize,
-        tileset.zoomRange,
-        tileset.bounds,
-        [&](const OverscaledTileID& tileID) {
-            return std::make_unique<VectorTile>(tileID, baseImpl->id, parameters, tileset);
-        },
-        baseImpl->getPrefetchZoomDelta(),
-        baseImpl->getMaxOverscaleFactorForParentTiles());
+    tilePyramid.update(layers,
+                       needsRendering,
+                       needsRelayout,
+                       parameters,
+                       *baseImpl,
+                       util::tileSize,
+                       tileset.zoomRange,
+                       tileset.bounds,
+                       [&](const OverscaledTileID& tileID) {
+                           return std::make_unique<VectorTile>(tileID, baseImpl->id, parameters, tileset);
+                       });
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -53,13 +53,11 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
                          const bool needsRendering,
                          const bool needsRelayout,
                          const TileParameters& parameters,
-                         const SourceType type,
+                         const style::Source::Impl& sourceImpl,
                          const uint16_t tileSize,
                          const Range<uint8_t> zoomRange,
                          optional<LatLngBounds> bounds,
-                         std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile,
-                         const optional<uint8_t>& sourcePrefetchZoomDelta,
-                         const optional<uint8_t>& maxParentTileOverscaleFactor) {
+                         std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile) {
     // If we need a relayout, abandon any cached tiles; they're now stale.
     if (needsRelayout) {
         cache.clear();
@@ -86,10 +84,14 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
 
     handleWrapJump(parameters.transformState.getLatLng().longitude());
 
+    const auto type = sourceImpl.type;
     // Determine the overzooming/underzooming amounts and required tiles.
     int32_t overscaledZoom = util::coveringZoomLevel(parameters.transformState.getZoom(), type, tileSize);
     int32_t tileZoom = overscaledZoom;
     int32_t panZoom = zoomRange.max;
+
+    const optional<uint8_t>& sourcePrefetchZoomDelta = sourceImpl.getPrefetchZoomDelta();
+    const optional<uint8_t>& maxParentTileOverscaleFactor = sourceImpl.getMaxOverscaleFactorForParentTiles();
 
     std::vector<OverscaledTileID> idealTiles;
     std::vector<OverscaledTileID> panTiles;

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <mbgl/tile/tile_id.hpp>
-#include <mbgl/tile/tile_observer.hpp>
+#include <mbgl/style/layer_properties.hpp>
+#include <mbgl/style/source_impl.hpp>
+#include <mbgl/style/types.hpp>
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/tile/tile_cache.hpp>
-#include <mbgl/style/types.hpp>
-#include <mbgl/style/layer_properties.hpp>
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/tile/tile_observer.hpp>
 
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/feature.hpp>
@@ -37,13 +38,11 @@ public:
                 bool needsRendering,
                 bool needsRelayout,
                 const TileParameters&,
-                style::SourceType type,
+                const style::Source::Impl&,
                 uint16_t tileSize,
                 Range<uint8_t> zoomRange,
                 optional<LatLngBounds> bounds,
-                std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile,
-                const optional<uint8_t>& sourcePrefetchZoomDelta,
-                const optional<uint8_t>& maxParentTileOverscaleFactor);
+                std::function<std::unique_ptr<Tile>(const OverscaledTileID&)> createTile);
 
     const std::map<UnwrappedTileID, std::reference_wrapper<Tile>>& getRenderedTiles() const { return renderedTiles; }
     Tile* getTile(const OverscaledTileID&);

--- a/src/mbgl/style/custom_tile_loader.hpp
+++ b/src/mbgl/style/custom_tile_loader.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <mbgl/actor/actor_ref.hpp>
 #include <mbgl/style/sources/custom_geometry_source.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/geojson.hpp>
-#include <mbgl/actor/actor_ref.hpp>
 
 #include <map>
 #include <mutex>
@@ -14,8 +14,10 @@ class CustomGeometryTile;
 
 namespace style {
 
-class CustomTileLoader : private util::noncopyable {
+class CustomTileLoader {
 public:
+    CustomTileLoader(const CustomTileLoader&) = delete;
+    CustomTileLoader& operator=(const CustomTileLoader&) = delete;
 
     using OverscaledIDFunctionTuple = std::tuple<uint8_t, int16_t, ActorRef<CustomGeometryTile>>;
 

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -43,6 +43,18 @@ optional<uint8_t> Source::getPrefetchZoomDelta() const noexcept {
     return baseImpl->getPrefetchZoomDelta();
 }
 
+void Source::setMinimumTileUpdateInterval(Duration interval) noexcept {
+    if (getMinimumTileUpdateInterval() == interval) return;
+    auto newImpl = createMutable();
+    newImpl->setMinimumTileUpdateInterval(interval);
+    baseImpl = std::move(newImpl);
+    observer->onSourceChanged(*this);
+}
+
+Duration Source::getMinimumTileUpdateInterval() const noexcept {
+    return baseImpl->getMinimumTileUpdateInterval();
+}
+
 void Source::setMaxOverscaleFactorForParentTiles(optional<uint8_t> overscaleFactor) noexcept {
     if (getMaxOverscaleFactorForParentTiles() == overscaleFactor) return;
     auto newImpl = createMutable();

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -22,15 +22,19 @@ public:
     virtual optional<std::string> getAttribution() const = 0;
     void setPrefetchZoomDelta(optional<uint8_t> delta) noexcept;
     optional<uint8_t> getPrefetchZoomDelta() const noexcept;
+    void setMinimumTileUpdateInterval(Duration interval) { minimumTileUpdateInterval = interval; }
+    Duration getMinimumTileUpdateInterval() const { return minimumTileUpdateInterval; }
     void setMaxOverscaleFactorForParentTiles(optional<uint8_t> overscaleFactor) noexcept;
     optional<uint8_t> getMaxOverscaleFactorForParentTiles() const noexcept;
 
     const SourceType type;
     const std::string id;
-    optional<uint8_t> prefetchZoomDelta;
-    optional<uint8_t> maxOverscaleFactor;
 
 protected:
+    optional<uint8_t> prefetchZoomDelta;
+    optional<uint8_t> maxOverscaleFactor;
+    Duration minimumTileUpdateInterval{Duration::zero()};
+
     Impl(SourceType, std::string);
     Impl(const Impl&) = default;
 };

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -122,4 +122,8 @@ void RasterDEMTile::setNecessity(TileNecessity necessity) {
     loader.setNecessity(necessity);
 }
 
+void RasterDEMTile::setMinimumUpdateInterval(Duration interval) {
+    loader.setMinimumUpdateInterval(interval);
+}
+
 } // namespace mbgl

--- a/src/mbgl/tile/raster_dem_tile.hpp
+++ b/src/mbgl/tile/raster_dem_tile.hpp
@@ -67,7 +67,8 @@ public:
     ~RasterDEMTile() override;
 
     std::unique_ptr<TileRenderData> createRenderData() override;
-    void setNecessity(TileNecessity) final;
+    void setNecessity(TileNecessity) override;
+    void setMinimumUpdateInterval(Duration) override;
 
     void setError(std::exception_ptr);
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -78,4 +78,8 @@ void RasterTile::setNecessity(TileNecessity necessity) {
     loader.setNecessity(necessity);
 }
 
+void RasterTile::setMinimumUpdateInterval(Duration interval) {
+    loader.setMinimumUpdateInterval(interval);
+}
+
 } // namespace mbgl

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -23,7 +23,8 @@ public:
     ~RasterTile() override;
 
     std::unique_ptr<TileRenderData> createRenderData() override;
-    void setNecessity(TileNecessity) final;
+    void setNecessity(TileNecessity) override;
+    void setMinimumUpdateInterval(Duration) override;
 
     void setError(std::exception_ptr);
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -52,6 +52,7 @@ public:
     void setObserver(TileObserver* observer);
 
     virtual void setNecessity(TileNecessity) {}
+    virtual void setMinimumUpdateInterval(Duration) {}
 
     // Mark this tile as no longer needed and cancel any pending work.
     virtual void cancel();

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -22,16 +22,8 @@ public:
                const Tileset&);
     ~TileLoader();
 
-    void setNecessity(TileNecessity newNecessity) {
-        if (newNecessity != necessity) {
-            necessity = newNecessity;
-            if (necessity == TileNecessity::Required) {
-                makeRequired();
-            } else {
-                makeOptional();
-            }
-        }
-    }
+    void setNecessity(TileNecessity newNecessity);
+    void setMinimumUpdateInterval(Duration);
 
 private:
     // called when the tile is one of the ideal tiles that we want to show definitely. the tile source
@@ -48,11 +40,16 @@ private:
     void loadedData(const Response&);
     void loadFromNetwork();
 
+    bool hasPendingNetworkRequest() const {
+        return resource.loadingMethod == Resource::LoadingMethod::NetworkOnly && request;
+    }
+
     T& tile;
     TileNecessity necessity;
     Resource resource;
     std::shared_ptr<FileSource> fileSource;
     std::unique_ptr<AsyncRequest> request;
+    Duration minimumUpdateInterval{Duration::zero()};
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -57,6 +57,30 @@ template <typename T>
 TileLoader<T>::~TileLoader() = default;
 
 template <typename T>
+void TileLoader<T>::setNecessity(TileNecessity newNecessity) {
+    if (newNecessity != necessity) {
+        necessity = newNecessity;
+        if (necessity == TileNecessity::Required) {
+            makeRequired();
+        } else {
+            makeOptional();
+        }
+    }
+}
+
+template <typename T>
+void TileLoader<T>::setMinimumUpdateInterval(Duration interval) {
+    if (minimumUpdateInterval != interval) {
+        minimumUpdateInterval = interval;
+        if (hasPendingNetworkRequest()) {
+            // Update the pending request.
+            request.reset();
+            loadFromNetwork();
+        }
+    }
+}
+
+template <typename T>
 void TileLoader<T>::loadFromCache() {
     assert(!request);
     if (!fileSource) {
@@ -99,7 +123,7 @@ void TileLoader<T>::makeRequired() {
 
 template <typename T>
 void TileLoader<T>::makeOptional() {
-    if (resource.loadingMethod == Resource::LoadingMethod::NetworkOnly && request) {
+    if (hasPendingNetworkRequest()) {
         // Abort the current request, but only when we know that we're specifically querying for a
         // network resource only.
         request.reset();
@@ -135,6 +159,7 @@ void TileLoader<T>::loadFromNetwork() {
     // Instead of using Resource::LoadingMethod::All, we're first doing a CacheOnly, and then a
     // NetworkOnly request.
     resource.loadingMethod = Resource::LoadingMethod::NetworkOnly;
+    resource.minimumUpdateInterval = minimumUpdateInterval;
     request = fileSource->request(resource, [this](const Response& res) { loadedData(res); });
 }
 

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -16,6 +16,10 @@ void VectorTile::setNecessity(TileNecessity necessity) {
     loader.setNecessity(necessity);
 }
 
+void VectorTile::setMinimumUpdateInterval(Duration interval) {
+    loader.setMinimumUpdateInterval(interval);
+}
+
 void VectorTile::setMetadata(optional<Timestamp> modified_, optional<Timestamp> expires_) {
     modified = std::move(modified_);
     expires = std::move(expires_);

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -16,6 +16,7 @@ public:
                const Tileset&);
 
     void setNecessity(TileNecessity) final;
+    void setMinimumUpdateInterval(Duration interval) final;
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);
     void setData(const std::shared_ptr<const std::string>& data);
 

--- a/src/mbgl/util/http_timeout.cpp
+++ b/src/mbgl/util/http_timeout.cpp
@@ -32,11 +32,11 @@ Duration errorRetryTimeout(Response::Error::Reason failedRequestReason, uint32_t
 Duration expirationTimeout(optional<Timestamp> expires, uint32_t expiredRequests) {
     if (expiredRequests) {
         return Seconds(1u << std::min(expiredRequests - 1, 31u));
-    } else if (expires) {
-        return std::max(Seconds::zero(), *expires - util::now());
-    } else {
-        return Duration::max();
     }
+    if (expires) {
+        return std::max(Seconds::zero(), *expires - util::now());
+    }
+    return Duration::max();
 }
 
 } // namespace http

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -767,18 +767,15 @@ public:
                         const bool needsRendering,
                         const bool needsRelayout,
                         const TileParameters& parameters) override {
-        tilePyramid.update(
-            layers,
-            needsRendering,
-            needsRelayout,
-            parameters,
-            SourceType::Vector,
-            util::tileSize,
-            tileset.zoomRange,
-            tileset.bounds,
-            [&](const OverscaledTileID& tileID) { return std::make_unique<FakeTile>(*this, tileID); },
-            baseImpl->getPrefetchZoomDelta(),
-            baseImpl->getMaxOverscaleFactorForParentTiles());
+        tilePyramid.update(layers,
+                           needsRendering,
+                           needsRelayout,
+                           parameters,
+                           *baseImpl,
+                           util::tileSize,
+                           tileset.zoomRange,
+                           tileset.bounds,
+                           [&](const OverscaledTileID& tileID) { return std::make_unique<FakeTile>(*this, tileID); });
     }
 
     const optional<Tileset>& getTileset() const override {


### PR DESCRIPTION
The `Source::setMinimumTileUpdateInterval(Duration)` method sets the minimum tile update interval, which is used to throttle the tile update network requests.

The corresponding `Source::getMinimumTileUpdateInterval()`  getter is added too.

Default minimum tile update interval value is `Duration::zero()`.

Tag https://github.com/mapbox/mapbox-gl-native-team/issues/335