### PR TITLE
[core] Add platform abstractions for utils::now()

### DIFF
--- a/include/mbgl/platform/time.hpp
+++ b/include/mbgl/platform/time.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <chrono>
+
+namespace mbgl {
+namespace platform {
+
+// Returns the current time. Abstracted because some platforms
+// will not allow direct access to the current time via syscall.
+std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds> now();
+
+} // namespace platform
+} // namespace mbgl

--- a/include/mbgl/util/chrono.hpp
+++ b/include/mbgl/util/chrono.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mbgl/platform/time.hpp>
+
 #include <chrono>
 #include <string>
 
@@ -19,7 +21,7 @@ using Timestamp = std::chrono::time_point<std::chrono::system_clock, Seconds>;
 namespace util {
 
 inline Timestamp now() {
-    return std::chrono::time_point_cast<Seconds>(std::chrono::system_clock::now());
+    return platform::now();
 }
 
 // Returns the RFC1123 formatted date. E.g. "Tue, 04 Nov 2014 02:13:24 GMT"

--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -50,6 +50,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gfx/headless_frontend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gl/headless_backend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/map/map_snapshotter.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/platform/time.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/asset_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/database_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_manager.cpp

--- a/platform/default/src/mbgl/platform/time.cpp
+++ b/platform/default/src/mbgl/platform/time.cpp
@@ -1,0 +1,11 @@
+#include <chrono>
+
+namespace mbgl {
+namespace platform {
+
+std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds> now() {
+    return std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::now());
+}
+
+} // namespace platform
+} // namespace mbgl

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -49,6 +49,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gfx/headless_frontend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/layermanager/layer_manager.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/map/map_snapshotter.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/platform/time.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/asset_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/database_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_manager.cpp

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -18,6 +18,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/i18n/collator.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/i18n/number_format.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/layermanager/layer_manager.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/platform/time.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/asset_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/database_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_manager.cpp

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -42,6 +42,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gfx/headless_frontend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/layermanager/layer_manager.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/map/map_snapshotter.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/platform/time.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/asset_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/database_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_manager.cpp

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -31,6 +31,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gl/headless_backend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/i18n/collator.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/layermanager/layer_manager.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/platform/time.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/asset_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/database_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/file_source_manager.cpp

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/util/http_header.hpp>
 
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/string.hpp>
 
 #include <boost/spirit/include/qi.hpp>
@@ -31,7 +32,7 @@ optional<Timestamp> parseRetryHeaders(const optional<std::string>& retryAfter,
     if (retryAfter) {
         try {
             auto secs = std::chrono::seconds(std::stoi(*retryAfter));
-            return std::chrono::time_point_cast<Seconds>(std::chrono::system_clock::now() + secs);
+            return std::chrono::time_point_cast<Seconds>(util::now() + secs);
         } catch (...) {
             return util::parseTimestamp((*retryAfter).c_str());
         }


### PR DESCRIPTION
Some platforms might require special permissions or custom APIs to access the current time of the day.