### PR TITLE
Add 3D camera API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - [core] Add support for `Polygon`, `MultiPolygon` geometry types in `distance` expression. ([#16446](https://github.com/mapbox/mapbox-gl-native/pull/16446))
 
+- [core] Introduce a new API for controlling the camera ([#16419]https://github.com/mapbox/mapbox-gl-native/pull/16419)
+
+  Functions `Map::getFreeCameraOptions()` and `Map::setFreeCameraOptions(options)` provides an alternative way of accessing and modifying properties of the underlying camera entity. The API allows the user to treat the camera as a more traditional 3D object by modifying its position and orientation directly as opposed to setting the state implicitly by using `CameraOptions`. Both APIs are fully compatible with each other.
+
 ### 🐞 Bug fixes
 
 - [core][tile mode] Labels priority fixes ([#16432](https://github.com/mapbox/mapbox-gl-native/pull/16432))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/unitbezier.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/util.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/variant.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/util/vectors.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/work_request.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/work_task.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/work_task_impl.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,6 +749,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/src/mbgl/tile/vector_tile.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/tile/vector_tile_data.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/tile/vector_tile_data.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/util/camera.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/bounding_volumes.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/bounding_volumes.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/chrono.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,6 +790,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/mat4.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/math.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/premultiply.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/util/quaternion.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/rapidjson.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/rapidjson.hpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/rect.hpp

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -135,6 +135,14 @@ public:
     bool isFullyLoaded() const;
     void dumpDebugLogs() const;
 
+    // FreeCameraOptions provides more direct access to the underlying camera entity.
+    // For backwards compatibility the state set using this API must be representable with
+    // `CameraOptions` as well. Parameters are clamped to a valid range or discarded as invalid
+    // if the conversion to the pitch and bearing presentation is ambiguous. For example orientation
+    // can be invalid if it leads to the camera being upside down or the quaternion has zero length.
+    void setFreeCameraOptions(const FreeCameraOptions& camera);
+    FreeCameraOptions getFreeCameraOptions() const;
+
 protected:
     class Impl;
     const std::unique_ptr<Impl> impl;

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -241,4 +241,9 @@ public:
     }
 };
 
+struct LatLngAltitude {
+    LatLng location = {0.0, 0.0};
+    double altitude = 0.0;
+};
+
 } // namespace mbgl

--- a/include/mbgl/util/vectors.hpp
+++ b/include/mbgl/util/vectors.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <array>
+
+namespace mbgl {
+
+using vec2 = std::array<double, 2>;
+using vec3 = std::array<double, 3>;
+using vec3f = std::array<float, 3>;
+using vec3i = std::array<int, 3>;
+using vec4 = std::array<double, 4>;
+
+} // namespace mbgl

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -20,6 +20,7 @@
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/platform.hpp>
@@ -206,6 +207,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_, const mbgl::ResourceOption
     printf("- Press `U` to toggle pitch bounds\n");
     printf("- Press `H` to take a snapshot of a current map.\n");
     printf("- Press `J` to take a snapshot of a current map with an extrusions overlay.\n");
+    printf("- Press `Y` to start a camera fly-by demo\n");
     printf("\n");
     printf("- Press `1` through `6` to add increasing numbers of point annotations for testing\n");
     printf("- Press `7` through `0` to add increasing numbers of shape annotations for testing\n");
@@ -487,6 +489,11 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
         case GLFW_KEY_G: {
             view->toggleLocationIndicatorLayer();
         } break;
+        case GLFW_KEY_Y: {
+            view->freeCameraDemoPhase = 0;
+            view->freeCameraDemoStartTime = mbgl::Clock::now();
+            view->invalidate();
+        } break;
         }
     }
 
@@ -505,6 +512,52 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
         case GLFW_KEY_0: view->addRandomShapeAnnotations(1000); break;
         case GLFW_KEY_M: view->addAnimatedAnnotation(); break;
         }
+    }
+}
+
+namespace mbgl {
+namespace util {
+
+template <>
+struct Interpolator<mbgl::LatLng> {
+    mbgl::LatLng operator()(const mbgl::LatLng &a, const mbgl::LatLng &b, const double t) {
+        return {
+            interpolate<double>(a.latitude(), b.latitude(), t),
+            interpolate<double>(a.longitude(), b.longitude(), t),
+        };
+    }
+};
+
+} // namespace util
+} // namespace mbgl
+
+void GLFWView::updateFreeCameraDemo() {
+    const mbgl::LatLng trainStartPos = {60.171367, 24.941359};
+    const mbgl::LatLng trainEndPos = {60.185147, 24.936668};
+    const mbgl::LatLng cameraStartPos = {60.167443, 24.927176};
+    const mbgl::LatLng cameraEndPos = {60.185107, 24.933366};
+    const double cameraStartAlt = 1000.0;
+    const double cameraEndAlt = 150.0;
+    const double duration = 8.0;
+
+    // Interpolate between starting and ending points
+    std::chrono::duration<double> deltaTime = mbgl::Clock::now() - freeCameraDemoStartTime;
+    freeCameraDemoPhase = deltaTime.count() / duration;
+
+    auto trainPos = mbgl::util::interpolate(trainStartPos, trainEndPos, freeCameraDemoPhase);
+    auto cameraPos = mbgl::util::interpolate(cameraStartPos, cameraEndPos, freeCameraDemoPhase);
+    auto cameraAlt = mbgl::util::interpolate(cameraStartAlt, cameraEndAlt, freeCameraDemoPhase);
+
+    mbgl::FreeCameraOptions camera;
+
+    // Update camera position and focus point on the map with interpolated values
+    camera.setLocation({cameraPos, cameraAlt});
+    camera.lookAtPoint(trainPos);
+
+    map->setFreeCameraOptions(camera);
+
+    if (freeCameraDemoPhase > 1.0) {
+        freeCameraDemoPhase = -1.0;
     }
 }
 
@@ -860,11 +913,14 @@ void GLFWView::run() {
 
             rendererFrontend->render();
 
+            if (freeCameraDemoPhase >= 0.0) {
+                updateFreeCameraDemo();
+            }
+
             report(1000 * (glfwGetTime() - started));
             if (benchmark) {
                 invalidate();
             }
-
         }
     };
 

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -89,6 +89,7 @@ private:
     void addRandomShapeAnnotations(int count);
     void addRandomCustomPointAnnotations(int count);
     void addAnimatedAnnotation();
+    void updateFreeCameraDemo();
     void updateAnimatedAnnotations();
     void toggleCustomSource();
     void toggleLocationIndicatorLayer();
@@ -114,6 +115,8 @@ private:
 
     std::string testDirectory = ".";
 
+    double freeCameraDemoPhase = -1;
+    mbgl::TimePoint freeCameraDemoStartTime;
     bool fullscreen = false;
     const bool benchmark = false;
     bool tracking = false;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -500,4 +500,14 @@ void Map::dumpDebugLogs() const {
     Log::Info(Event::General, "--------------------------------------------------------------------------------");
 }
 
+void Map::setFreeCameraOptions(const FreeCameraOptions& camera) {
+    impl->transform.setFreeCameraOptions(camera);
+    impl->cameraMutated = true;
+    impl->onUpdate();
+}
+
+FreeCameraOptions Map::getFreeCameraOptions() const {
+    return impl->transform.getFreeCameraOptions();
+}
+
 } // namespace mbgl

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -650,4 +650,13 @@ double Transform::getMaxPitchForEdgeInsets(const EdgeInsets& insets) const {
     // e.g. Maximum pitch of 60 degrees is when perspective center's offset from the top is 84% of screen height.
 }
 
+FreeCameraOptions Transform::getFreeCameraOptions() const {
+    return state.getFreeCameraOptions();
+}
+
+void Transform::setFreeCameraOptions(const FreeCameraOptions& options) {
+    cancelTransitions();
+    state.setFreeCameraOptions(options);
+}
+
 } // namespace mbgl

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -113,6 +113,9 @@ public:
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Wrapped) const;
 
+    FreeCameraOptions getFreeCameraOptions() const;
+    void setFreeCameraOptions(const FreeCameraOptions& options);
+
 private:
     MapObserver& observer;
     TransformState state;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -9,6 +9,15 @@
 #include <mbgl/util/tile_coordinate.hpp>
 
 namespace mbgl {
+
+namespace {
+LatLng latLngFromMercator(Point<double> mercatorCoordinate, LatLng::WrapMode wrapMode = LatLng::WrapMode::Unwrapped) {
+    return {util::RAD2DEG * (2 * std::atan(std::exp(M_PI - mercatorCoordinate.y * util::M2PI)) - M_PI_2),
+            mercatorCoordinate.x * 360.0 - 180.0,
+            wrapMode};
+}
+} // namespace
+
 TransformState::TransformState(ConstrainMode constrainMode_, ViewportMode viewportMode_)
     : bounds(LatLngBounds()), constrainMode(constrainMode_), viewportMode(viewportMode_) {}
 
@@ -101,54 +110,39 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
     // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
     const double farZ = furthestDistance * 1.01;
 
-    matrix::perspective(projMatrix, getFieldOfView(), double(size.width) / size.height, nearZ, farZ);
+    // Make sure the camera state is up-to-date
+    updateCameraState();
+
+    mat4 worldToCamera = camera.getWorldToCamera(scale, viewportMode == ViewportMode::FlippedY);
+    mat4 cameraToClip =
+        camera.getCameraToClipPerspective(getFieldOfView(), double(size.width) / size.height, nearZ, farZ);
 
     // Move the center of perspective to center of specified edgeInsets.
     // Values are in range [-1, 1] where the upper and lower range values
     // position viewport center to the screen edges. This is overriden
     // if using axonometric perspective (not in public API yet, Issue #11882).
     // TODO(astojilj): Issue #11882 should take edge insets into account, too.
-    projMatrix[8] = -offset.x * 2.0 / size.width;
-    projMatrix[9] = offset.y * 2.0 / size.height;
-
-    const bool flippedY = viewportMode == ViewportMode::FlippedY;
-    matrix::scale(projMatrix, projMatrix, 1.0, flippedY ? 1 : -1, 1);
-
-    matrix::translate(projMatrix, projMatrix, 0, 0, -cameraToCenterDistance);
-
-    using NO = NorthOrientation;
-    switch (getNorthOrientation()) {
-        case NO::Rightwards:
-            matrix::rotate_y(projMatrix, projMatrix, getPitch());
-            break;
-        case NO::Downwards:
-            matrix::rotate_x(projMatrix, projMatrix, -getPitch());
-            break;
-        case NO::Leftwards:
-            matrix::rotate_y(projMatrix, projMatrix, -getPitch());
-            break;
-        default:
-            matrix::rotate_x(projMatrix, projMatrix, getPitch());
-            break;
+    if (!axonometric) {
+        cameraToClip[8] = -offset.x * 2.0 / size.width;
+        cameraToClip[9] = offset.y * 2.0 / size.height;
     }
 
-    matrix::rotate_z(projMatrix, projMatrix, getBearing() + getNorthOrientationAngle());
+    // Apply north orientation angle
+    if (getNorthOrientation() != NorthOrientation::Upwards) {
+        matrix::rotate_z(cameraToClip, cameraToClip, -getNorthOrientationAngle());
+    }
 
-    const double dx = pixel_x() - size.width / 2.0f;
-    const double dy = pixel_y() - size.height / 2.0f;
-    matrix::translate(projMatrix, projMatrix, dx, dy, 0);
+    matrix::multiply(projMatrix, cameraToClip, worldToCamera);
 
     if (axonometric) {
         // mat[11] controls perspective
-        projMatrix[11] = 0;
+        projMatrix[11] = 0.0;
 
         // mat[8], mat[9] control x-skew, y-skew
-        projMatrix[8] = xSkew;
-        projMatrix[9] = ySkew;
+        double pixelsPerMeter = 1.0 / Projection::getMetersPerPixelAtLatitude(getLatLng().latitude(), getZoom());
+        projMatrix[8] = xSkew * pixelsPerMeter;
+        projMatrix[9] = ySkew * pixelsPerMeter;
     }
-
-    matrix::scale(projMatrix, projMatrix, 1, 1,
-                  1.0 / Projection::getMetersPerPixelAtLatitude(getLatLng(LatLng::Unwrapped).latitude(), getZoom()));
 
     // Make a second projection matrix that is aligned to a pixel grid for rendering raster tiles.
     // We're rounding the (floating point) x/y values to achieve to avoid rendering raster images to fractional
@@ -156,7 +150,12 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
     // is an odd integer to preserve rendering to the pixel grid. We're rotating this shift based on the angle
     // of the transformation so that 0°, 90°, 180°, and 270° rasters are crisp, and adjust the shift so that
     // it is always <= 0.5 pixels.
+
     if (aligned) {
+        const double worldSize = Projection::worldSize(scale);
+        const double dx = x - 0.5 * worldSize;
+        const double dy = y - 0.5 * worldSize;
+
         const float xShift = float(size.width % 2) / 2;
         const float yShift = float(size.height % 2) / 2;
         const double bearingCos = std::cos(bearing);
@@ -168,6 +167,65 @@ void TransformState::getProjMatrix(mat4& projMatrix, uint16_t nearZ, bool aligne
     }
 }
 
+void TransformState::updateCameraState() const {
+    if (!valid()) {
+        return;
+    }
+
+    const double worldSize = Projection::worldSize(scale);
+    const double cameraToCenterDistance = getCameraToCenterDistance();
+
+    // x & y tracks the center of the map in pixels. However as rendering is done in pixel coordinates the rendering
+    // origo is actually in the middle of the map (0.5 * worldSize). x&y positions have to be negated because it defines
+    // position of the map, not the camera. Moving map 10 units left has the same effect as moving camera 10 units to the
+    // right.
+    const double dx = 0.5 * worldSize - x;
+    const double dy = 0.5 * worldSize - y;
+
+    // Set camera orientation and move it to a proper distance from the map
+    camera.setOrientation(getPitch(), getBearing());
+
+    const vec3 forward = camera.forward();
+    const vec3 orbitPosition = {{-forward[0] * cameraToCenterDistance,
+                                 -forward[1] * cameraToCenterDistance,
+                                 -forward[2] * cameraToCenterDistance}};
+    vec3 cameraPosition = {{dx + orbitPosition[0], dy + orbitPosition[1], orbitPosition[2]}};
+
+    cameraPosition[0] /= worldSize;
+    cameraPosition[1] /= worldSize;
+    cameraPosition[2] /= worldSize;
+
+    camera.setPosition(cameraPosition);
+}
+
+void TransformState::updateStateFromCamera() {
+    const vec3 position = camera.getPosition();
+    const vec3 forward = camera.forward();
+
+    const double dx = forward[0];
+    const double dy = forward[1];
+    const double dz = forward[2];
+    assert(position[2] > 0.0 && dz < 0.0);
+
+    // Compute bearing and pitch
+    double newBearing;
+    double newPitch;
+    camera.getOrientation(newPitch, newBearing);
+    newPitch = util::clamp(newPitch, minPitch, maxPitch);
+
+    // Compute zoom level from the camera altitude
+    const double centerDistance = getCameraToCenterDistance();
+    const double zoom = util::log2(centerDistance / (position[2] / std::cos(newPitch) * util::tileSize));
+    const double newScale = util::clamp(std::pow(2.0, zoom), min_scale, max_scale);
+
+    // Compute center point of the map
+    const double travel = -position[2] / dz;
+    const Point<double> mercatorPoint = {position[0] + dx * travel, position[1] + dy * travel};
+
+    setLatLngZoom(latLngFromMercator(mercatorPoint), scaleZoom(newScale));
+    setBearing(newBearing);
+    setPitch(newPitch);
+}
 void TransformState::updateMatricesIfNeeded() const {
     if (!needsMatricesUpdate() || size.isEmpty()) return;
 

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <mbgl/map/mode.hpp>
 #include <mbgl/map/camera.hpp>
+#include <mbgl/map/mode.hpp>
+#include <mbgl/util/camera.hpp>
+#include <mbgl/util/constants.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/geometry.hpp>
-#include <mbgl/util/constants.hpp>
+#include <mbgl/util/mat4.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/projection.hpp>
-#include <mbgl/util/mat4.hpp>
 #include <mbgl/util/size.hpp>
 
 #include <cstdint>
@@ -248,6 +249,9 @@ private:
     void updateMatricesIfNeeded() const;
     bool needsMatricesUpdate() const { return requestMatricesUpdate; }
 
+    void updateCameraState() const;
+    void updateStateFromCamera();
+
     const mat4& getCoordMatrix() const;
     const mat4& getInvertedMatrix() const;
 
@@ -276,6 +280,7 @@ private:
     bool axonometric = false;
 
     EdgeInsets edgeInsets;
+    mutable util::Camera camera;
 
     // cache values for spherical mercator math
     double Bc = Projection::worldSize(scale) / util::DEGREES_MAX;

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -219,6 +219,9 @@ public:
     const mat4& getProjectionMatrix() const;
     const mat4& getInvProjectionMatrix() const;
 
+    FreeCameraOptions getFreeCameraOptions() const;
+    void setFreeCameraOptions(const FreeCameraOptions& options);
+
 private:
     bool rotatedNorth() const;
 
@@ -249,6 +252,8 @@ private:
     void updateMatricesIfNeeded() const;
     bool needsMatricesUpdate() const { return requestMatricesUpdate; }
 
+    bool setCameraPosition(const vec3& position);
+    bool setCameraOrientation(const Quaternion& orientation);
     void updateCameraState() const;
     void updateStateFromCamera();
 

--- a/src/mbgl/util/camera.cpp
+++ b/src/mbgl/util/camera.cpp
@@ -1,0 +1,215 @@
+#include "camera.hpp"
+#include <cassert>
+#include <cmath>
+#include <mbgl/map/camera.hpp>
+#include <mbgl/math/log2.hpp>
+#include <mbgl/util/constants.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/projection.hpp>
+
+namespace mbgl {
+
+namespace {
+double vec2Len(const vec2& v) {
+    return std::sqrt(v[0] * v[0] + v[1] * v[1]);
+};
+
+double vec2Dot(const vec2& a, const vec2& b) {
+    return a[0] * b[0] + a[1] * b[1];
+};
+
+vec2 vec2Scale(const vec2& v, double s) {
+    return vec2{{v[0] * s, v[1] * s}};
+};
+} // namespace
+
+namespace util {
+
+static double mercatorXfromLng(double lng) {
+    return (180.0 + lng) / 360.0;
+}
+
+static double mercatorYfromLat(double lat) {
+    return (180.0 - (180.0 / M_PI * std::log(std::tan(M_PI_4 + lat * M_PI / 360.0)))) / 360.0;
+}
+
+static double latFromMercatorY(double y) {
+    return util::RAD2DEG * (2.0 * std::atan(std::exp(M_PI - y * util::M2PI)) - M_PI_2);
+}
+
+static double lngFromMercatorX(double x) {
+    return x * 360.0 - 180.0;
+}
+
+static double* getColumn(mat4& matrix, int col) {
+    assert(col >= 0 && col < 4);
+    return &matrix[col * 4];
+}
+
+static const double* getColumn(const mat4& matrix, int col) {
+    assert(col >= 0 && col < 4);
+    return &matrix[col * 4];
+}
+
+static vec3 toMercator(const LatLng& location, double altitudeMeters) {
+    const double pixelsPerMeter = 1.0 / Projection::getMetersPerPixelAtLatitude(location.latitude(), 0.0);
+    const double worldSize = Projection::worldSize(std::pow(2.0, 0.0));
+
+    return {{mercatorXfromLng(location.longitude()),
+             mercatorYfromLat(location.latitude()),
+             altitudeMeters * pixelsPerMeter / worldSize}};
+}
+
+static Quaternion orientationFromPitchBearing(double pitch, double bearing) {
+    // Both angles have to be negated to achieve CW rotation around the axis of rotation
+    Quaternion rotBearing = Quaternion::fromAxisAngle({{0.0, 0.0, 1.0}}, -bearing);
+    Quaternion rotPitch = Quaternion::fromAxisAngle({{1.0, 0.0, 0.0}}, -pitch);
+
+    return rotBearing.multiply(rotPitch);
+}
+
+static void updateTransform(mat4& transform, const Quaternion& orientation) {
+    // Construct rotation matrix from orientation
+    mat4 m = orientation.toRotationMatrix();
+
+    // Apply translation to the matrix
+    double* col = getColumn(m, 3);
+
+    col[0] = getColumn(transform, 3)[0];
+    col[1] = getColumn(transform, 3)[1];
+    col[2] = getColumn(transform, 3)[2];
+
+    transform = m;
+}
+
+static void updateTransform(mat4& transform, const vec3& position) {
+    getColumn(transform, 3)[0] = position[0];
+    getColumn(transform, 3)[1] = position[1];
+    getColumn(transform, 3)[2] = position[2];
+}
+
+Camera::Camera() : orientation(Quaternion::identity) {
+    matrix::identity(transform);
+}
+
+vec3 Camera::getPosition() const {
+    const double* p = getColumn(transform, 3);
+    return {{p[0], p[1], p[2]}};
+}
+
+mat4 Camera::getCameraToWorld(double scale, bool flippedY) const {
+    mat4 cameraToWorld;
+    matrix::invert(cameraToWorld, getWorldToCamera(scale, flippedY));
+    return cameraToWorld;
+}
+
+mat4 Camera::getWorldToCamera(double scale, bool flippedY) const {
+    // transformation chain from world space to camera space:
+    // 1. Height value (z) of renderables is in meters. Scale z coordinate by pixelsPerMeter
+    // 2. Transform from pixel coordinates to camera space with cameraMatrix^-1
+    // 3. flip Y if required
+
+    // worldToCamera: flip * cam^-1 * zScale
+    // cameraToWorld: (flip * cam^-1 * zScale)^-1 => (zScale^-1 * cam * flip^-1)
+    const double worldSize = Projection::worldSize(scale);
+    const double latitude = latFromMercatorY(getColumn(transform, 3)[1]);
+    const double pixelsPerMeter = worldSize / (std::cos(latitude * util::DEG2RAD) * util::M2PI * util::EARTH_RADIUS_M);
+
+    // Compute inverse of the camera matrix
+    mat4 result = orientation.conjugate().toRotationMatrix();
+
+    matrix::translate(
+        result, result, -transform[12] * worldSize, -transform[13] * worldSize, -transform[14] * worldSize);
+
+    if (!flippedY) {
+        // Pre-multiply y
+        result[1] *= -1.0;
+        result[5] *= -1.0;
+        result[9] *= -1.0;
+        result[13] *= -1.0;
+    }
+
+    // Post-multiply z
+    result[8] *= pixelsPerMeter;
+    result[9] *= pixelsPerMeter;
+    result[10] *= pixelsPerMeter;
+    result[11] *= pixelsPerMeter;
+
+    return result;
+}
+
+mat4 Camera::getCameraToClipPerspective(double fovy, double aspectRatio, double nearZ, double farZ) const {
+    mat4 projection;
+    matrix::perspective(projection, fovy, aspectRatio, nearZ, farZ);
+    return projection;
+}
+
+vec3 Camera::forward() const {
+    const double* column = getColumn(transform, 2);
+    // The forward direction is towards the map, [0, 0, -1]
+    return {{-column[0], -column[1], -column[2]}};
+}
+
+vec3 Camera::right() const {
+    const double* column = getColumn(transform, 0);
+    return {{column[0], column[1], column[2]}};
+}
+
+vec3 Camera::up() const {
+    const double* column = getColumn(transform, 1);
+    // Up direction has to be flipped due to y-axis pointing towards south
+    return {{-column[0], -column[1], -column[2]}};
+}
+
+void Camera::getOrientation(double& pitch, double& bearing) const {
+    const vec3 f = forward();
+    const vec3 r = right();
+
+    bearing = std::atan2(-r[1], r[0]);
+    pitch = std::atan2(std::sqrt(f[0] * f[0] + f[1] * f[1]), -f[2]);
+}
+
+void Camera::setOrientation(double pitch, double bearing) {
+    orientation = orientationFromPitchBearing(pitch, bearing);
+    updateTransform(transform, orientation);
+}
+
+void Camera::setOrientation(const Quaternion& orientation_) {
+    orientation = orientation_;
+    updateTransform(transform, orientation);
+}
+
+void Camera::setPosition(const vec3& position) {
+    updateTransform(transform, position);
+}
+
+optional<Quaternion> Camera::orientationFromFrame(const vec3& forward, const vec3& up) {
+    vec3 upVector = up;
+
+    vec2 xyForward = {{forward[0], forward[1]}};
+    vec2 xyUp = {{up[0], up[1]}};
+    const double epsilon = 1e-15;
+
+    // Remove roll-component of the resulting orientation by projecting
+    // the up-vector to the forward vector on xy-plane
+    if (vec2Len(xyForward) >= epsilon) {
+        const vec2 xyDir = vec2Scale(xyForward, 1.0 / vec2Len(xyForward));
+
+        xyUp = vec2Scale(xyDir, vec2Dot(xyUp, xyDir));
+        upVector[0] = xyUp[0];
+        upVector[1] = xyUp[1];
+    }
+
+    const vec3 right = vec3Cross(upVector, forward);
+
+    if (vec3Length(right) < epsilon) {
+        return nullopt;
+    }
+
+    const double bearing = std::atan2(-right[1], right[0]);
+    const double pitch = std::atan2(std::sqrt(forward[0] * forward[0] + forward[1] * forward[1]), -forward[2]);
+
+    return util::orientationFromPitchBearing(pitch, bearing);
+}
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/camera.hpp
+++ b/src/mbgl/util/camera.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <mbgl/util/optional.hpp>
+#include <mbgl/util/size.hpp>
+#include "quaternion.hpp"
+
+namespace mbgl {
+
+class LatLng;
+
+namespace util {
+
+class Camera {
+public:
+    Camera();
+
+    vec3 getPosition() const;
+    mat4 getCameraToWorld(double scale, bool flippedY) const;
+    mat4 getWorldToCamera(double scale, bool flippedY) const;
+    mat4 getCameraToClipPerspective(double fovy, double aspectRatio, double nearZ, double farZ) const;
+
+    vec3 forward() const;
+    vec3 right() const;
+    vec3 up() const;
+
+    const Quaternion& getOrientation() const { return orientation; }
+    void getOrientation(double& pitch, double& bearing) const;
+    void setOrientation(double pitch, double bearing);
+    void setOrientation(const Quaternion& orientation_);
+    void setPosition(const vec3& position);
+
+    // Computes orientation using forward and up vectors of the provided coordinate frame.
+    // Only bearing and pitch components will be used. Does not return a value if input is invalid
+    static optional<Quaternion> orientationFromFrame(const vec3& forward, const vec3& up);
+
+private:
+    Quaternion orientation;
+    mat4 transform; // Position (mercator) and orientation of the camera
+};
+
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/mat3.hpp
+++ b/src/mbgl/util/mat3.hpp
@@ -24,12 +24,10 @@
 
 #include <array>
 #include <cmath>
+#include <mbgl/util/vectors.hpp>
 
 namespace mbgl {
 
-using vec3 = std::array<double, 3>;
-using vec3f = std::array<float, 3>;
-using vec3i = std::array<int, 3>;
 using mat3 = std::array<double, 9>;
 
 inline vec3 vec3Cross(const vec3& a, const vec3& b) {

--- a/src/mbgl/util/mat4.hpp
+++ b/src/mbgl/util/mat4.hpp
@@ -23,10 +23,10 @@
 #pragma once
 
 #include <array>
+#include <mbgl/util/vectors.hpp>
 
 namespace mbgl {
 
-using vec4 = std::array<double, 4>;
 using mat4 = std::array<double, 16>;
 
 namespace matrix {

--- a/src/mbgl/util/quaternion.cpp
+++ b/src/mbgl/util/quaternion.cpp
@@ -1,0 +1,111 @@
+#include "quaternion.hpp"
+#include <cassert>
+#include <cmath>
+
+namespace mbgl {
+
+Quaternion Quaternion::identity = Quaternion(0.0, 0.0, 0.0, 1.0);
+
+Quaternion Quaternion::conjugate() const {
+    return {-x, -y, -z, w};
+}
+
+Quaternion Quaternion::normalized() const {
+    const double len = length();
+    assert(len > 0.0);
+    return {x / len, y / len, z / len, w / len};
+}
+
+Quaternion Quaternion::fromAxisAngle(const vec3& axis, double angleRad) {
+    const double coss = std::cos(0.5 * angleRad);
+    const double sins = std::sin(0.5 * angleRad);
+
+    Quaternion q;
+    q.x = sins * axis[0];
+    q.y = sins * axis[1];
+    q.z = sins * axis[2];
+    q.w = coss;
+    return q;
+}
+
+Quaternion Quaternion::fromEulerAngles(double x, double y, double z) {
+    double cz = std::cos(z * 0.5);
+    double sz = std::sin(z * 0.5);
+    double cy = std::cos(y * 0.5);
+    double sy = std::sin(y * 0.5);
+    double cx = std::cos(x * 0.5);
+    double sx = std::sin(x * 0.5);
+
+    Quaternion q;
+    q.x = sx * cy * cz - cx * sy * sz;
+    q.y = cx * sy * cz + sx * cy * sz;
+    q.z = cx * cy * sz - sx * sy * cz;
+    q.w = cx * cy * cz + sx * sy * sz;
+
+    return q;
+}
+
+Quaternion Quaternion::multiply(const Quaternion& o) const {
+    Quaternion q;
+    q.w = w * o.w - x * o.x - y * o.y - z * o.z;
+    q.x = w * o.x + x * o.w + y * o.z - z * o.y;
+    q.y = w * o.y + y * o.w + z * o.x - x * o.z;
+    q.z = w * o.z + z * o.w + x * o.y - y * o.x;
+    return q;
+}
+
+double Quaternion::length() const {
+    return std::sqrt(x * x + y * y + z * z + w * w);
+}
+
+vec3 Quaternion::transform(const vec3& v) const {
+    const Quaternion src = {v[0], v[1], v[2], 0.0};
+    const Quaternion res = multiply(src).multiply(conjugate());
+    return {res.x, res.y, res.z};
+}
+
+mat4 Quaternion::toRotationMatrix() const {
+    mat4 mat;
+
+    const double tx = 2.0 * x;
+    const double ty = 2.0 * y;
+    const double tz = 2.0 * z;
+    const double twx = tx * w;
+    const double twy = ty * w;
+    const double twz = tz * w;
+    const double txx = tx * x;
+    const double txy = ty * x;
+    const double txz = tz * x;
+    const double tyy = ty * y;
+    const double tyz = tz * y;
+    const double tzz = tz * z;
+
+    mat[0] = 1.0 - (tyy + tzz);
+    mat[1] = txy + twz;
+    mat[2] = txz - twy;
+    mat[3] = 0.0;
+    mat[4] = txy - twz;
+    mat[5] = 1.0 - (txx + tzz);
+    mat[6] = tyz + twx;
+    mat[7] = 0.0;
+    mat[8] = txz + twy;
+    mat[9] = tyz - twx;
+    mat[10] = 1.0 - (txx + tyy);
+    mat[11] = 0.0;
+    mat[12] = 0.0;
+    mat[13] = 0.0;
+    mat[14] = 0.0;
+    mat[15] = 1.0;
+
+    return mat;
+}
+
+bool operator!=(const Quaternion& a, const Quaternion& b) {
+    return !(a == b);
+}
+
+bool operator==(const Quaternion& a, const Quaternion& b) {
+    return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+} // namespace mbgl

--- a/src/mbgl/util/quaternion.hpp
+++ b/src/mbgl/util/quaternion.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "mat3.hpp"
+#include "mat4.hpp"
+
+namespace mbgl {
+
+struct Quaternion {
+    union {
+        vec4 m;
+        struct {
+            double x, y, z, w;
+        };
+    };
+
+    Quaternion() : Quaternion(0.0, 0.0, 0.0, 0.0) {}
+    Quaternion(double x_, double y_, double z_, double w_) : x(x_), y(y_), z(z_), w(w_) {}
+    Quaternion(const vec4& vec) : m(vec) {}
+
+    Quaternion conjugate() const;
+    Quaternion normalized() const;
+    Quaternion multiply(const Quaternion& o) const;
+    double length() const;
+    vec3 transform(const vec3& v) const;
+    mat4 toRotationMatrix() const;
+
+    static Quaternion fromAxisAngle(const vec3& axis, double angleRad);
+    static Quaternion fromEulerAngles(double x, double y, double z);
+
+    static Quaternion identity;
+};
+
+bool operator==(const Quaternion&, const Quaternion&);
+bool operator!=(const Quaternion&, const Quaternion&);
+
+} // namespace mbgl

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/tile/vector_tile.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/async_task.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/bounding_volumes.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/util/camera.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/dtoa.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/geo.test.cpp
     ${PROJECT_SOURCE_DIR}/test/util/grid_index.test.cpp

--- a/test/util/camera.test.cpp
+++ b/test/util/camera.test.cpp
@@ -1,0 +1,259 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/map/camera.hpp>
+#include <mbgl/util/mat3.hpp>
+#include <mbgl/util/quaternion.hpp>
+
+#include <gmock/gmock.h>
+
+using namespace mbgl;
+
+static const double abs_double_error = 1e-7;
+
+MATCHER_P(Vec3NearEquals, vec, "") {
+    return std::fabs(vec[0] - arg[0]) <= abs_double_error && std::fabs(vec[1] - arg[1]) <= abs_double_error &&
+           std::fabs(vec[2] - arg[2]) <= abs_double_error;
+}
+
+TEST(FreeCameraOptions, SetLocation) {
+    FreeCameraOptions options;
+
+    options.setLocation({{0.0, 0.0}, util::EARTH_RADIUS_M * M_PI});
+    ASSERT_TRUE(options.position);
+    ASSERT_THAT(options.position.value(), Vec3NearEquals(vec3{{0.5, 0.5, 0.5}}));
+
+    options.setLocation({{25.0, -180.0}, 1000.0});
+    ASSERT_TRUE(options.position);
+    ASSERT_THAT(options.position.value(), Vec3NearEquals(vec3{{0.0, 0.4282409625, 0.000027532812465}}));
+
+    options.setLocation(
+        {{util::LATITUDE_MAX, 0.0}, util::EARTH_RADIUS_M * M_PI * std::cos(util::LATITUDE_MAX * util::DEG2RAD)});
+    ASSERT_TRUE(options.position);
+    ASSERT_THAT(options.position.value(), Vec3NearEquals(vec3{{0.5, 0.0, 0.5}}));
+
+    options.setLocation(
+        {{-util::LATITUDE_MAX, 0.0}, util::EARTH_RADIUS_M * M_PI * std::cos(-util::LATITUDE_MAX * util::DEG2RAD)});
+    ASSERT_TRUE(options.position);
+    ASSERT_THAT(options.position.value(), Vec3NearEquals(vec3{{0.5, 1.0, 0.5}}));
+}
+
+TEST(FreeCameraOptions, SetLocationNegativeAltitude) {
+    FreeCameraOptions options;
+    options.setLocation({{0.0, 0.0}, -100.0});
+    ASSERT_TRUE(options.position);
+    ASSERT_DOUBLE_EQ(options.position.value()[2], -100.0 / util::M2PI / util::EARTH_RADIUS_M);
+}
+
+TEST(FreeCameraOptions, SetLocationUnwrappedLocation) {
+    FreeCameraOptions options;
+
+    options.setLocation({{0.0, -540.0}, 0.0});
+    ASSERT_TRUE(options.position);
+    ASSERT_THAT(options.position.value(), Vec3NearEquals(vec3{{-1.0, 0.5, 0.0}}));
+}
+
+TEST(FreeCameraOptions, GetLocation) {
+    FreeCameraOptions options;
+    LatLngAltitude latLngAltitude;
+
+    options.position = vec3{{0.5, 0.5, 0.5}};
+    ASSERT_TRUE(options.getLocation());
+    latLngAltitude = options.getLocation().value();
+    ASSERT_DOUBLE_EQ(latLngAltitude.location.latitude(), 0.0);
+    ASSERT_DOUBLE_EQ(latLngAltitude.location.longitude(), 0.0);
+    ASSERT_DOUBLE_EQ(latLngAltitude.altitude, 20037508.342789244);
+
+    options.position = vec3{{0.0, 0.4282409625, 0.000027532812465}};
+    ASSERT_TRUE(options.getLocation());
+    latLngAltitude = options.getLocation().value();
+    ASSERT_NEAR(latLngAltitude.location.latitude(), 25.0, 1e-7);
+    ASSERT_NEAR(latLngAltitude.location.longitude(), -180.0, 1e-7);
+    ASSERT_NEAR(latLngAltitude.altitude, 1000.0, 1e-7);
+
+    options.position = vec3{{0.5, 0.0, 0.5}};
+    ASSERT_TRUE(options.getLocation());
+    latLngAltitude = options.getLocation().value();
+    ASSERT_NEAR(latLngAltitude.location.latitude(), util::LATITUDE_MAX, 1e-7);
+    ASSERT_NEAR(latLngAltitude.location.longitude(), 0.0, 1e-7);
+    ASSERT_NEAR(latLngAltitude.altitude, 1728570.489074, 1e-6);
+}
+
+TEST(FreeCameraOptions, GetLocationInvalidPosition) {
+    FreeCameraOptions options;
+    // Mercator position not set. Should return nothing
+    ASSERT_FALSE(options.getLocation());
+
+    // Invalid latitude
+    options.position = vec3{{0.0, -0.1, 0.0}};
+    ASSERT_FALSE(options.getLocation());
+    options.position = vec3{{0.0, 2.0, 0.0}};
+    ASSERT_FALSE(options.getLocation());
+}
+
+TEST(FreeCameraOptions, GetLocationNegativeAltitude) {
+    FreeCameraOptions options;
+    options.position = vec3{{0.5, 0.5, -0.25}};
+    const auto latLngAltitude = options.getLocation();
+    ASSERT_TRUE(latLngAltitude);
+
+    ASSERT_DOUBLE_EQ(latLngAltitude->altitude, -0.5 * util::EARTH_RADIUS_M * M_PI);
+}
+
+TEST(FreeCameraOptions, GetLocationUnwrappedPosition) {
+    FreeCameraOptions options;
+    options.position = vec3{{1.25, 0.5, 0.0}};
+    const auto latLngAltitude = options.getLocation();
+    ASSERT_TRUE(latLngAltitude);
+    ASSERT_DOUBLE_EQ(latLngAltitude->location.longitude(), 270.0);
+    ASSERT_DOUBLE_EQ(latLngAltitude->location.latitude(), 0.0);
+    ASSERT_DOUBLE_EQ(latLngAltitude->altitude, 0.0);
+}
+
+static std::tuple<vec3, vec3, vec3> rotatedFrame(const std::array<double, 4>& quaternion) {
+    Quaternion q(quaternion);
+    return std::make_tuple(
+        q.transform({{1.0, 0.0, 0.0}}), q.transform({{0.0, -1.0, 0.0}}), q.transform({{0.0, 0.0, -1.0}}));
+}
+
+TEST(FreeCameraOptions, LookAtPoint) {
+    FreeCameraOptions options;
+    vec3 right, up, forward;
+    const double cosPi4 = 1.0 / std::sqrt(2.0);
+
+    // Pitch: 45, bearing: 0
+    options.position = vec3{{0.5, 0.5, 0.5}};
+    options.lookAtPoint({util::LATITUDE_MAX, 0.0});
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{1.0, 0.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, -cosPi4, cosPi4}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, -cosPi4, -cosPi4}}));
+
+    // Look directly to east
+    options.position = vec3{{0.5, 0.5, 0.0}};
+    options.lookAtPoint({0.0, 30.0});
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{0.0, 1.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, 0.0, 1.0}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{1.0, 0.0, 0.0}}));
+
+    // Pitch: 0, bearing: 0
+    options.setLocation({{60.1699, 24.9384}, 100.0});
+    options.lookAtPoint({60.1699, 24.9384}, vec3{{0.0, -1.0, 0.0}});
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{1.0, 0.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, -1.0, 0.0}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, 0.0, -1.0}}));
+
+    // Pitch: 0, bearing: 45
+    options.setLocation({{60.1699, 24.9384}, 100.0});
+    options.lookAtPoint({60.1699, 24.9384}, vec3{{-1.0, -1.0, 0.0}});
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{cosPi4, -cosPi4, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{-cosPi4, -cosPi4, 0.0}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, 0.0, -1.0}}));
+
+    // Looking south, up vector almost same as forward vector
+    options.setLocation({{37.7749, 122.4194}, 0.0});
+    options.lookAtPoint({37.5, 122.4194}, vec3{{0.0, 1.0, 0.00001}});
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{-1.0, 0.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, 0.0, 1.0}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, 1.0, 0.0}}));
+
+    // Orientation with roll-component
+    options.setLocation({{-33.8688, 151.2093}, 0.0});
+    options.lookAtPoint({-33.8688, 160.0}, vec3{{0.0, -1.0, 0.1}});
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{0.0, 1.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, 0.0, 1.0}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{1.0, 0.0, 0.0}}));
+
+    // Up vector pointing downwards
+    options.position = vec3{{0.5, 0.5, 0.5}};
+    options.lookAtPoint({util::LATITUDE_MAX, 0.0}, vec3{{0.0, 0.0, -0.5}});
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{1.0, 0.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, -cosPi4, cosPi4}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, -cosPi4, -cosPi4}}));
+}
+
+TEST(FreeCameraOptions, LookAtPointInvalidInput) {
+    FreeCameraOptions options;
+
+    // Position not set
+    options.orientation = vec4{{0.0, 0.0, 0.0, 0.0}};
+    options.lookAtPoint({0.0, 0.0});
+    ASSERT_FALSE(options.orientation);
+
+    // Target same as position
+    options.orientation = vec4{{0.0, 0.0, 0.0, 0.0}};
+    options.position = vec3{{0.5, 0.5, 0.0}};
+    options.lookAtPoint({0.0, 0.0});
+    ASSERT_FALSE(options.orientation);
+
+    // Camera looking directly down without an explicit up vector
+    options.orientation = vec4{{0.0, 0.0, 0.0, 0.0}};
+    options.position = vec3{{0.5, 0.5, 0.5}};
+    options.lookAtPoint({0.0, 0.0});
+    ASSERT_FALSE(options.orientation);
+
+    // Zero up vector
+    options.orientation = vec4{{0.0, 0.0, 0.0, 0.0}};
+    options.lookAtPoint({0.0, 0.0}, vec3{{0.0, 0.0, 0.0}});
+    ASSERT_FALSE(options.orientation);
+
+    // Up vector same as direction
+    options.orientation = vec4{{0.0, 0.0, 0.0, 0.0}};
+    options.lookAtPoint({0.0, 0.0}, vec3{{0.0, 0.0, -1.0}});
+    ASSERT_FALSE(options.orientation);
+}
+
+TEST(FreeCameraOptions, SetPitchBearing) {
+    FreeCameraOptions options;
+    vec3 right, up, forward;
+
+    options.setPitchBearing(0.0, 0.0);
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{1.0, 0.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, -1.0, 0.0}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, 0.0, -1.0}}));
+
+    options.setPitchBearing(0.0, 180.0);
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{-1.0, 0.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, 1.0, 0.0}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, 0.0, -1.0}}));
+
+    const double cos60 = std::cos(60.0 * util::DEG2RAD);
+    const double sin60 = std::sin(60.0 * util::DEG2RAD);
+
+    options.setPitchBearing(60.0, 0.0);
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{1.0, 0.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{0.0, -cos60, sin60}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{0.0, -sin60, -cos60}}));
+
+    options.setPitchBearing(60.0, -450);
+    ASSERT_TRUE(options.orientation);
+    std::tie(right, up, forward) = rotatedFrame(options.orientation.value());
+    ASSERT_THAT(right, Vec3NearEquals(vec3{{0.0, 1.0, 0.0}}));
+    ASSERT_THAT(up, Vec3NearEquals(vec3{{cos60, 0.0, sin60}}));
+    ASSERT_THAT(forward, Vec3NearEquals(vec3{{sin60, 0.0, -cos60}}));
+}


### PR DESCRIPTION
This pull request is the first iteration of a "real" 3D camera API that gives the user more precise controls of the camera entity itself by exposing direct properties like position and orientation. The difference to the current viewport API is that instead of applying transformations to the map the user has (a limited) access to the underlying camera object that is orbiting around the map center point at a certain distance. Implementation follows standard conventions and is a typical way of controlling the camera in any 3D engine/software.

Both interfaces, the old and the new, are interchangeable and fully compatible with each other: changes made to the transformation via one API is immediately reflected to the other one.

 - Same constraints apply to both APIs. Pitch is limited to 60 degrees, arbitrary camera positions are not allowed and roll-component of the camera orientation is disabled. In other words the camera state is valid on both APIs.
 - Camera/map transformation properties can be modified in parallel with both APIs. There are certain limitations as some properties might have dependencies with each other. For example modifying the zoom using the old API will also change position of the camera seen from the new API.

## Interface
**Disclaimer**: naming of things is not final!
```c
struct FreeCameraOptions {
    /** Position of the camera in mercator coordinates */
    optional<std::array<double, 3>> mercatorPosition;

    /** Focus point on the map where the camera is looking at. Effectively the same value as
        map center coordinate. */
    optional<LatLng> focusPoint;

    /** Helper function for setting the mercator position using Lat&Lng and altitude */
    void setLocation(const LatLng& location, double altitudeMeters);

    /** Helper function for converting mercator position into Lat&Lng and altitude. */
    std::tuple<LatLng, double> getLocation();
};
```

Only two parameters are currently exposed to the user: position in mercator coordinates and focus point on the map. Focus point is equivalent of the center point in the viewport API and it's used to compute the orientation of the camera. Zoom value can't be set explicitly set as it's computed from the distance between the camera and the focus point.

This interface could be extended to give the user better control of the camera (raw orientation access as a quaternion, view frustum information, projection properties, etc.)

### TODO
 - [x] More input validations
 - [x] Add unit tests