### PR TITLE
[core] Add style::Source::setVolatile()/isVolatile() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 
   Currently, the `distance` expression supports `Point`, `MultiPoint`, `LineString`, `MultiLineString` geometry types.
 
+- [core] Introduce style::Source::setVolatile()/isVolatile() API ([#16422](https://github.com/mapbox/mapbox-gl-native/pull/16422))
+
+  The `Source::setVolatile(bool)` method sets a flag defining whether or not the fetched tiles for the given source should be stored in the local cache.
+
+  The corresponding `Source::isVolatile()` getter is added too.
+
+  By default, the source is not volatile.
+
 ## maps-v1.6.0-rc.1
 
 ### ✨ New features

--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -33,6 +33,8 @@ public:
         Offline
     };
 
+    enum class StoragePolicy : bool { Permanent, Volatile };
+
     struct TileData {
         std::string urlTemplate;
         uint8_t pixelRatio;
@@ -96,6 +98,7 @@ public:
     optional<std::string> priorEtag = {};
     std::shared_ptr<const std::string> priorData;
     Duration minimumUpdateInterval{Duration::zero()};
+    StoragePolicy storagePolicy{StoragePolicy::Permanent};
 };
 
 inline bool Resource::hasLoadingMethod(Resource::LoadingMethod method) const {

--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -82,8 +82,9 @@ public:
     optional<uint8_t> getPrefetchZoomDelta() const noexcept;
 
     // If the given source supports loading tiles from a server,
-    // sets the minimum tile update interval, which is used to
-    // throttle the tile update network requests.
+    // sets the minimum tile update interval.
+    // Update network requests that are more frequent than the
+    // minimum tile update interval are suppressed.
     //
     // Default value is `Duration::zero()`.
     void setMinimumTileUpdateInterval(Duration) noexcept;

--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -66,11 +66,13 @@ public:
     std::string getID() const;
     optional<std::string> getAttribution() const;
 
+    // The data from the volatile sources are not stored in a persistent storage.
+    bool isVolatile() const noexcept;
+    void setVolatile(bool) noexcept;
+
     // Private implementation
     class Impl;
     Immutable<Impl> baseImpl;
-
-    Source(Immutable<Impl>);
 
     void setObserver(SourceObserver*);
     SourceObserver* observer = nullptr;
@@ -114,6 +116,7 @@ public:
     virtual mapbox::base::WeakPtr<Source> makeWeakPtr() = 0;
 
 protected:
+    explicit Source(Immutable<Impl>);
     virtual Mutable<Impl> createMutable() const noexcept = 0;
 };
 

--- a/platform/default/src/mbgl/storage/database_file_source.cpp
+++ b/platform/default/src/mbgl/storage/database_file_source.cpp
@@ -21,7 +21,8 @@ public:
         : db(std::make_unique<OfflineDatabase>(cachePath)), onlineFileSource(std::move(onlineFileSource_)) {}
 
     void request(const Resource& resource, const ActorRef<FileSourceRequest>& req) {
-        auto offlineResponse = db->get(resource);
+        optional<Response> offlineResponse =
+            (resource.storagePolicy != Resource::StoragePolicy::Volatile) ? db->get(resource) : nullopt;
         if (!offlineResponse) {
             offlineResponse.emplace();
             offlineResponse->noContent = true;

--- a/platform/default/src/mbgl/storage/database_file_source.cpp
+++ b/platform/default/src/mbgl/storage/database_file_source.cpp
@@ -179,6 +179,8 @@ std::unique_ptr<AsyncRequest> DatabaseFileSource::request(const Resource& resour
 }
 
 void DatabaseFileSource::forward(const Resource& res, const Response& response, std::function<void()> callback) {
+    if (res.storagePolicy == Resource::StoragePolicy::Volatile) return;
+
     std::function<void()> wrapper;
     if (callback) {
         wrapper = Scheduler::GetCurrent()->bindOnce(std::move(callback));

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -93,6 +93,7 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
     const optional<uint8_t>& sourcePrefetchZoomDelta = sourceImpl.getPrefetchZoomDelta();
     const optional<uint8_t>& maxParentTileOverscaleFactor = sourceImpl.getMaxOverscaleFactorForParentTiles();
     const Duration minimumUpdateInterval = sourceImpl.getMinimumTileUpdateInterval();
+    const bool isVolatile = sourceImpl.isVolatile();
 
     std::vector<OverscaledTileID> idealTiles;
     std::vector<OverscaledTileID> panTiles;
@@ -132,7 +133,7 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
 
     auto retainTileFn = [&](Tile& tile, TileNecessity necessity) -> void {
         if (retain.emplace(tile.id).second) {
-            tile.setUpdateParameters({minimumUpdateInterval});
+            tile.setUpdateParameters({minimumUpdateInterval, isVolatile});
             tile.setNecessity(necessity);
         }
 

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -132,7 +132,7 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
 
     auto retainTileFn = [&](Tile& tile, TileNecessity necessity) -> void {
         if (retain.emplace(tile.id).second) {
-            tile.setMinimumUpdateInterval(minimumUpdateInterval);
+            tile.setUpdateParameters({minimumUpdateInterval});
             tile.setNecessity(necessity);
         }
 

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -27,6 +27,18 @@ optional<std::string> Source::getAttribution() const {
     return baseImpl->getAttribution();
 }
 
+bool Source::isVolatile() const noexcept {
+    return baseImpl->isVolatile();
+}
+
+void Source::setVolatile(bool set) noexcept {
+    if (isVolatile() == set) return;
+    auto newImpl = createMutable();
+    newImpl->setVolatile(set);
+    baseImpl = std::move(newImpl);
+    observer->onSourceChanged(*this);
+}
+
 void Source::setObserver(SourceObserver* observer_) {
     observer = observer_ ? observer_ : &nullObserver;
 }

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mbgl/style/source.hpp>
-#include <mbgl/util/noncopyable.hpp>
 
 #include <string>
 
@@ -27,6 +26,8 @@ public:
     void setMaxOverscaleFactorForParentTiles(optional<uint8_t> overscaleFactor) noexcept;
     optional<uint8_t> getMaxOverscaleFactorForParentTiles() const noexcept;
 
+    bool isVolatile() const { return volatileFlag; }
+    void setVolatile(bool set) { volatileFlag = set; }
     const SourceType type;
     const std::string id;
 
@@ -34,6 +35,7 @@ protected:
     optional<uint8_t> prefetchZoomDelta;
     optional<uint8_t> maxOverscaleFactor;
     Duration minimumTileUpdateInterval{Duration::zero()};
+    bool volatileFlag = false;
 
     Impl(SourceType, std::string);
     Impl(const Impl&) = default;

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -122,8 +122,8 @@ void RasterDEMTile::setNecessity(TileNecessity necessity) {
     loader.setNecessity(necessity);
 }
 
-void RasterDEMTile::setMinimumUpdateInterval(Duration interval) {
-    loader.setMinimumUpdateInterval(interval);
+void RasterDEMTile::setUpdateParameters(const TileUpdateParameters& params) {
+    loader.setUpdateParameters(params);
 }
 
 } // namespace mbgl

--- a/src/mbgl/tile/raster_dem_tile.hpp
+++ b/src/mbgl/tile/raster_dem_tile.hpp
@@ -68,7 +68,7 @@ public:
 
     std::unique_ptr<TileRenderData> createRenderData() override;
     void setNecessity(TileNecessity) override;
-    void setMinimumUpdateInterval(Duration) override;
+    void setUpdateParameters(const TileUpdateParameters&) override;
 
     void setError(std::exception_ptr);
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -78,8 +78,8 @@ void RasterTile::setNecessity(TileNecessity necessity) {
     loader.setNecessity(necessity);
 }
 
-void RasterTile::setMinimumUpdateInterval(Duration interval) {
-    loader.setMinimumUpdateInterval(interval);
+void RasterTile::setUpdateParameters(const TileUpdateParameters& params) {
+    loader.setUpdateParameters(params);
 }
 
 } // namespace mbgl

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -24,7 +24,7 @@ public:
 
     std::unique_ptr<TileRenderData> createRenderData() override;
     void setNecessity(TileNecessity) override;
-    void setMinimumUpdateInterval(Duration) override;
+    void setUpdateParameters(const TileUpdateParameters&) override;
 
     void setError(std::exception_ptr);
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -36,10 +36,11 @@ class UploadPass;
 
 struct TileUpdateParameters {
     Duration minimumUpdateInterval;
+    bool isVolatile;
 };
 
 inline bool operator==(const TileUpdateParameters& a, const TileUpdateParameters& b) {
-    return a.minimumUpdateInterval == b.minimumUpdateInterval;
+    return a.minimumUpdateInterval == b.minimumUpdateInterval && a.isVolatile == b.isVolatile;
 }
 
 inline bool operator!=(const TileUpdateParameters& a, const TileUpdateParameters& b) {

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -34,6 +34,17 @@ namespace gfx {
 class UploadPass;
 } // namespace gfx
 
+struct TileUpdateParameters {
+    Duration minimumUpdateInterval;
+};
+
+inline bool operator==(const TileUpdateParameters& a, const TileUpdateParameters& b) {
+    return a.minimumUpdateInterval == b.minimumUpdateInterval;
+}
+
+inline bool operator!=(const TileUpdateParameters& a, const TileUpdateParameters& b) {
+    return !(a == b);
+}
 class Tile {
 public:
     enum class Kind : uint8_t {
@@ -52,7 +63,8 @@ public:
     void setObserver(TileObserver* observer);
 
     virtual void setNecessity(TileNecessity) {}
-    virtual void setMinimumUpdateInterval(Duration) {}
+
+    virtual void setUpdateParameters(const TileUpdateParameters&) {}
 
     // Mark this tile as no longer needed and cancel any pending work.
     virtual void cancel();

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -49,7 +49,7 @@ private:
     Resource resource;
     std::shared_ptr<FileSource> fileSource;
     std::unique_ptr<AsyncRequest> request;
-    TileUpdateParameters updateParameters{{Duration::zero()}};
+    TileUpdateParameters updateParameters{Duration::zero(), false};
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -23,7 +23,7 @@ public:
     ~TileLoader();
 
     void setNecessity(TileNecessity newNecessity);
-    void setMinimumUpdateInterval(Duration);
+    void setUpdateParameters(const TileUpdateParameters&);
 
 private:
     // called when the tile is one of the ideal tiles that we want to show definitely. the tile source
@@ -49,7 +49,7 @@ private:
     Resource resource;
     std::shared_ptr<FileSource> fileSource;
     std::unique_ptr<AsyncRequest> request;
-    Duration minimumUpdateInterval{Duration::zero()};
+    TileUpdateParameters updateParameters{{Duration::zero()}};
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -160,6 +160,8 @@ void TileLoader<T>::loadFromNetwork() {
     // NetworkOnly request.
     resource.loadingMethod = Resource::LoadingMethod::NetworkOnly;
     resource.minimumUpdateInterval = updateParameters.minimumUpdateInterval;
+    resource.storagePolicy =
+        updateParameters.isVolatile ? Resource::StoragePolicy::Volatile : Resource::StoragePolicy::Permanent;
     request = fileSource->request(resource, [this](const Response& res) { loadedData(res); });
 }
 

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -69,9 +69,9 @@ void TileLoader<T>::setNecessity(TileNecessity newNecessity) {
 }
 
 template <typename T>
-void TileLoader<T>::setMinimumUpdateInterval(Duration interval) {
-    if (minimumUpdateInterval != interval) {
-        minimumUpdateInterval = interval;
+void TileLoader<T>::setUpdateParameters(const TileUpdateParameters& params) {
+    if (updateParameters != params) {
+        updateParameters = params;
         if (hasPendingNetworkRequest()) {
             // Update the pending request.
             request.reset();
@@ -159,7 +159,7 @@ void TileLoader<T>::loadFromNetwork() {
     // Instead of using Resource::LoadingMethod::All, we're first doing a CacheOnly, and then a
     // NetworkOnly request.
     resource.loadingMethod = Resource::LoadingMethod::NetworkOnly;
-    resource.minimumUpdateInterval = minimumUpdateInterval;
+    resource.minimumUpdateInterval = updateParameters.minimumUpdateInterval;
     request = fileSource->request(resource, [this](const Response& res) { loadedData(res); });
 }
 

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -16,8 +16,8 @@ void VectorTile::setNecessity(TileNecessity necessity) {
     loader.setNecessity(necessity);
 }
 
-void VectorTile::setMinimumUpdateInterval(Duration interval) {
-    loader.setMinimumUpdateInterval(interval);
+void VectorTile::setUpdateParameters(const TileUpdateParameters& params) {
+    loader.setUpdateParameters(params);
 }
 
 void VectorTile::setMetadata(optional<Timestamp> modified_, optional<Timestamp> expires_) {

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -16,7 +16,7 @@ public:
                const Tileset&);
 
     void setNecessity(TileNecessity) final;
-    void setMinimumUpdateInterval(Duration interval) final;
+    void setUpdateParameters(const TileUpdateParameters&) final;
     void setMetadata(optional<Timestamp> modified, optional<Timestamp> expires);
     void setData(const std::shared_ptr<const std::string>& data);
 

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -229,7 +229,6 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RespectMinimumUpdateInterval)) {
     std::unique_ptr<AsyncRequest> req = fs->request(resource, [&](Response) {
         auto wait = util::now() - start;
         EXPECT_GE(wait, resource.minimumUpdateInterval);
-        EXPECT_LT(wait, resource.minimumUpdateInterval + Milliseconds(10));
         loop.stop();
     });
 

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -749,7 +749,7 @@ public:
         renderable = true;
     }
     void setNecessity(TileNecessity necessity) override;
-    void setMinimumUpdateInterval(Duration) override;
+    void setUpdateParameters(const TileUpdateParameters&) override;
     bool layerPropertiesUpdated(const Immutable<style::LayerProperties>&) override { return true; }
 
     std::unique_ptr<TileRenderData> createRenderData() override { return nullptr; }
@@ -789,8 +789,8 @@ void FakeTile::setNecessity(TileNecessity necessity) {
     source.tileSetNecessity(necessity);
 }
 
-void FakeTile::setMinimumUpdateInterval(Duration interval) {
-    source.tileSetMinimumUpdateInterval(interval);
+void FakeTile::setUpdateParameters(const TileUpdateParameters& params) {
+    source.tileSetMinimumUpdateInterval(params.minimumUpdateInterval);
 }
 
 } // namespace


### PR DESCRIPTION
The tile data from the volatile sources are not stored in local storage, i.e. they are not cached.

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/335