### PR TITLE
Add common vector math operations to mat3.hpp

### DIFF
--- a/src/mbgl/util/bounding_volumes.cpp
+++ b/src/mbgl/util/bounding_volumes.cpp
@@ -11,34 +11,6 @@ vec3 toVec3(const vec4& v) {
     return vec3{v[0], v[1], v[2]};
 }
 
-vec3 vec3Sub(const vec3& a, const vec3& b) {
-    return vec3{a[0] - b[0], a[1] - b[1], a[2] - b[2]};
-}
-
-vec3 vec3Scale(const vec3& a, double s) {
-    return vec3{a[0] * s, a[1] * s, a[2] * s};
-}
-
-vec3 vec3Cross(const vec3& a, const vec3& b) {
-    return vec3{a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]};
-}
-
-double vec3Dot(const vec3& a, const vec3& b) {
-    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-}
-
-double vec3LengthSq(const vec3& a) {
-    return vec3Dot(a, a);
-}
-
-double vec3Length(const vec3& a) {
-    return std::sqrt(vec3LengthSq(a));
-}
-
-vec3 vec3Normalize(const vec3& a) {
-    return vec3Scale(a, 1.0 / vec3Length(a));
-}
-
 double vec4Dot(const vec4& a, const vec4& b) {
     return a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3];
 }

--- a/src/mbgl/util/mat3.hpp
+++ b/src/mbgl/util/mat3.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 
 namespace mbgl {
 
@@ -30,6 +31,34 @@ using vec3 = std::array<double, 3>;
 using vec3f = std::array<float, 3>;
 using vec3i = std::array<int, 3>;
 using mat3 = std::array<double, 9>;
+
+inline vec3 vec3Cross(const vec3& a, const vec3& b) {
+    return vec3{a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]};
+}
+
+inline double vec3Dot(const vec3& a, const vec3& b) {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+inline double vec3LengthSq(const vec3& a) {
+    return vec3Dot(a, a);
+}
+
+inline double vec3Length(const vec3& a) {
+    return std::sqrt(vec3LengthSq(a));
+}
+
+inline vec3 vec3Scale(const vec3& a, double s) {
+    return vec3{a[0] * s, a[1] * s, a[2] * s};
+}
+
+inline vec3 vec3Normalize(const vec3& a) {
+    return vec3Scale(a, 1.0 / vec3Length(a));
+}
+
+inline vec3 vec3Sub(const vec3& a, const vec3& b) {
+    return vec3{a[0] - b[0], a[1] - b[1], a[2] - b[2]};
+}
 
 namespace matrix {
 


### PR DESCRIPTION
Move common vec3 math operations defined in `bounding_volumes.cpp` to `mat3.hpp` for shared use. These functions are required in the 3D camera development https://github.com/mapbox/mapbox-gl-native/pull/16419.
