### PR TITLE
Fix error receiving local file URL response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 
   By default, the source is not volatile.
 
+### Bug fixes
+
+- [ios, macos] Fixed error receiving local file URL response ([#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428))
+
 ## maps-v1.6.0-rc.1
 
 ### ✨ New features

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -371,6 +371,8 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
                             std::make_unique<Error>(Error::Reason::Other, std::string{ "HTTP status code " } +
                                                                               std::to_string(responseCode));
                     }
+                } else if ([url isFileURL]) {
+                    response.data = std::make_shared<std::string>((const char *)[data bytes], [data length]);
                 } else {
                     // This should never happen.
                     response.error = std::make_unique<Error>(Error::Reason::Other,


### PR DESCRIPTION
Happily accept the data in an NSURLResponse that isn’t an NSHTTPURLResponse as long as the file is a local file URL. I left the existing else statement in place just in case, but we could probably remove that error to fix other non-HTTP protocols like smb:.

Fixes #16427.

/cc @mapbox/maps-ios