### PR TITLE
[build] Make the output directory consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ option(MBGL_WITH_RTTI "Compile with runtime type information" OFF)
 option(MBGL_WITH_OPENGL "Build with OpenGL renderer" ON)
 option(MBGL_WITH_WERROR "Make all compilation warnings errors" ON)
 
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 add_library(
     mbgl-compiler-options INTERFACE
 )

--- a/benchmark/ios/BenchmarkApp_iphoneos13.2-arm64e-release.xctestrun
+++ b/benchmark/ios/BenchmarkApp_iphoneos13.2-arm64e-release.xctestrun
@@ -15,8 +15,8 @@
 		<array/>
 		<key>DependentProductPaths</key>
 		<array>
-			<string>__TESTROOT__/Release-iphoneos/BenchmarkApp.app</string>
-			<string>__TESTROOT__/Release-iphoneos/BenchmarkApp.app/PlugIns/BenchmarkAppTests.xctest</string>
+			<string>__TESTROOT__/Release/BenchmarkApp.app</string>
+			<string>__TESTROOT__/Release/BenchmarkApp.app/PlugIns/BenchmarkAppTests.xctest</string>
 		</array>
 		<key>EnvironmentVariables</key>
 		<dict>
@@ -38,7 +38,7 @@
 		<key>TestHostBundleIdentifier</key>
 		<string>com.mapbox.BenchmarkApp</string>
 		<key>TestHostPath</key>
-		<string>__TESTROOT__/Release-iphoneos/BenchmarkApp.app</string>
+		<string>__TESTROOT__/Release/BenchmarkApp.app</string>
 		<key>TestLanguage</key>
 		<string></string>
 		<key>TestRegion</key>

--- a/benchmark/ios/codesigning/codesign_all.sh
+++ b/benchmark/ios/codesigning/codesign_all.sh
@@ -3,9 +3,9 @@ identity=$(/usr/bin/env xcrun security find-identity -v -p codesigning)
 var=${identity#*1)\ }
 CODE_SIGN_IDENTITY=${var%\ \"Apple\ Development*}
 
-codesign --force --sign $CODE_SIGN_IDENTITY --entitlements codesigning/BenchmarkApp.app.xcent --timestamp=none ./Release-iphoneos/BenchmarkApp.app
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/BenchmarkApp.app/Frameworks/libXCTestSwiftSupport.dylib
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/BenchmarkApp.app/Frameworks/libXCTestBundleInject.dylib
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/BenchmarkApp.app/Frameworks/XCTAutomationSupport.framework
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/BenchmarkApp.app/Frameworks/XCTest.framework
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --entitlements codesigning/BenchmarkAppTests.xctest.xcent --timestamp=none ./Release-iphoneos/BenchmarkApp.app/PlugIns/BenchmarkAppTests.xctest
+codesign --force --sign $CODE_SIGN_IDENTITY --entitlements codesigning/BenchmarkApp.app.xcent --timestamp=none ./Release/BenchmarkApp.app
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/BenchmarkApp.app/Frameworks/libXCTestSwiftSupport.dylib
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/BenchmarkApp.app/Frameworks/libXCTestBundleInject.dylib
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/BenchmarkApp.app/Frameworks/XCTAutomationSupport.framework
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/BenchmarkApp.app/Frameworks/XCTest.framework
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --entitlements codesigning/BenchmarkAppTests.xctest.xcent --timestamp=none ./Release/BenchmarkApp.app/PlugIns/BenchmarkAppTests.xctest

--- a/circle.yml
+++ b/circle.yml
@@ -418,7 +418,7 @@ commands:
             cd build
             ./codesigning/generate-entitlements.swift
             ./codesigning/codesign_all.sh
-            codesign -dv --verbose=4 Release-iphoneos/*.app # for debugging that app is signed or not
+            codesign -dv --verbose=4 Release/*.app # for debugging that app is signed or not
   run-ios-test-app:
     parameters:
       directory:
@@ -432,7 +432,7 @@ commands:
               # arrange files in a way Firebase expects it, and package them in a zip file
               cp << parameters.directory >>/*_iphoneos13.2-arm64e-release.xctestrun build
               cd build
-              zip testapp.zip -r Release-iphoneos/*.app --quiet
+              zip testapp.zip -r Release/*.app --quiet
               zip testapp.zip *_iphoneos13.2-arm64e-release.xctestrun
               gcloud firebase test ios models list
               gcloud firebase test ios run \

--- a/render-test/ios/RenderTestApp_iphoneos13.2-arm64e-release.xctestrun
+++ b/render-test/ios/RenderTestApp_iphoneos13.2-arm64e-release.xctestrun
@@ -15,8 +15,8 @@
 		<array/>
 		<key>DependentProductPaths</key>
 		<array>
-			<string>__TESTROOT__/Release-iphoneos/RenderTestApp.app</string>
-			<string>__TESTROOT__/Release-iphoneos/RenderTestApp.app/PlugIns/RenderTestAppTests.xctest</string>
+			<string>__TESTROOT__/Release/RenderTestApp.app</string>
+			<string>__TESTROOT__/Release/RenderTestApp.app/PlugIns/RenderTestAppTests.xctest</string>
 		</array>
 		<key>EnvironmentVariables</key>
 		<dict>
@@ -38,7 +38,7 @@
 		<key>TestHostBundleIdentifier</key>
 		<string>com.mapbox.RenderTestApp</string>
 		<key>TestHostPath</key>
-		<string>__TESTROOT__/Release-iphoneos/RenderTestApp.app</string>
+		<string>__TESTROOT__/Release/RenderTestApp.app</string>
 		<key>TestLanguage</key>
 		<string></string>
 		<key>TestRegion</key>

--- a/render-test/ios/codesigning/codesign_all.sh
+++ b/render-test/ios/codesigning/codesign_all.sh
@@ -3,9 +3,9 @@ identity=$(/usr/bin/env xcrun security find-identity -v -p codesigning)
 var=${identity#*1)\ }
 CODE_SIGN_IDENTITY=${var%\ \"Apple\ Development*}
 
-codesign --force --sign $CODE_SIGN_IDENTITY --entitlements codesigning/RenderTestApp.app.xcent --timestamp=none ./Release-iphoneos/RenderTestApp.app
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/RenderTestApp.app/Frameworks/libXCTestSwiftSupport.dylib
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/RenderTestApp.app/Frameworks/libXCTestBundleInject.dylib
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/RenderTestApp.app/Frameworks/XCTAutomationSupport.framework
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/RenderTestApp.app/Frameworks/XCTest.framework
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --entitlements codesigning/RenderTestAppTests.xctest.xcent --timestamp=none ./Release-iphoneos/RenderTestApp.app/PlugIns/RenderTestAppTests.xctest
+codesign --force --sign $CODE_SIGN_IDENTITY --entitlements codesigning/RenderTestApp.app.xcent --timestamp=none ./Release/RenderTestApp.app
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/RenderTestApp.app/Frameworks/libXCTestSwiftSupport.dylib
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/RenderTestApp.app/Frameworks/libXCTestBundleInject.dylib
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/RenderTestApp.app/Frameworks/XCTAutomationSupport.framework
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/RenderTestApp.app/Frameworks/XCTest.framework
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --entitlements codesigning/RenderTestAppTests.xctest.xcent --timestamp=none ./Release/RenderTestApp.app/PlugIns/RenderTestAppTests.xctest

--- a/test/ios/UnitTestsApp_iphoneos13.2-arm64e-release.xctestrun
+++ b/test/ios/UnitTestsApp_iphoneos13.2-arm64e-release.xctestrun
@@ -15,8 +15,8 @@
 		<array/>
 		<key>DependentProductPaths</key>
 		<array>
-			<string>__TESTROOT__/Release-iphoneos/UnitTestsApp.app</string>
-			<string>__TESTROOT__/Release-iphoneos/UnitTestsApp.app/PlugIns/UnitTestsAppTests.xctest</string>
+			<string>__TESTROOT__/Release/UnitTestsApp.app</string>
+			<string>__TESTROOT__/Release/UnitTestsApp.app/PlugIns/UnitTestsAppTests.xctest</string>
 		</array>
 		<key>EnvironmentVariables</key>
 		<dict>
@@ -38,7 +38,7 @@
 		<key>TestHostBundleIdentifier</key>
 		<string>com.mapbox.UnitTestsApp</string>
 		<key>TestHostPath</key>
-		<string>__TESTROOT__/Release-iphoneos/UnitTestsApp.app</string>
+		<string>__TESTROOT__/Release/UnitTestsApp.app</string>
 		<key>TestLanguage</key>
 		<string></string>
 		<key>TestRegion</key>

--- a/test/ios/codesigning/codesign_all.sh
+++ b/test/ios/codesigning/codesign_all.sh
@@ -3,9 +3,9 @@ identity=$(/usr/bin/env xcrun security find-identity -v -p codesigning)
 var=${identity#*1)\ }
 CODE_SIGN_IDENTITY=${var%\ \"Apple\ Development*}
 
-codesign --force --sign $CODE_SIGN_IDENTITY --entitlements codesigning/UnitTestsApp.app.xcent --timestamp=none ./Release-iphoneos/UnitTestsApp.app
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/UnitTestsApp.app/Frameworks/libXCTestSwiftSupport.dylib
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/UnitTestsApp.app/Frameworks/libXCTestBundleInject.dylib
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/UnitTestsApp.app/Frameworks/XCTAutomationSupport.framework
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release-iphoneos/UnitTestsApp.app/Frameworks/XCTest.framework
-codesign --force --sign $CODE_SIGN_IDENTITY --deep --entitlements codesigning/UnitTestsAppTests.xctest.xcent --timestamp=none ./Release-iphoneos/UnitTestsApp.app/PlugIns/UnitTestsAppTests.xctest
+codesign --force --sign $CODE_SIGN_IDENTITY --entitlements codesigning/UnitTestsApp.app.xcent --timestamp=none ./Release/UnitTestsApp.app
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/UnitTestsApp.app/Frameworks/libXCTestSwiftSupport.dylib
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/UnitTestsApp.app/Frameworks/libXCTestBundleInject.dylib
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/UnitTestsApp.app/Frameworks/XCTAutomationSupport.framework
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --preserve-metadata=identifier,entitlements,flags --timestamp=none ./Release/UnitTestsApp.app/Frameworks/XCTest.framework
+codesign --force --sign $CODE_SIGN_IDENTITY --deep --entitlements codesigning/UnitTestsAppTests.xctest.xcent --timestamp=none ./Release/UnitTestsApp.app/PlugIns/UnitTestsAppTests.xctest


### PR DESCRIPTION
Instead of placing binaries and libraries scattered inside the build directory.