### PR TITLE
[core][tile mode] Labels priority fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## master
+
+### 🐞 Bug fixes
+
+- [core][tile mode] Labels priority fixes ([#16432](https://github.com/mapbox/mapbox-gl-native/pull/16432))
+
+  This change does the following:
+
+  - strictly arranges all the intersecting labels accordingly to the style-defined priorities
+  - fixes placement order of the variable labels.
+    Before this change, all variable labels that could potentially intersect tile borders were placed first, breaking the style label placement priority order. Now, all the variable labels, which do not actually intersect the tile borders, are placed accordingly to the style-defined priorities
+
 ## maps-v1.6.0-rc.2
 
 ### ✨ New features

--- a/metrics/binary-size/macos-xcode11/metrics.json
+++ b/metrics/binary-size/macos-xcode11/metrics.json
@@ -3,17 +3,17 @@
         [
             "mbgl-glfw",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-glfw",
-            5198016
+            5243480
         ],
         [
             "mbgl-offline",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-offline",
-            4430448
+            4475952
         ],
         [
             "mbgl-render",
             "/tmp/attach/install/macos-xcode11-release/bin/mbgl-render",
-            5044352
+            5089824
         ]
     ]
 }

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -142,9 +142,7 @@ public:
 protected:
     friend SymbolBucket;
     virtual void placeSymbolBucket(const BucketPlacementData&, std::set<uint32_t>& seenCrossTileIDs);
-    void placeSymbol(const SymbolInstance& symbolInstance,
-                     const PlacementContext&,
-                     std::set<uint32_t>& seenCrossTileIDs);
+    JointPlacement placeSymbol(const SymbolInstance& symbolInstance, const PlacementContext&);
     void placeLayer(const RenderLayer&, std::set<uint32_t>&);
     virtual void commit();
     virtual void newSymbolPlaced(const SymbolInstance&,


### PR DESCRIPTION
This PR fixes label priority issues in the Tile mode. It does the following:
- strictly arranges all the intersecting labels accordingly to the style-defined priorities
- fixes placement order of the variable labels.
    _Before this change, all variable labels that could potentially
    intersect tile borders were placed first, breaking the style
    label placement priority order. Now, all the variable labels, which
    do not actually intersect the tile borders, are placed accordingly 
    to the style-defined priorities_

Fixes https://github.com/mapbox/mapbox-gl-native-team/issues/338