### PR TITLE
Support query elevation data from raster DEM source.

### DIFF
--- a/src/mbgl/geometry/dem_data.hpp
+++ b/src/mbgl/geometry/dem_data.hpp
@@ -17,6 +17,8 @@ public:
     void backfillBorder(const DEMData& borderTileData, int8_t dx, int8_t dy);
 
     int32_t get(int32_t x, int32_t y) const;
+    float getFloat(int32_t x, int32_t y) const;
+    float getInterpolated(float x, float y) const;
     const std::array<float, 4>& getUnpackVector() const;
 
     const PremultipliedImage* getImage() const {

--- a/src/mbgl/renderer/sources/render_raster_dem_source.cpp
+++ b/src/mbgl/renderer/sources/render_raster_dem_source.cpp
@@ -108,11 +108,17 @@ void RenderRasterDEMSource::onTileChanged(Tile& tile){
 }
 
 std::unordered_map<std::string, std::vector<Feature>>
-RenderRasterDEMSource::queryRenderedFeatures(const ScreenLineString&,
-                                          const TransformState&,
-                                          const std::unordered_map<std::string, const RenderLayer*>&,
-                                          const RenderedQueryOptions&,
-                                          const mat4&) const {
+RenderRasterDEMSource::queryRenderedFeatures(const ScreenLineString& geometry,
+                                             const TransformState& transformState,
+                                             const std::unordered_map<std::string, const RenderLayer*>& layers,
+                                             const RenderedQueryOptions& options,
+                                             const mat4& projMatrix) const {
+    // Only query the first layer for this source.
+    for (const auto& layer : layers) {
+        if (layer.second->baseImpl->source == impl().id) {
+            return tilePyramid.queryRenderedFeatures(geometry, transformState, { layer }, options, projMatrix, {});
+        }
+    }
     return std::unordered_map<std::string, std::vector<Feature>>{};
 }
 

--- a/src/mbgl/tile/raster_dem_tile.hpp
+++ b/src/mbgl/tile/raster_dem_tile.hpp
@@ -76,6 +76,12 @@ public:
 
     bool layerPropertiesUpdated(const Immutable<style::LayerProperties>& layerProperties) override;
 
+    void queryRenderedFeatures(std::unordered_map<std::string, std::vector<Feature>>& result,
+                               const GeometryCoordinates& queryGeometry, const TransformState&,
+                               const std::unordered_map<std::string, const RenderLayer*>& layers,
+                               const RenderedQueryOptions& options, const mat4& projMatrix,
+                               const SourceFeatureState& featureState) override;
+
     HillshadeBucket* getBucket() const;
     void backfillBorder(const RasterDEMTile& borderTile, DEMTileNeighbors mask);
 


### PR DESCRIPTION
I have enhanced queryRenderedFeatures to return elevation data from raster DEM source for point query.

Initially, I want to add a method to return elevation data. But after I studied queryRenderedFeatures, I thought it may not be a bad idea to just enhance it, as currently it does nothing for raster DEM source.

The implementation will return "ele" and "zoom" for a point query. "ele" is the elevation in meters. It will return the interpolated value without any rounding, and let developers decide how many decimal places to keep themselves. "zoom" is the zoom level of the tile from which the elevation is obtained. The implementation tries to return one result for a query. But when the device is offline, it seems that multiple results may be returned with different zoom levels. Developers can use the one with the highest zoom level.

This PR will affect existing Mapbox projects which do point query without any layer IDs and filters. Probably, the logic in those projects are general enough to handle this extra result.

See whether this PR is acceptable. If not, see whether it is possible to provide some other ways to retrieve the elevation data.