### PR TITLE
Add a factor to limit tilt when offset value is important

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -644,7 +644,8 @@ double Transform::getMaxPitchForEdgeInsets(const EdgeInsets& insets) const {
     // We use half of fov, as it is field of view above perspective center.
     // With inset, this angle changes and tangentOfFovAboveCenterAngle = (h/2 + centerOffsetY) / (height * 1.5).
     // 1.03 is a bit extra added to prevent parallel ground to viewport clipping plane.
-    const double tangentOfFovAboveCenterAngle = 1.03 * (height / 2.0 + centerOffsetY) / (1.5 * height);
+    // 2.4 is an arbitrary factor to prevent too much depth when the top offset is important.
+    const double tangentOfFovAboveCenterAngle = 1.03 * (height / 2.0 + centerOffsetY * 2.4) / (1.5 * height);
     const double fovAboveCenter = std::atan(tangentOfFovAboveCenterAngle);
     return M_PI * 0.5 - fovAboveCenter;
     // e.g. Maximum pitch of 60 degrees is when perspective center's offset from the top is 84% of screen height.


### PR DESCRIPTION
With an important tilt, when using a top padding to offset the map center, like in GPS apps, currently the view depth becomes very far away, and the apps become very laggy (unusable on Android devices).
PR https://github.com/mapbox/mapbox-gl-native/pull/15195 limits the depth, but this is far from enough. 

As described in https://github.com/mapbox/mapbox-gl-native-android/issues/162 , from the demo sample :

- Add a button on activity_basic_simpe_mapview.xml
```
    <Button  
        android:id="@+id/simple_map_change_padding"  
        android:layout_width="wrap_content"  
        android:layout_height="wrap_content"  
        android:text="Change padding" />
```

- Modify the SimpleMapActivity. At the end of the onCreate, add
```
    findViewById(R.id.simple_map_change_padding).setOnClickListener(v -> {  
        mapView.getMapAsync(mapboxMap -> {  
        mapboxMap.setCameraPosition(new CameraPosition.Builder().padding(0, (int) (mapView.getMeasuredHeight() * 0.7), 0, 0).build());
        });  
    });
```

As a result, the view depth is too far away :

![Capture d’écran 2020-04-29 à 19 27 14](https://user-images.githubusercontent.com/16834537/80626951-7e0c3480-8a4f-11ea-90c8-ae71f4ae22b0.png)

By adding a factor of 2.4 (value to be discussed) to the top offset when calculating the maximum tilt for a specified inset, the depth is less far away and the behavior is much more reasonable, allowing to use the app without lag while maintaining a view depth similar as when there is no padding, and also similar as what we had before the padding behavior was changed (post Android 7.4 release).
![Capture d’écran 2020-04-29 à 19 34 43](https://user-images.githubusercontent.com/16834537/80627624-831db380-8a50-11ea-9209-b2410c854824.png)

Note that on this particular screen, the resulting max tilt is approximately 45 degrees, which could be set manually using the MapboxMapOptions. However, this means the value would be set even when padding values do not need it (what about landscape mode ?). Also I think the current behavior looks like a bug, and users should not have to dig into mapbox issues to find this workaround.

Regards !