### PR TITLE
[darwin] Remove `accountType` check

### DIFF
--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -93,7 +93,6 @@ public:
 
     NSURLSession* session = nil;
     NSString* userAgent = nil;
-    NSInteger accountType = 0;
 
 private:
     NSString* getUserAgent() const;
@@ -196,12 +195,11 @@ BOOL isValidMapboxEndpoint(NSURL *url) {
 }
 
 MGL_APPLE_EXPORT
-NSURL *resourceURLWithAccountType(const Resource& resource, NSInteger accountType) {
+NSURL *resourceURL(const Resource& resource) {
     
     NSURL *url = [NSURL URLWithString:@(resource.url.c_str())];
-    
-#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-    if (accountType == 0 && isValidMapboxEndpoint(url)) {
+
+    if (isValidMapboxEndpoint(url)) {
         NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
         NSMutableArray *queryItems = [NSMutableArray array];
 
@@ -219,9 +217,6 @@ NSURL *resourceURLWithAccountType(const Resource& resource, NSInteger accountTyp
         components.queryItems = queryItems;
         url = components.URL;
     }
-#else
-    (void)accountType;
-#endif
     return url;
 }
     
@@ -230,7 +225,7 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
     auto shared = request->shared; // Explicit copy so that it also gets copied into the completion handler block below.
 
     @autoreleasepool {
-        NSURL *url = resourceURLWithAccountType(resource, impl->accountType);
+        NSURL *url = resourceURL(resource);
         [MGLNativeNetworkManager.sharedManager debugLog:@"Requesting URI: %@", url.relativePath];
 
         NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];


### PR DESCRIPTION
## Launch Checklist

This PR removes the check for whether `accountType` is equal to `0`. 

@julianrex 