### PR TITLE
[ios] Update generated Xcode project with -Os & -flto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+### 🐞 Bug fixes
+
+- [ios, macos] Fix iOS [framework size regression](https://github.com/mapbox/mapbox-gl-native-ios/issues/63) by restoring optimization settings to `-Os`. ([#16460](https://github.com/mapbox/mapbox-gl-native/pull/16460))
+
 ## maps-v1.6.0
 
 ### ✨ New features

--- a/platform/ios/ios-test-runners.cmake
+++ b/platform/ios/ios-test-runners.cmake
@@ -1,3 +1,22 @@
+macro(initialize_ios_test_target target bitcode_generation)
+    set(EXTRA_ARGS ${ARGN})
+    list(LENGTH EXTRA_ARGS EXTRA_ARGS_NUM)
+    if(${EXTRA_ARGS_NUM} EQUAL 1)
+        list(GET EXTRA_ARGS 0 PLIST)
+        set_target_properties(${target} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${PLIST})
+    endif()
+
+    if("${bitcode_generation}" STREQUAL "YES")
+        set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")
+        set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE bitcode)
+    endif()
+
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IOS_DEPLOYMENT_TARGET}")
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
+endmacro()
+
 if(MBGL_IOS_RENDER_TEST)
     include(${PROJECT_SOURCE_DIR}/vendor/zip-archive.cmake)
     initialize_ios_target(mbgl-vendor-zip-archive)
@@ -24,7 +43,7 @@ if(MBGL_IOS_RENDER_TEST)
         ${PROJECT_SOURCE_DIR}/render-test/ios/iosTestRunner.mm
         ${RESOURCES}
     )
-    initialize_ios_target(RenderTestApp)
+    initialize_ios_test_target(RenderTestApp "YES")
     add_dependencies(RenderTestApp RenderTestApp-prepare)
 
     set_target_properties(
@@ -79,12 +98,7 @@ if(MBGL_IOS_RENDER_TEST)
     )
 
     xctest_add_test(XCTest.RenderTestApp RenderTestAppTests)
-
-    set_target_properties(RenderTestAppTests PROPERTIES XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IOS_DEPLOYMENT_TARGET}")
-    set_target_properties(RenderTestAppTests PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
-    set_target_properties(RenderTestAppTests PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/render-test/ios/tests/Info.plist)
-    set_target_properties(RenderTestAppTests PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
-    set_target_properties(RenderTestAppTests PROPERTIES XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
+    initialize_ios_test_target(RenderTestAppTests "NO" ${PROJECT_SOURCE_DIR}/render-test/ios/tests/Info.plist)
 endif()
 
 if(MBGL_IOS_UNIT_TEST)
@@ -109,7 +123,7 @@ if(MBGL_IOS_UNIT_TEST)
         ${PROJECT_SOURCE_DIR}/test/ios/iosTestRunner.h
         ${RESOURCES}
     )
-    initialize_ios_target(UnitTestsApp)
+    initialize_ios_test_target(UnitTestsApp "YES")
 
     set_target_properties(
         UnitTestsApp
@@ -151,12 +165,7 @@ if(MBGL_IOS_UNIT_TEST)
     )
 
     xctest_add_test(XCTest.UnitTestsApp UnitTestsAppTests)
-
-    set_target_properties(UnitTestsAppTests PROPERTIES XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IOS_DEPLOYMENT_TARGET}")
-    set_target_properties(UnitTestsAppTests PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
-    set_target_properties(UnitTestsAppTests PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/test/ios/tests/Info.plist)
-    set_target_properties(UnitTestsAppTests PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
-    set_target_properties(UnitTestsAppTests PROPERTIES XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
+    initialize_ios_test_target(UnitTestsAppTests "NO" ${PROJECT_SOURCE_DIR}/test/ios/tests/Info.plist)
 endif()
 
 if(MBGL_IOS_BENCHMARK)
@@ -181,7 +190,7 @@ if(MBGL_IOS_BENCHMARK)
         ${PROJECT_SOURCE_DIR}/benchmark/ios/iosTestRunner.h
         ${RESOURCES}
     )
-    initialize_ios_target(BenchmarkApp)
+    initialize_ios_test_target(BenchmarkApp "YES")
 
     target_include_directories(
         BenchmarkApp
@@ -214,10 +223,5 @@ if(MBGL_IOS_BENCHMARK)
     )
 
     xctest_add_test(XCTest.BenchmarkApp BenchmarkAppTests)
-
-    set_target_properties(BenchmarkAppTests PROPERTIES XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IOS_DEPLOYMENT_TARGET}")
-    set_target_properties(BenchmarkAppTests PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
-    set_target_properties(BenchmarkAppTests PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/benchmark/ios/tests/Info.plist)
-    set_target_properties(BenchmarkAppTests PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
-    set_target_properties(BenchmarkAppTests PROPERTIES XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
+    initialize_ios_test_target(BenchmarkAppTests "NO" ${PROJECT_SOURCE_DIR}/benchmark/ios/tests/Info.plist)
 endif()

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -11,12 +11,12 @@ macro(initialize_ios_target target)
     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
 
     # Enable LTO & -Os for Release and RelWithDebInfo (which is currently still used by iOS release packages)
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=MinSizeRel] $<$<CONFIG:MINSIZEREL>:s>)
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:s>)
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] $<$<CONFIG:RELEASE>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=MinSizeRel] $<$<CONFIG:MINSIZEREL>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] $<$<CONFIG:RELEASE>:s>)
 
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:YES>)
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=Release] $<$<CONFIG:RELEASE>:YES>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:YES>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=Release] $<$<CONFIG:RELEASE>:YES>)
 endmacro()
 
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -9,6 +9,13 @@ macro(initialize_ios_target target)
     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")
     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE bitcode)
     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
+
+    # Enable LTO & -Os for Release and RelWithDebInfo (which is currently still used by iOS release packages)
+
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELEASE>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELWITHDEBINFO>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELEASE>:YES>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELWITHDEBINFO>:YES>)
 endmacro()
 
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -11,11 +11,12 @@ macro(initialize_ios_target target)
     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
 
     # Enable LTO & -Os for Release and RelWithDebInfo (which is currently still used by iOS release packages)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=MinSizeRel] $<$<CONFIG:MINSIZEREL>:s>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:s>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] $<$<CONFIG:RELEASE>:s>)
 
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELEASE>:s>)
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELWITHDEBINFO>:s>)
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELEASE>:YES>)
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELWITHDEBINFO>:YES>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:YES>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=Release] $<$<CONFIG:RELEASE>:YES>)
 endmacro()
 
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -3,16 +3,14 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
 
 macro(initialize_macos_target target)
-    # Enable LTO & -Os for Release and RelWithDebInfo (which is currently still used by iOS release packages)
+    # Enable LTO & -Os for Release and RelWithDebInfo
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=MinSizeRel] $<$<CONFIG:MINSIZEREL>:s>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:s>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] $<$<CONFIG:RELEASE>:s>)
 
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELEASE>:s>)
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELWITHDEBINFO>:s>)
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELEASE>:YES>)
-    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELWITHDEBINFO>:YES>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:YES>)
+     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=Release] $<$<CONFIG:RELEASE>:YES>)
 endmacro()
-
-
-
 
 if(MBGL_WITH_OPENGL)
     find_package(OpenGL REQUIRED)
@@ -90,7 +88,9 @@ target_include_directories(
 include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
 
 initialize_macos_target(mbgl-core)
+initialize_macos_target(mbgl-vendor-csscolorparser)
 initialize_macos_target(mbgl-vendor-icu)
+initialize_macos_target(mbgl-vendor-parsedate)
 
 target_link_libraries(
     mbgl-core

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -4,12 +4,12 @@ set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC
 
 macro(initialize_macos_target target)
     # Enable LTO & -Os for Release and RelWithDebInfo
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=MinSizeRel] $<$<CONFIG:MINSIZEREL>:s>)
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:s>)
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] $<$<CONFIG:RELEASE>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=MinSizeRel] $<$<CONFIG:MINSIZEREL>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] $<$<CONFIG:RELEASE>:s>)
 
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:YES>)
-     set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=Release] $<$<CONFIG:RELEASE>:YES>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=RelWithDebInfo] $<$<CONFIG:RELWITHDEBINFO>:YES>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO[variant=Release] $<$<CONFIG:RELEASE>:YES>)
 endmacro()
 
 if(MBGL_WITH_OPENGL)

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -2,6 +2,18 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
 
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
 
+macro(initialize_macos_target target)
+    # Enable LTO & -Os for Release and RelWithDebInfo (which is currently still used by iOS release packages)
+
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELEASE>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL $<$<CONFIG:RELWITHDEBINFO>:s>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELEASE>:YES>)
+    set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_LLVM_LTO $<$<CONFIG:RELWITHDEBINFO>:YES>)
+endmacro()
+
+
+
+
 if(MBGL_WITH_OPENGL)
     find_package(OpenGL REQUIRED)
 
@@ -76,6 +88,9 @@ target_include_directories(
 )
 
 include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
+
+initialize_macos_target(mbgl-core)
+initialize_macos_target(mbgl-vendor-icu)
 
 target_link_libraries(
     mbgl-core


### PR DESCRIPTION
See https://github.com/mapbox/mapbox-gl-native-ios/issues/134 for context.

This PR adds `-Os` and `-flto` for the `Release` and `RelWithDebInfo` configurations, both of which are currently used by the iOS Maps SDK release process. (This is a possible first step in transitioning iOS to just use Release & Debug configurations).

It turned out it wasn't sufficient to set these optimization settings by "just" changing the gcc flags, instead it needed to be changed with:

```
set_target_properties(${target} PROPERTIES XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] $<$<CONFIG:RELEASE>:s>)
```

There may be a better way (I'm definitely a cmake novice), so would appreciate any improvements.

cc @mapbox/maps-ios @1ec5 