### PR TITLE
[qt] Ignore status code with 'data' URLs

### DIFF
--- a/platform/qt/src/http_request.cpp
+++ b/platform/qt/src/http_request.cpp
@@ -94,6 +94,16 @@ void HTTPRequest::handleNetworkReply(QNetworkReply *reply, const QByteArray& dat
         }
     }
 
+    if (reply->url().scheme() == QStringLiteral("data")) {
+        if (data.isEmpty()) {
+            response.data = std::make_shared<std::string>();
+        } else {
+            response.data = std::make_shared<std::string>(data.constData(), data.size());
+        }
+        callback(response);
+        return;
+    }
+
     int responseCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
     switch(responseCode) {


### PR DESCRIPTION
This is a master equivalent of #16437.

_Original text:_

Users might want to add image sources from a Qt application using base64 encoded image using the data URL scheme. This is supported by Qt but HTTP status code is not present. This adds a special case to the HTTPRequest::handleNetworkReply.

I could not think of any other scheme that could be reasonably used here. HTTP and file:// seem to report the status code properly.

Will also provide MR to master when this one is accepted. Let me know if this should be done to master first.