### PR TITLE
[core] Handle exception while queried feature is not included in a source.

### DIFF
--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -599,7 +599,11 @@ FeatureExtensionValue RenderOrchestrator::queryFeatureExtensions(const std::stri
                                                              const std::string& extensionField,
                                                              const optional<std::map<std::string, Value>>& args) const {
     if (RenderSource* renderSource = getRenderSource(sourceID)) {
-        return renderSource->queryFeatureExtensions(feature, extension, extensionField, args);
+        try {
+            return renderSource->queryFeatureExtensions(feature, extension, extensionField, args);
+        } catch (...) {
+            return {};
+        }
     }
     return {};
 }

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -602,7 +602,7 @@ FeatureExtensionValue RenderOrchestrator::queryFeatureExtensions(const std::stri
         try {
             return renderSource->queryFeatureExtensions(feature, extension, extensionField, args);
         } catch (...) {
-            return {};
+            mbgl::Log::Warning(mbgl::Event::General, "No FeatureExtension found.");
         }
     }
     return {};


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-gl-native-android/issues/121

If the queried feature is not included in the current source, an exception `std::runtime_error("No cluster with the specified id.")` will be thrown out which will then cause the app crash. This pr will catch this exception and then return an empty result.
