### PR TITLE
[android] Cherry-pick remove source memory leak.

### DIFF
--- a/platform/android/src/style/sources/custom_geometry_source.cpp
+++ b/platform/android/src/style/sources/custom_geometry_source.cpp
@@ -111,10 +111,10 @@ namespace android {
         static auto& javaClass = jni::Class<CustomGeometrySource>::Singleton(*_env);
         static auto releaseThreads = javaClass.GetMethod<void ()>(*_env, "releaseThreads");
 
-        assert(javaPeer);
-
-        auto peer = jni::Cast(*_env, javaClass, javaPeer);
-        peer.Call(*_env, releaseThreads);
+        if(javaPeer) {
+            auto peer = jni::Cast(*_env, javaClass, javaPeer);
+            peer.Call(*_env, releaseThreads);
+        }
     };
 
     bool CustomGeometrySource::isCancelled(jni::jint z,

--- a/platform/android/src/style/sources/source.cpp
+++ b/platform/android/src/style/sources/source.cpp
@@ -67,6 +67,10 @@ namespace android {
     }
 
     Source::~Source() {
+        if (ownedSource) {
+            ownedSource.reset();
+            ownedSource.release();
+        }
         // Before being added to a map, the Java peer owns this C++ peer and cleans
         //  up after itself correctly through the jni native peer bindings.
         // After being added to the map, the ownership is flipped and the C++ peer has a strong reference
@@ -137,7 +141,7 @@ namespace android {
 
         // Release the strong reference to the java peer
         assert(javaPeer);
-        javaPeer.release();
+        javaPeer.reset();
 
         rendererFrontend = nullptr;
     }


### PR DESCRIPTION
Cherry-pick from https://github.com/mapbox/mapbox-gl-native-android/pull/412

