### PR TITLE
Update Qt redirection handling

### DIFF
--- a/platform/qt/src/http_file_source.cpp
+++ b/platform/qt/src/http_file_source.cpp
@@ -29,8 +29,13 @@ void HTTPFileSource::Impl::request(HTTPRequest* req)
     }
 
     QNetworkRequest networkRequest = req->networkRequest();
-#if QT_VERSION >= 0x050600
+#if QT_VERSION < 0x060000
+#    if QT_VERSION >= 0x050900
+    networkRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                                QNetworkRequest::NoLessSafeRedirectPolicy);
+#    elif QT_VERSION >= 0x050600
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+#    endif
 #endif
 
     data.first = m_manager->get(networkRequest);


### PR DESCRIPTION
Since 5.9 RedirectPolicyAttribute is preferred, and from 6.0 the
behavior of NoLessSafeRedirectPolicy is the default.
So updated the ifdefery to match this.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
