### PR TITLE
Add toString(long) and toString(long long)

### DIFF
--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -47,9 +47,19 @@ inline std::string toString(uint8_t t) {
     return toString(static_cast<uint32_t>(t));
 }
 
+template <typename = std::enable_if<!std::is_same<int64_t, long>::value>>
+inline std::string toString(long t) {
+    return toString(static_cast<int64_t>(t));
+}
+
 template <typename = std::enable_if<!std::is_same<uint64_t, unsigned long>::value>>
 inline std::string toString(unsigned long t) {
     return toString(static_cast<uint64_t>(t));
+}
+
+template <typename = std::enable_if<!std::is_same<int64_t, long long>::value>>
+inline std::string toString(long long t) {
+    return toString(static_cast<int64_t>(t));
 }
 
 template <typename = std::enable_if<!std::is_same<uint64_t, unsigned long long>::value>>


### PR DESCRIPTION
This solves a compile error I get in `platform/default/src/mbgl/storage/http_file_source.cpp`.  I am doing something a little weird - building a custom platform - but even so I'm surprised this hasn't been hit before.  I can't see why this would be an error in a custom build but not in the standard one.  It stems from `long` not being implicitly convertible to `int64_t` (or some other type `toString()` can take).

```
mapbox-gl-native/platform/default/src/mbgl/storage/http_file_source.cpp:395:68: error: call to deleted function
      'toString'
                                                                   util::toString(responseCode));
                                                                   ^~~~~~~~~~~~~~
mapbox-gl-native/include/mbgl/util/string.hpp:71:13: note: candidate function [with T = long] has been
      explicitly deleted
std::string toString(T) = delete;
            ^

...<snip>...

mapbox-gl-native/platform/default/src/mbgl/storage/http_file_source.cpp:399:67: error: call to deleted function
      'toString'
                                                                  util::toString(responseCode));
                                                                  ^~~~~~~~~~~~~~
mapbox-gl-native/include/mbgl/util/string.hpp:71:13: note: candidate function [with T = long] has been
      explicitly deleted
std::string toString(T) = delete;
            ^
```

The compiler is:
```
Apple clang version 11.0.3 (clang-1103.0.32.62)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
```
And `sizeof(long) == sizeof(int64_t)`.  It's been a long time since I've done a standard build, I don't know if a new version of Xcode has brought this in, a change of code or if it's just the way I'm building.  Regardless, I don't see any downsides to the change and it makes the set of overloads/specialisations complete - there are already specialisations for `unsigned long`, this just adds the same for `signed long` (and `signed long long` for completeness).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes - **N/A**
 - [ ] write tests for all new functionality - **didn't think the change is enough to warrant it**
 - [ ] document any changes to public APIs - **N/A**
 - [ ] tagged `@mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk` if this PR adds or updates a public API - **N/A**
 - [ ] tagged `@mapbox/gl-js` if this PR includes shader changes or needs a js port - **N/A**
 - [ ] apply `needs changelog` label if a changelog is needed (remove label when added) - **N/A**
