### PR TITLE
Use references when iterating over elements 

### DIFF
--- a/src/mbgl/style/expression/within.cpp
+++ b/src/mbgl/style/expression/within.cpp
@@ -39,7 +39,7 @@ Polygon<int64_t> getTilePolygon(const Polygon<double>& polygon,
     for (const auto& ring : polygon) {
         LinearRing<int64_t> temp;
         temp.reserve(ring.size());
-        for (const auto p : ring) {
+        for (const auto& p : ring) {
             const auto coord = latLonToTileCoodinates(p, canonical);
             temp.push_back(coord);
             updateBBox(bbox, coord);

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -242,12 +242,12 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
             result.reserve(polygons.size());
             for (const auto& pg : polygons) {
                 for (const auto& r : pg) {
-                    LinearRing<int16_t> ring;
-                    ring.reserve(r.size());
+                    LinearRing<int16_t> temp;
+                    temp.reserve(r.size());
                     for (const auto& p : r) {
-                        ring.emplace_back(latLonToTileCoodinates(p));
+                        temp.emplace_back(latLonToTileCoodinates(p));
                     }
-                    result.emplace_back(ring);
+                    result.emplace_back(temp);
                 }
             }
             return result;

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -198,7 +198,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
         [&](const MultiPoint<double>& points) -> GeometryCollection {
             MultiPoint<int16_t> result;
             result.reserve(points.size());
-            for (const auto p : points) {
+            for (const auto& p : points) {
                 result.emplace_back(latLonToTileCoodinates(p));
             }
             return {std::move(result)};
@@ -206,7 +206,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
         [&](const LineString<double>& lineString) -> GeometryCollection {
             LineString<int16_t> result;
             result.reserve(lineString.size());
-            for (const auto p : lineString) {
+            for (const auto& p : lineString) {
                 result.emplace_back(latLonToTileCoodinates(p));
             }
             return {std::move(result)};
@@ -217,7 +217,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
             for (const auto& line : lineStrings) {
                 LineString<int16_t> temp;
                 temp.reserve(line.size());
-                for (const auto p : line) {
+                for (const auto& p : line) {
                     temp.emplace_back(latLonToTileCoodinates(p));
                 }
                 result.emplace_back(temp);
@@ -230,7 +230,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
             for (const auto& ring : polygon) {
                 LinearRing<int16_t> temp;
                 temp.reserve(ring.size());
-                for (const auto p : ring) {
+                for (const auto& p : ring) {
                     temp.emplace_back(latLonToTileCoodinates(p));
                 }
                 result.emplace_back(temp);
@@ -244,7 +244,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
                 for (const auto& r : pg) {
                     LinearRing<int16_t> ring;
                     ring.reserve(r.size());
-                    for (const auto p : r) {
+                    for (const auto& p : r) {
                         ring.emplace_back(latLonToTileCoodinates(p));
                     }
                     result.emplace_back(ring);


### PR DESCRIPTION
This PR changes code to avoid warnings (errors at `-Werror`) by Xcode 12 / recent Clang (see #16540).
*(Note that this doesn't solve all issues with Xcode 12; so it still won't work out of the box. I'll probably create a follow-up PR in the near future if nobody beats me to it)*

In addition to those `&` changes, I also made the variable naming in `convertGeometry` more consistent.

---

*(It would be nice if you can tag this PR for hacktoberfest inclusion as described in https://hacktoberfest.digitalocean.com/details#rules - feel free to ignore this last bit if you don't want this)*


