### PR TITLE
Port mapbox-gl-js PR 9372 ("Fix addImage API option for pixel ratio ")

### DIFF
--- a/src/mbgl/programs/fill_extrusion_program.cpp
+++ b/src/mbgl/programs/fill_extrusion_program.cpp
@@ -51,7 +51,6 @@ FillExtrusionPatternProgram::layoutUniformValues(mat4 matrix,
                                            const TransformState& state,
                                            const float opacity,
                                            const float heightFactor,
-                                           const float pixelRatio,
                                            const EvaluatedLight& light,
                                            const float verticalGradient) {
     const auto tileRatio = 1 / tileID.pixelsToTileUnits(1, state.getIntegerZoom());
@@ -62,7 +61,7 @@ FillExtrusionPatternProgram::layoutUniformValues(mat4 matrix,
     return {
         uniforms::matrix::Value( matrix ),
         uniforms::opacity::Value( opacity ),
-        uniforms::scale::Value( {{pixelRatio, tileRatio, crossfade.fromScale, crossfade.toScale}} ),
+        uniforms::scale::Value( {{tileRatio, crossfade.fromScale, crossfade.toScale}} ),
         uniforms::texsize::Value( atlasSize ),
         uniforms::fade::Value( crossfade.t ),
         uniforms::pixel_coord_upper::Value( std::array<float, 2>{{ float(pixelX >> 16), float(pixelY >> 16) }} ),

--- a/src/mbgl/programs/fill_extrusion_program.hpp
+++ b/src/mbgl/programs/fill_extrusion_program.hpp
@@ -108,7 +108,6 @@ public:
                                                    const TransformState&,
                                                    float opacity,
                                                    float heightFactor,
-                                                   float pixelRatio,
                                                    const EvaluatedLight&,
                                                    float verticalGradient);
 };

--- a/src/mbgl/programs/fill_program.cpp
+++ b/src/mbgl/programs/fill_program.cpp
@@ -16,8 +16,7 @@ FillPatternProgram::layoutUniformValues(mat4 matrix,
                                         Size atlasSize,
                                         const CrossfadeParameters& crossfade,
                                         const UnwrappedTileID& tileID,
-                                        const TransformState& state,
-                                        const float pixelRatio) {
+                                        const TransformState& state) {
     const auto tileRatio = 1 / tileID.pixelsToTileUnits(1, state.getIntegerZoom());
     int32_t tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
     int32_t pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
@@ -27,7 +26,7 @@ FillPatternProgram::layoutUniformValues(mat4 matrix,
         uniforms::matrix::Value( matrix ),
         uniforms::world::Value( framebufferSize ),
         uniforms::texsize::Value( atlasSize ),
-        uniforms::scale::Value({ {pixelRatio, tileRatio, crossfade.fromScale, crossfade.toScale} } ),
+        uniforms::scale::Value({ {tileRatio, crossfade.fromScale, crossfade.toScale} } ),
         uniforms::fade::Value( crossfade.t ),
         uniforms::pixel_coord_upper::Value( std::array<float, 2> {{ float(pixelX >> 16), float(pixelY >> 16) }}),
         uniforms::pixel_coord_lower::Value( std::array<float, 2> {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }} )

--- a/src/mbgl/programs/fill_program.hpp
+++ b/src/mbgl/programs/fill_program.hpp
@@ -71,8 +71,7 @@ public:
                                                    Size atlasSize,
                                                    const CrossfadeParameters& crossfade,
                                                    const UnwrappedTileID&,
-                                                   const TransformState&,
-                                                   float pixelRatio);
+                                                   const TransformState&);
 };
 
 class FillOutlineProgram : public Program<

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -103,7 +103,7 @@ LinePatternProgram::LayoutUniformValues LinePatternProgram::layoutUniformValues(
         state,
         pixelsToGLUnits,
         pixelRatio,
-        uniforms::scale::Value ({ {pixelRatio, tileRatio, crossfade.fromScale, crossfade.toScale} }),
+        uniforms::scale::Value ({ {tileRatio, crossfade.fromScale, crossfade.toScale} }),
         uniforms::texsize::Value( atlasSize ),
         uniforms::fade::Value( crossfade.t )
     );

--- a/src/mbgl/programs/uniforms.hpp
+++ b/src/mbgl/programs/uniforms.hpp
@@ -51,7 +51,7 @@ MBGL_DEFINE_UNIFORM_SCALAR(float, extrude_scale);
 
 MBGL_DEFINE_UNIFORM_VECTOR(uint16_t, 4, pattern_from);
 MBGL_DEFINE_UNIFORM_VECTOR(uint16_t, 4, pattern_to);
-MBGL_DEFINE_UNIFORM_VECTOR(float, 4, scale);
+MBGL_DEFINE_UNIFORM_VECTOR(float, 3, scale);
 MBGL_DEFINE_UNIFORM_VECTOR(uint16_t, 2, pattern_tl_a);
 MBGL_DEFINE_UNIFORM_VECTOR(uint16_t, 2, pattern_br_a);
 MBGL_DEFINE_UNIFORM_VECTOR(uint16_t, 2, pattern_tl_b);

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -200,7 +200,6 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                         parameters.state,
                         evaluated.get<FillExtrusionOpacity>(),
                         -std::pow(2, tile.id.canonical.z) / util::tileSize / 8.0f,
-                        parameters.pixelRatio,
                         parameters.evaluatedLight,
                         evaluated.get<FillExtrusionVerticalGradient>()
                     ),

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -191,8 +191,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                         tile.getIconAtlasTexture().size,
                         crossfade,
                         tile.id,
-                        parameters.state,
-                        parameters.pixelRatio
+                        parameters.state
                     ),
                     paintPropertyBinders,
                     evaluated,


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-gl-js/pull/9372 the type of `u_scale` in fill_program was changed from `vec4` to `vec3`. New attributes and some logic were also added.

Because mapbox-gl-native re-uses the mapbox-gl-js shaders, I feel this should have been updated or reported as issue when the submodule was updated in https://github.com/mapbox/mapbox-gl-native/pull/16298.

When I'm touching the shaders in a fork of mapbox, this discrepancy will cause errors.

Because this PR is still incomplete, I'll mark this PR as a draft, so it's mostly a reminder that this still has to be fixed. I assume the final version of the PR will also have to run `scripts/generate-shaders.js`, while also adding the new attributes.

Early feedback or comments welcome.

---

*(It would be nice if you can tag this PR for hacktoberfest inclusion as described in https://hacktoberfest.digitalocean.com/details#rules - feel free to ignore this last bit if you don't want this)*