### PR TITLE
[glfw] glfw errors should not be fatal

### DIFF
--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -109,7 +109,6 @@ void addFillExtrusionLayer(mbgl::style::Style &style, bool visible) {
 
 void glfwError(int error, const char *description) {
     mbgl::Log::Error(mbgl::Event::OpenGL, "GLFW error (%i): %s", error, description);
-    assert(false);
 }
 
 GLFWView::GLFWView(bool fullscreen_, bool benchmark_, const mbgl::ResourceOptions &options)


### PR DESCRIPTION
Callbacks to the glfw error handler should not be fatal.
However an `assert(false)` in a debug build essentially makes it fatal - this can be very confusing.

I ran into this issue on macOS 10.15.7.
When AirPlay is used on macOS, GLFW will actually cause a warning (?) via the glfw error callback.
This would trigger the assertion, which would lead to exiting of the glfw platform demo.
I've also reported this problem to GLFW: https://github.com/glfw/glfw/issues/1791 to fix the root issue eventually.

With the assertion removed, the demo will work as expected, even if airplay is currently being used.

I assume that it's probably enough to report "errors" to `mbgl::Log`. Actual glfw errors should probably be handled when the glfw calls return unsuccessfully.
I assume it will take some time until upstream glfw resolves this "airplay is an error", and even longer until the fix is widely deployed. Hence the decision to remove the assertion.

---

*(It would be nice if you can tag this PR for hacktoberfest inclusion as described in https://hacktoberfest.digitalocean.com/details#rules - feel free to ignore this last bit if you don't want this)*