### PR TITLE
[Qt] Fix for style conversion with Qt 5.15

### DIFF
--- a/platform/qt/src/qt_conversion.hpp
+++ b/platform/qt/src/qt_conversion.hpp
@@ -79,7 +79,9 @@ public:
     }
 
     static optional<float> toNumber(const QVariant& value) {
-        if (value.type() == QVariant::Int || value.type() == QVariant::Double) {
+        if (value.type() == QVariant::Int ||
+            value.type() == QVariant::LongLong ||
+            value.type() == QVariant::Double) {
             return value.toFloat();
         } else {
             return {};
@@ -87,7 +89,9 @@ public:
     }
 
     static optional<double> toDouble(const QVariant& value) {
-        if (value.type() == QVariant::Int || value.type() == QVariant::Double) {
+        if (value.type() == QVariant::Int ||
+            value.type() == QVariant::LongLong ||
+            value.type() == QVariant::Double) {
             return value.toDouble();
         } else {
             return {};

--- a/platform/qt/src/qt_conversion.hpp
+++ b/platform/qt/src/qt_conversion.hpp
@@ -79,9 +79,9 @@ public:
     }
 
     static optional<float> toNumber(const QVariant& value) {
-        if (value.type() == QVariant::Int ||
-            value.type() == QVariant::LongLong ||
-            value.type() == QVariant::Double) {
+        if (value.type() == QVariant::Int
+         || value.type() == QVariant::LongLong 
+         || value.type() == QVariant::Double) {
             return value.toFloat();
         } else {
             return {};
@@ -89,9 +89,9 @@ public:
     }
 
     static optional<double> toDouble(const QVariant& value) {
-        if (value.type() == QVariant::Int ||
-            value.type() == QVariant::LongLong ||
-            value.type() == QVariant::Double) {
+        if (value.type() == QVariant::Int
+         || value.type() == QVariant::LongLong
+         || value.type() == QVariant::Double) {
             return value.toDouble();
         } else {
             return {};


### PR DESCRIPTION
When building with Qt 5.15, a number of features stopped rendering like icons and text. While debugging, I noticed that QVariant has started interpreting some integers as `long long` instead of `int`. This adds `long long` to the list of accepted QVariant types when converting toNumber() or toDouble().

Example errors when trying to add layers:
```
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be a number
W0824 15:38:10.241241  :0] Unable to add layer: value must be an array of numbers
W0824 15:38:10.242242  :0] Unable to add layer: value must be a number
W0824 15:38:10.242242  :0] Unable to add layer: value must be a number
W0824 15:38:10.242242  mapbox_layer_abstract.cxx:455] Could not enable layer  "admin-1-boundary-bg"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.242242  mapbox_layer_abstract.cxx:455] Could not enable layer  "admin-0-boundary-bg"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.242242  mapbox_layer_abstract.cxx:455] Could not enable layer  "admin-0-boundary-disputed"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.242242  :0] Unable to add layer: value must be a number
W0824 15:38:10.242242  :0] Unable to add layer: value must be a number
W0824 15:38:10.242242  :0] Unable to add layer: value must be a number
W0824 15:38:10.242242  :0] Unable to add layer: value must be a number
W0824 15:38:10.242242  :0] Unable to add layer: value must be a number
W0824 15:38:10.243243  :0] Unable to add layer: value must be a number
W0824 15:38:10.243243  :0] Unable to add layer: value must be a number
W0824 15:38:10.243243  mapbox_layer_abstract.cxx:455] Could not enable layer  "waterway-label"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.243243  mapbox_layer_abstract.cxx:455] Could not enable layer  "settlement-subdivision-label"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.243243  mapbox_layer_abstract.cxx:455] Could not enable layer  "settlement-label"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.243243  mapbox_layer_abstract.cxx:455] Could not enable layer  "natural-point-label"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.243243  mapbox_layer_abstract.cxx:455] Could not enable layer  "state-label"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.243243  mapbox_layer_abstract.cxx:455] Could not enable layer  "country-label"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.243243  mapbox_layer_abstract.cxx:455] Could not enable layer  "poi-label"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.243243  :0] Unable to add layer: value must be a number
W0824 15:38:10.244244  :0] Unable to add layer: value must be a number
W0824 15:38:10.244244  :0] Unable to add layer: value must be a number
W0824 15:38:10.244244  :0] Unable to add layer: value must be a number
W0824 15:38:10.244244  mapbox_layer_abstract.cxx:455] Could not enable layer  "land-structure-polygon"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.244244  mapbox_layer_abstract.cxx:455] Could not enable layer  "land-structure-line"  because it doesn't exist in the MapboxGL widget.
W0824 15:38:10.245245  :0] Unable to add layer: value must be a number
W0824 15:38:10.245245  :0] Unable to add layer: value must be a number
W0824 15:38:10.245245  :0] Unable to add layer: value must be a number
W0824 15:38:10.245245  :0] Unable to add layer: value must be a number
W0824 15:38:10.246246  :0] Unable to add layer: value must be a number
W0824 15:38:10.246246  :0] Unable to add layer: value must be a number
W0824 15:38:10.246246  :0] Unable to add layer: value must be a number
W0824 15:38:10.246246  :0] Unable to add layer: value must be a number
W0824 15:38:10.246246  :0] Unable to add layer: value must be a number
W0824 15:38:10.246246  :0] Unable to add layer: value must be a number
```
