### PR TITLE
[Qt] Resolve deprecation errors when building with Qt 5.15.

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -448,16 +448,20 @@ void MapWindow::mouseMoveEvent(QMouseEvent *ev)
 
 void MapWindow::wheelEvent(QWheelEvent *ev)
 {
-    if (ev->orientation() == Qt::Horizontal) {
+    if (ev->angleDelta().x() != 0) {
         return;
     }
 
-    float factor = ev->delta() / 1200.;
-    if (ev->delta() < 0) {
+    float factor = ev->angleDelta().y() / 1200.;
+    if (ev->angleDelta().y() < 0) {
         factor = factor > -1 ? factor : 1 / factor;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,12,0)
+    m_map->scaleBy(1 + factor, ev->position());
+#else
     m_map->scaleBy(1 + factor, ev->pos());
+#endif
     ev->accept();
 }
 

--- a/platform/qt/src/http_request.cpp
+++ b/platform/qt/src/http_request.cpp
@@ -38,9 +38,6 @@ QNetworkRequest HTTPRequest::networkRequest() const
 {
     QNetworkRequest req = QNetworkRequest(requestUrl());
     req.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
-    req.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, true);
-    req.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
-    req.setPriority(QNetworkRequest::HighPriority);
 
     static const QByteArray agent = QString("MapboxGL/%1 (Qt %2)").arg(version::revision).arg(QT_VERSION_STR).toLatin1();
     req.setRawHeader("User-Agent", agent);

--- a/platform/qt/src/http_request.cpp
+++ b/platform/qt/src/http_request.cpp
@@ -38,6 +38,9 @@ QNetworkRequest HTTPRequest::networkRequest() const
 {
     QNetworkRequest req = QNetworkRequest(requestUrl());
     req.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
+    req.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, true);
+    req.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
+    req.setPriority(QNetworkRequest::HighPriority);
 
     static const QByteArray agent = QString("MapboxGL/%1 (Qt %2)").arg(version::revision).arg(QT_VERSION_STR).toLatin1();
     req.setRawHeader("User-Agent", agent);

--- a/platform/qt/src/local_glyph_rasterizer.cpp
+++ b/platform/qt/src/local_glyph_rasterizer.cpp
@@ -52,7 +52,11 @@ Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
         return glyph;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
+    glyph.metrics.width = impl->metrics->horizontalAdvance(glyphID);
+#else
     glyph.metrics.width = impl->metrics->width(glyphID);
+#endif
     glyph.metrics.height = impl->metrics->height();
     glyph.metrics.left = 3;
     glyph.metrics.top = -8;
@@ -68,8 +72,14 @@ Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack&, GlyphID glyphID) {
     // Render at constant baseline, to align with glyphs that are rendered by node-fontnik.
     painter.drawText(QPointF(0, 20), QString(QChar(glyphID)));
 
+    
+#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
+    auto img = std::make_unique<uint8_t[]>(image.sizeInBytes());
+    memcpy(img.get(), image.constBits(), image.sizeInBytes());
+#else
     auto img = std::make_unique<uint8_t[]>(image.byteCount());
     memcpy(img.get(), image.constBits(), image.byteCount());
+#endif
 
     glyph.bitmap = AlphaImage { size, std::move(img) };
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -108,8 +108,13 @@ std::unique_ptr<mbgl::style::Image> toStyleImage(const QString &id, const QImage
         .rgbSwapped()
         .convertToFormat(QImage::Format_ARGB32_Premultiplied);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
+    auto img = std::make_unique<uint8_t[]>(swapped.sizeInBytes());
+    memcpy(img.get(), swapped.constBits(), swapped.sizeInBytes());
+#else
     auto img = std::make_unique<uint8_t[]>(swapped.byteCount());
     memcpy(img.get(), swapped.constBits(), swapped.byteCount());
+#endif
 
     return std::make_unique<mbgl::style::Image>(
         id.toStdString(),

--- a/platform/qt/src/qt_image.cpp
+++ b/platform/qt/src/qt_image.cpp
@@ -45,8 +45,13 @@ PremultipliedImage decodeImage(const std::string& string) {
         throw std::runtime_error("Unsupported image type");
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
+    auto img = std::make_unique<uint8_t[]>(image.sizeInBytes());
+    memcpy(img.get(), image.constBits(), image.sizeInBytes());
+#else
     auto img = std::make_unique<uint8_t[]>(image.byteCount());
     memcpy(img.get(), image.constBits(), image.byteCount());
+#endif
 
     return { { static_cast<uint32_t>(image.width()), static_cast<uint32_t>(image.height()) },
              std::move(img) };


### PR DESCRIPTION
Building mapbox-gl-native with Qt 5.15 triggers a number of deprecation errors. This adds Qt version checking and utilizes updated methods where appropriate.

![image](https://user-images.githubusercontent.com/956113/100123476-2a749480-2e40-11eb-9626-f8e6755fffb8.png)
