### PR TITLE
[build][qt] Add support for using qmapboxgl as a proper CMake dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-project("Mapbox GL Native" LANGUAGES CXX C)
+project("Mapbox GL Native" LANGUAGES CXX C VERSION 1.6.0)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER Core)

--- a/platform/qt/QMapboxGLConfig.cmake.in
+++ b/platform/qt/QMapboxGLConfig.cmake.in
@@ -1,0 +1,12 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Qt5Gui @REQUIRED_QT_VERSION@)
+find_dependency(Qt5Network @REQUIRED_QT_VERSION@)
+
+if(@MBGL_WITH_QT_HEADLESS@ OR NOT @MBGL_WITH_QT_LIB_ONLY@)
+	find_dependency(Qt5OpenGL @REQUIRED_QT_VERSION@)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/QMapboxGLTargets.cmake")
+@PACKAGE_INCLUDE_QCHTARGETS@

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -145,8 +145,9 @@ target_include_directories(
 )
 
 target_include_directories(
-    qmapboxgl
-    PUBLIC ${PROJECT_SOURCE_DIR}/platform/qt/include
+    qmapboxgl PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/platform/qt/include>
+    $<INSTALL_INTERFACE:include>
 )
 
 target_compile_definitions(
@@ -172,7 +173,8 @@ install(
 
 install(
     TARGETS qmapboxgl
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shared NAMELINK_SKIP
+    EXPORT QMapboxGLTargets
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shared
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT development
 )
 
@@ -185,6 +187,34 @@ install(
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/qt5"
     COMPONENT development
 )
+
+set_target_properties(qmapboxgl PROPERTIES
+	EXPORT_NAME QMapboxGL
+	SOVERSION ${PROJECT_VERSION_MAJOR}
+	VERSION ${PROJECT_VERSION})
+
+include(CMakePackageConfigHelpers)
+set(CMAKECONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/qmapboxgl/)
+
+configure_package_config_file(
+	"platform/qt/QMapboxGLConfig.cmake.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/QMapboxGLConfig.cmake"
+	INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+	PATH_VARS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_INCLUDEDIR
+	CMAKE_INSTALL_LIBDIR NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/QMapboxGLConfigVersion.cmake
+	VERSION ${qmapboxgl_VERSION}
+	COMPATIBILITY AnyNewerVersion)
+
+install(EXPORT QMapboxGLTargets
+	DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+	COMPONENT development)
+
+install(FILES
+	"${CMAKE_CURRENT_BINARY_DIR}/QMapboxGLConfig.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/QMapboxGLConfigVersion.cmake"
+	DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+	COMPONENT development)
 
 # stop here if only library is requested
 if(MBGL_WITH_QT_LIB_ONLY)


### PR DESCRIPTION
This way other CMake projects requiring it can just do the usual:

```
find_package(QMapboxGL REQUIRED)
target_link_libraries(<target name> PUBLIC QMapboxGL)
```

~This depends on #16394 to actually install the target we're linking against so it includes it's commit. This needs rebasing when #16394 is merged.~
This is now considered the continuation of #16394.