### PR TITLE
build options for gles and clang-tidy cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ option(MBGL_WITH_SANITIZER "Use [address|thread|undefined] here" OFF)
 option(MBGL_WITH_RTTI "Compile with runtime type information" OFF)
 option(MBGL_WITH_OPENGL "Build with OpenGL renderer" ON)
 option(MBGL_WITH_WERROR "Make all compilation warnings errors" ON)
+option(MBGL_WITH_GLES2 "Build with GLES2" OFF)
+
+if(MBGL_WITH_GLES2)
+    add_compile_definitions(MBGL_USE_GLES2)
+endif()
 
 add_library(
     mbgl-compiler-options INTERFACE
@@ -57,6 +62,7 @@ target_compile_options(
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=maybe-uninitialized>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=return-type>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=unknown-pragmas>
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-error=type-limits>
         $<$<CXX_COMPILER_ID:AppleClang>:-Wno-error=deprecated-declarations>
         $<$<CXX_COMPILER_ID:AppleClang>:-Wno-error=unused-parameter>
         $<$<CXX_COMPILER_ID:AppleClang>:-Wno-error=unused-property-ivar>

--- a/platform/glfw/CMakeLists.txt
+++ b/platform/glfw/CMakeLists.txt
@@ -3,6 +3,15 @@ find_package(PkgConfig REQUIRED)
 
 pkg_search_module(GLFW glfw3 REQUIRED)
 
+# build glfw3 with GLFW_USE_WAYLAND=ON
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+    pkg_check_modules(WAYLAND
+            wayland-client>=0.2.7
+            wayland-cursor>=0.2.7
+            wayland-egl>=0.2.7
+            xkbcommon)
+endif()
+
 add_executable(
     mbgl-glfw
     ${PROJECT_SOURCE_DIR}/platform/glfw/main.cpp
@@ -53,12 +62,27 @@ target_link_libraries(
         Mapbox::Map
         mbgl-compiler-options
         Mapbox::Base::cheap-ruler-cpp
+        ${WAYLAND_LINK_LIBRARIES}
 )
 
 if(MBGL_WITH_OPENGL)
     target_link_libraries(
         mbgl-glfw
         PRIVATE OpenGL::GL
+    )
+endif()
+
+if(MBGL_WITH_GLES2)
+    target_compile_definitions(
+        mbgl-glfw
+        PRIVATE MBGL_WITH_EGL
+    )
+endif()
+
+if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    target_compile_definitions(
+        mbgl-glfw
+        PRIVATE DEBUG
     )
 endif()
 

--- a/platform/glfw/glfw_backend.hpp
+++ b/platform/glfw/glfw_backend.hpp
@@ -15,14 +15,14 @@ class GLFWBackend {
 public:
     explicit GLFWBackend() = default;
     GLFWBackend(const GLFWBackend&) = delete;
-    GLFWBackend& operator=(const GLFWBackend&) = delete;
+    auto operator=(const GLFWBackend&) -> GLFWBackend& = delete;
     virtual ~GLFWBackend() = default;
 
-    static std::unique_ptr<GLFWBackend> Create(GLFWwindow* window, bool capFrameRate) {
+    static auto Create(GLFWwindow* window, bool capFrameRate) -> std::unique_ptr<GLFWBackend> {
         return mbgl::gfx::Backend::Create<GLFWBackend, GLFWwindow*, bool>(window, capFrameRate);
     }
 
-    virtual mbgl::gfx::RendererBackend& getRendererBackend() = 0;
-    virtual mbgl::Size getSize() const = 0;
+    virtual auto getRendererBackend() -> mbgl::gfx::RendererBackend& = 0;
+    virtual auto getSize() const -> mbgl::Size = 0;
     virtual void setSize(mbgl::Size) = 0;
 };

--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -52,7 +52,7 @@ void GLFWGLBackend::deactivate() {
     glfwMakeContextCurrent(nullptr);
 }
 
-mbgl::gl::ProcAddress GLFWGLBackend::getExtensionFunctionPointer(const char* name) {
+auto GLFWGLBackend::getExtensionFunctionPointer(const char* name) -> mbgl::gl::ProcAddress {
     return glfwGetProcAddress(name);
 }
 
@@ -61,7 +61,7 @@ void GLFWGLBackend::updateAssumedState() {
     setViewport(0, 0, size);
 }
 
-mbgl::Size GLFWGLBackend::getSize() const {
+auto GLFWGLBackend::getSize() const -> mbgl::Size {
     return size;
 }
 
@@ -77,8 +77,8 @@ namespace mbgl {
 namespace gfx {
 
 template <>
-std::unique_ptr<GLFWBackend>
-Backend::Create<mbgl::gfx::Backend::Type::OpenGL>(GLFWwindow* window, bool capFrameRate) {
+auto
+Backend::Create<mbgl::gfx::Backend::Type::OpenGL>(GLFWwindow* window, bool capFrameRate) -> std::unique_ptr<GLFWBackend> {
     return std::make_unique<GLFWGLBackend>(window, capFrameRate);
 }
 

--- a/platform/glfw/glfw_gl_backend.hpp
+++ b/platform/glfw/glfw_gl_backend.hpp
@@ -17,16 +17,14 @@ public:
     void swap();
 
     // GLFWRendererBackend implementation
-public:
-    mbgl::gfx::RendererBackend& getRendererBackend() override {
+    auto getRendererBackend() -> mbgl::gfx::RendererBackend& override {
         return *this;
     }
-    mbgl::Size getSize() const override;
+    auto getSize() const -> mbgl::Size override;
     void setSize(mbgl::Size) override;
 
     // mbgl::gfx::RendererBackend implementation
-public:
-    mbgl::gfx::Renderable& getDefaultRenderable() override {
+    auto getDefaultRenderable() -> mbgl::gfx::Renderable& override {
         return *this;
     }
 
@@ -35,8 +33,7 @@ protected:
     void deactivate() override;
 
     // mbgl::gl::RendererBackend implementation
-protected:
-    mbgl::gl::ProcAddress getExtensionFunctionPointer(const char*) override;
+    auto getExtensionFunctionPointer(const char*) -> mbgl::gl::ProcAddress override;
     void updateAssumedState() override;
 
 private:

--- a/platform/glfw/glfw_renderer_frontend.cpp
+++ b/platform/glfw/glfw_renderer_frontend.cpp
@@ -41,7 +41,7 @@ void GLFWRendererFrontend::render() {
     renderer->render(updateParameters_);
 }
 
-mbgl::Renderer* GLFWRendererFrontend::getRenderer() {
+auto GLFWRendererFrontend::getRenderer() -> mbgl::Renderer* {
     assert(renderer);
     return renderer.get();
 }

--- a/platform/glfw/glfw_renderer_frontend.hpp
+++ b/platform/glfw/glfw_renderer_frontend.hpp
@@ -20,7 +20,7 @@ public:
     void update(std::shared_ptr<mbgl::UpdateParameters>) override;
     void render();
     
-    mbgl::Renderer* getRenderer();
+    auto getRenderer() -> mbgl::Renderer*;
 
 private:
     GLFWView& glfwView;

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -28,13 +28,13 @@ public:
     GLFWView(bool fullscreen, bool benchmark, const mbgl::ResourceOptions &options);
     ~GLFWView() override;
 
-    float getPixelRatio() const;
+    auto getPixelRatio() const -> float;
 
     void setMap(mbgl::Map*);
     
     void setRenderFrontend(GLFWRendererFrontend*);
 
-    mbgl::gfx::RendererBackend& getRendererBackend();
+    auto getRendererBackend() -> mbgl::gfx::RendererBackend&;
 
     void setTestDirectory(std::string dir) { testDirectory = std::move(dir); };
 
@@ -56,7 +56,7 @@ public:
     
     void invalidate();
 
-    mbgl::Size getSize() const;
+    auto getSize() const -> mbgl::Size;
 
     // mbgl::MapObserver implementation
     void onDidFinishLoadingStyle() override;
@@ -78,9 +78,9 @@ private:
     // Internal
     void report(float duration);
 
-    mbgl::Color makeRandomColor() const;
-    mbgl::Point<double> makeRandomPoint() const;
-    static std::unique_ptr<mbgl::style::Image> makeImage(const std::string& id, int width, int height, float pixelRatio);
+    static auto makeRandomColor() -> mbgl::Color ;
+    auto makeRandomPoint() const -> mbgl::Point<double>;
+    static auto makeImage(const std::string& id, int width, int height, float pixelRatio) -> std::unique_ptr<mbgl::style::Image>;
 
     void nextOrientation();
 
@@ -106,7 +106,6 @@ private:
     mbgl::AnnotationIDs animatedAnnotationIDs;
     std::vector<double> animatedAnnotationAddedTimes;
 
-private:
     void toggle3DExtrusions(bool visible);
 
     mbgl::Map* map = nullptr;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -9,17 +9,13 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/default_styles.hpp>
 #include <mbgl/util/logging.hpp>
-#include <mbgl/util/platform.hpp>
 #include <mbgl/util/string.hpp>
 
 #include <args.hxx>
 
 #include <csignal>
-#include <fstream>
 #include <iostream>
 #include <cstdlib>
-#include <cstdio>
-#include <array>
 
 namespace {
 
@@ -36,7 +32,7 @@ void quit_handler(int) {
     }
 }
 
-int main(int argc, char *argv[]) {
+auto main(int argc, char *argv[]) -> int {
     args::ArgumentParser argumentParser("Mapbox GL GLFW example");
     args::HelpFlag helpFlag(argumentParser, "help", "Display this help menu", {'h', "help"});
 
@@ -79,8 +75,8 @@ int main(int argc, char *argv[]) {
     if (bearingValue) settings.bearing = args::get(bearingValue);
     if (pitchValue) settings.pitch = args::get(pitchValue);
 
-    const bool fullscreen = fullscreenFlag ? args::get(fullscreenFlag) : false;
-    const bool benchmark = benchmarkFlag ? args::get(benchmarkFlag) : false;
+    const bool fullscreen = fullscreenFlag && args::get(fullscreenFlag);
+    const bool benchmark = benchmarkFlag && args::get(benchmarkFlag);
     std::string style = styleValue ? args::get(styleValue) : "";
     const std::string cacheDB = cacheDBValue ? args::get(cacheDBValue) : "/tmp/mbgl-cache.db";
 

--- a/platform/glfw/settings_json.cpp
+++ b/platform/glfw/settings_json.cpp
@@ -18,7 +18,7 @@ void Settings_JSON::load() {
     }
 }
 
-void Settings_JSON::save() {
+void Settings_JSON::save() const {
     std::ofstream file("/tmp/mbgl-native.cfg");
     if (file) {
         file << longitude << std::endl;

--- a/platform/glfw/settings_json.hpp
+++ b/platform/glfw/settings_json.hpp
@@ -8,18 +8,14 @@ class Settings_JSON {
 public:
     Settings_JSON();
     void load();
-    void save();
+    void save() const;
     void clear();
 
-public:
     double longitude = 0;
     double latitude = 0;
     double zoom = 0;
     double bearing = 0;
     double pitch = 0;
-    bool axonometric = false;
-    double xSkew = 0.0;
-    double ySkew = 1.0;
 
     EnumType debug = 0;
     bool online = true;

--- a/platform/glfw/test_writer.cpp
+++ b/platform/glfw/test_writer.cpp
@@ -2,7 +2,6 @@
 
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 #include <ghc/filesystem.hpp>
 
 #include <cmath>
@@ -93,26 +92,26 @@ TestWriter::TestWriter() = default;
 
 TestWriter::~TestWriter() = default;
 
-TestWriter& TestWriter::withCameraOptions(const mbgl::CameraOptions& camera) {
+auto TestWriter::withCameraOptions(const mbgl::CameraOptions& camera) -> TestWriter& {
     operations.emplace_back(std::make_unique<SetCamera>(camera));
 
     return *this;
 }
 
-TestWriter& TestWriter::withStyle(const mbgl::style::Style& style) {
+auto TestWriter::withStyle(const mbgl::style::Style& style) -> TestWriter& {
     operations.emplace_back(std::make_unique<SetStyle>(style));
 
     return *this;
 }
 
-TestWriter& TestWriter::withInitialSize(const mbgl::Size& size) {
+auto TestWriter::withInitialSize(const mbgl::Size& size) -> TestWriter& {
     assert(initialSize == nullptr);
     initialSize = std::make_unique<SetInitialSize>(size);
 
     return *this;
 }
 
-bool TestWriter::write(const std::string& dir) const {
+auto TestWriter::write(const std::string& dir) const -> bool {
     namespace fs = ghc::filesystem;
 
     fs::path rootDir(dir);
@@ -144,7 +143,7 @@ bool TestWriter::write(const std::string& dir) const {
     return out.is_open() && out.good();
 }
 
-std::string TestWriter::serialize() const {
+auto TestWriter::serialize() const -> std::string {
     rapidjson::StringBuffer s;
     Writer writer(s);
 

--- a/platform/glfw/test_writer.hpp
+++ b/platform/glfw/test_writer.hpp
@@ -15,14 +15,14 @@ public:
     TestWriter();
     ~TestWriter();
 
-    TestWriter& withCameraOptions(const mbgl::CameraOptions&);
-    TestWriter& withStyle(const mbgl::style::Style&);
-    TestWriter& withInitialSize(const mbgl::Size&);
+    auto withCameraOptions(const mbgl::CameraOptions&) -> TestWriter&;
+    auto withStyle(const mbgl::style::Style&) -> TestWriter&;
+    auto withInitialSize(const mbgl::Size&) -> TestWriter&;
 
-    bool write(const std::string& dir) const;
+    auto write(const std::string& dir) const -> bool;
 
 private:
-    std::string serialize() const;
+    auto serialize() const -> std::string;
 
     std::vector<std::unique_ptr<TestOperationSerializer>> operations;
     std::unique_ptr<TestOperationSerializer> initialSize;

--- a/platform/linux/src/gl_functions.cpp
+++ b/platform/linux/src/gl_functions.cpp
@@ -7,7 +7,6 @@
 #include <GL/glext.h>
 #else
 #include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
 #endif
 
 namespace mbgl {

--- a/platform/linux/src/headless_backend_egl.cpp
+++ b/platform/linux/src/headless_backend_egl.cpp
@@ -24,7 +24,9 @@ public:
             throw std::runtime_error("Failed to obtain a valid EGL display.\n");
         }
 
-        EGLint major, minor, numConfigs;
+        EGLint major;
+        EGLint minor;
+        EGLint numConfigs;
         if (!eglInitialize(display, &major, &minor)) {
             throw std::runtime_error("eglInitialize() failed.\n");
         }
@@ -54,7 +56,7 @@ public:
         eglTerminate(display);
     }
 
-    static std::shared_ptr<const EGLDisplayConfig> create() {
+    static auto create() -> std::shared_ptr<const EGLDisplayConfig> {
         static std::weak_ptr<const EGLDisplayConfig> instance;
         auto shared = instance.lock();
         if (!shared) {
@@ -63,9 +65,8 @@ public:
         return shared;
     }
 
-public:
     EGLDisplay display = EGL_NO_DISPLAY;
-    EGLConfig config = 0;
+    EGLConfig config = nullptr;
 };
 
 class EGLBackendImpl : public HeadlessBackend::Impl {
@@ -116,9 +117,7 @@ public:
         }
     }
 
-    gl::ProcAddress getExtensionFunctionPointer(const char* name) final {
-        return eglGetProcAddress(name);
-    }
+    auto getExtensionFunctionPointer(const char* name) -> gl::ProcAddress final;
 
     void activateContext() final {
         if (!eglMakeCurrent(eglDisplay->display, eglSurface, eglSurface, eglContext)) {
@@ -137,6 +136,10 @@ private:
     EGLContext eglContext = EGL_NO_CONTEXT;
     EGLSurface eglSurface = EGL_NO_SURFACE;
 };
+
+auto EGLBackendImpl::getExtensionFunctionPointer(const char* name) -> gl::ProcAddress {
+    return eglGetProcAddress(name);
+}
 
 void HeadlessBackend::createImpl() {
     assert(!impl);


### PR DESCRIPTION
This PR:
* Adds CMake build options: MBGL_WITH_GLES2, MBGL_WITH_GLX.  This provides isolation between X11 and Wayland builds.
* mbgl-glfw links against Wayland libs if available.  So if GLFW3 is built with GLFW_USE_WAYLAND=ON, it will link and run on Wayland.
* Clang-Tidy cleanup in linux/glfw related files
* Moves mbgl-glfw to es3

Tested on Fedora 33 workstation.