### PR TITLE
Fix narrowing conversion warning/error

### DIFF
--- a/src/mbgl/layout/symbol_projection.cpp
+++ b/src/mbgl/layout/symbol_projection.cpp
@@ -95,7 +95,7 @@ namespace mbgl {
     PointAndCameraDistance project(const Point<float>& point, const mat4& matrix) {
         vec4 pos = {{ point.x, point.y, 0, 1 }};
         matrix::transformMat4(pos, pos, matrix);
-        return {{ static_cast<float>(pos[0] / pos[3]), static_cast<float>(pos[1] / pos[3]) }, pos[3] };
+        return {{ static_cast<float>(pos[0] / pos[3]), static_cast<float>(pos[1] / pos[3]) }, static_cast<float>(pos[3]) };
     }
 
     float evaluateSizeForFeature(const ZoomEvaluatedSize& zoomEvaluatedSize, const PlacedSymbol& placedSymbol) {


### PR DESCRIPTION
## Launch Checklist

`PointAndCameraDistance` is `std::pair<Point<float>,float>`. `vec4` is `std::array<double, 4>`. Implicitly converting double to float generates warnings (or errors if -Werror=narrowing is set). This pull request avoids the warning by explicitly casting the double to a float.

 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] tagged `@mapbox/maps-android @mapbox/maps-ios @mapbox/core-sdk` if this PR adds or updates a public API
 - [ ] tagged `@mapbox/gl-js` if this PR includes shader changes or needs a js port
 - [ ] apply `needs changelog` label if a changelog is needed (remove label when added)
