### PR TITLE
[qt] Add missing <cstdint> includes to fix build with GCC 13

### DIFF
--- a/include/mbgl/util/geometry.hpp
+++ b/include/mbgl/util/geometry.hpp
@@ -4,6 +4,8 @@
 #include <mapbox/geometry/point_arithmetic.hpp>
 #include <mapbox/geometry/for_each_point.hpp>
 
+#include <cstdint>
+
 namespace mbgl {
 
 enum class FeatureType : uint8_t {

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <cassert>
 #include <cstdlib>
+#include <cstdint>
 #include <exception>
 
 // Polyfill needed by Qt when building for Android with GCC

--- a/src/mbgl/gl/stencil_mode.hpp
+++ b/src/mbgl/gl/stencil_mode.hpp
@@ -2,6 +2,8 @@
 
 #include <mbgl/util/variant.hpp>
 
+#include <cstdint>
+
 namespace mbgl {
 namespace gl {
 


### PR DESCRIPTION
See:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1037830
- https://codereview.qt-project.org/c/qt/qtlocation-mapboxgl/+/446790

Cc @kkoehne @tmpsantos