### PR TITLE
[qt] Fix missing std::move when building on macOS with Xcode 14.3

### DIFF
--- a/include/mbgl/util/unique_any.hpp
+++ b/include/mbgl/util/unique_any.hpp
@@ -3,6 +3,7 @@
 #include <typeinfo>
 #include <type_traits>
 #include <stdexcept>
+#include <utility>
 namespace mbgl {
 namespace util {
 


### PR DESCRIPTION
Newer macos SDK shipped with Xcode 14.3 has likely re-ordered their include headers, which means std::move is not
available anymore via the includes that unique_any.hpp has.

Explicitly include the utility header to make std::move available.

## Launch Checklist

 - [x] briefly describe the changes in this PR